### PR TITLE
Drop the client's file cache when the mods behind it change

### DIFF
--- a/docs/MODDING.md
+++ b/docs/MODDING.md
@@ -342,9 +342,30 @@ a directory named in Korean is one the client never looks in.
 
 ### The client caches, hard
 
-The asset server keeps every file it has served in memory. **A changed image
-that appears not to take is usually a cached one** — restart the app, not just
-the server.
+There are two caches between your file and the screen, and they fail
+differently.
+
+The **asset server** keeps every file it has served in memory. It is emptied
+when the server stops, so restarting the app is enough.
+
+The **client** keeps its own copy of every file it downloads, in the browser's
+sandboxed filesystem, and looks there before asking the server again. That one
+is keyed by *filename* and survives restarts, which is what made this the
+nastiest failure in the whole system: a mod replacing a stock file the client
+had already saved — a login background, a loading screen, `itemInfo.lua` —
+loaded on the server, reported `on` in Settings, and changed nothing on screen.
+Everything that could tell you the mod was working said it was.
+
+The app now clears that cache for you. `link-assets` writes a fingerprint of
+the overlay to `state/assets/overlay.id` — the era, plus the name, size and
+mtime of every file each enabled mod puts under `data/`, `BGM/`, `System/` or
+`client/` — and the app drops the client's cache whenever that number moves.
+So installing, editing or switching off a mod takes effect on the next launch,
+and an ordinary launch still starts from a warm cache.
+
+A mod that only touches `db/`, `npc/` or `conf/` deliberately does not count:
+the client never sees those, and clearing its cache would cost you a re-download
+for nothing.
 
 ### Two things worth knowing before you replace a background
 

--- a/electron/main.js
+++ b/electron/main.js
@@ -10,7 +10,7 @@
 // sprites render doubled on WebKit (roBrowserLegacy #1350). One engine
 // everywhere is worth ~60 MB of download.
 //
-const { app, BrowserWindow, ipcMain, dialog, Menu, shell, clipboard } = require('electron');
+const { app, BrowserWindow, ipcMain, dialog, Menu, shell, clipboard, session } = require('electron');
 const path = require('path');
 const fs = require('fs');
 const os = require('os');
@@ -280,6 +280,51 @@ function readIfExists(p) {
 	} catch {
 		return '';
 	}
+}
+
+// Throw away the client's own file cache when the mods behind it have changed.
+//
+// roBrowser saves every file it downloads into the browser's sandboxed
+// filesystem and looks there before asking the server again, keyed by
+// filename. That is what makes the second launch quick, and it is also why an
+// enabled mod could change nothing on screen: the client already had a file of
+// that name from before the mod existed, so it never asked for the new one.
+// A mod's login background, loading screens and itemInfo table were all
+// invisible this way, while the mod itself loaded on the server and read as
+// `on` in Settings — the worst shape a bug can take, because everything that
+// reports status says it is working.
+//
+// The stack writes a fingerprint of the overlay next to the assets it serves;
+// anything that changes what the client is handed changes that number. Only
+// then is the cache dropped, so an ordinary launch still starts from a warm
+// one.
+//
+// Not just the sandboxed filesystem: Config.local.js and the plugin bundles
+// are ordinary HTTP requests, and a stale one of those loads the previous
+// mod's client code, or a plugin the player has since switched off.
+async function dropStaleClientCache() {
+	const want = readIfExists(path.join(stateDir(), 'assets', 'overlay.id')).trim();
+	// No fingerprint means link-assets has not run, and dropping a warm cache
+	// on a guess would just make the launch slower.
+	if (!want) return;
+	const stamp = path.join(stateDir(), 'client-cache.id');
+	if (readIfExists(stamp).trim() === want) return;
+	try {
+		const ses = session.defaultSession;
+		await ses.clearStorageData({ storages: ['filesystem', 'cachestorage'] });
+		await ses.clearCache();
+	} catch (e) {
+		// A cache we failed to clear shows stale art. A launch we refused
+		// shows nothing at all, so this is not worth failing over.
+		console.error('could not clear the client cache:', e.message);
+		return;
+	}
+	try {
+		fs.mkdirSync(stateDir(), { recursive: true });
+		// Written only after the clear succeeded: a stamp saved first would
+		// mark the cache current and never try again.
+		fs.writeFileSync(stamp, want + '\n');
+	} catch {}
 }
 
 function spawnSync(cmd, args) {
@@ -1831,12 +1876,16 @@ const handlers = {
 	close_setup: () => {
 		if (windows.setup && !windows.setup.isDestroyed()) windows.setup.close();
 	},
-	launch_game: () => {
+	launch_game: async () => {
 		const c = getClientPaths();
 		// The host's asset server when joining, our own when hosting. Hardcoding
 		// loopback here sent a joining player to a server that does not exist on
 		// their machine.
 		const base = c.mode === 'join' ? joinUrl(c.join_host) : 'http://127.0.0.1:3338';
+		// Before the page loads, not after: the client reads its cache as it
+		// boots, and clearing it out from under a running client would be a
+		// race for no gain.
+		if (c.mode !== 'join') await dropStaleClientCache();
 		const win = openGame();
 		win.loadURL(base + GAME_PATH);
 		win.setTitle(gameTitle());

--- a/stack/src/assets.rs
+++ b/stack/src/assets.rs
@@ -236,6 +236,10 @@ pub fn link(cfg: &Config, args: &[String]) -> Result<(), String> {
     // on every link cannot destroy them.
     let (plugins, item_tables) = overlay_mods(cfg, &server_root, &merged);
 
+    // Written after the overlay rather than before it, so a link that fails
+    // half way leaves no fingerprint claiming the client's cache is current.
+    let _ = fs::write(server_root.join("overlay.id"), overlay_fingerprint(cfg));
+
     link_dir(&merged, &server_root.join("System"))?;
     // Several loaders fall back to a SystemEN/ path when the System/ one is absent.
     link_dir(&en.join("SystemEN"), &server_root.join("SystemEN"))?;
@@ -291,6 +295,102 @@ fn overlay_mods(cfg: &Config, server_root: &Path, merged: &Path) -> (Vec<String>
         }
     }
     (plugins, item_tables)
+}
+
+/// FNV-1a, the same one `guest_fingerprint` uses, fed a piece at a time.
+fn fnv(hash: &mut u64, bytes: &[u8]) {
+    for b in bytes {
+        *hash ^= *b as u64;
+        *hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+}
+
+/// Hash a tree by name, size and mtime, in a fixed order.
+///
+/// `read_dir` order is whatever the filesystem hands back, so it is sorted
+/// here: an unsorted walk gives a different answer for the same tree on
+/// another machine, and the whole value of this number is that it only changes
+/// when the tree does.
+fn hash_tree(hash: &mut u64, dir: &Path, rel: &Path) {
+    let Ok(rd) = fs::read_dir(dir) else { return };
+    let mut entries: Vec<_> = rd.flatten().collect();
+    entries.sort_by_key(|e| e.file_name());
+    for e in entries {
+        let path = e.path();
+        let rel = rel.join(e.file_name());
+        if path.is_dir() {
+            hash_tree(hash, &path, &rel);
+            continue;
+        }
+        fnv(hash, rel.to_string_lossy().as_bytes());
+        let Ok(meta) = e.metadata() else { continue };
+        fnv(hash, &meta.len().to_le_bytes());
+        if let Ok(t) = meta.modified() {
+            if let Ok(d) = t.duration_since(std::time::UNIX_EPOCH) {
+                fnv(hash, &d.as_secs().to_le_bytes());
+            }
+        }
+    }
+}
+
+/// A fingerprint of everything the enabled mods put in front of the client.
+///
+/// The client keeps its own cache of every file it downloads, in the browser's
+/// sandboxed filesystem, and looks there before asking the server again. The
+/// cache is keyed by *filename*, which is what makes a mod that replaces a
+/// stock file invisible: a login background, a loading screen or an itemInfo
+/// table the client already has under that name is never re-fetched, so the
+/// mod loads on the server, shows as `on` in Settings, and changes nothing on
+/// screen. The app clears that cache when this value changes.
+///
+/// Size and mtime rather than contents. The tree is copied on every link
+/// anyway, and hashing the bytes would mean reading a mod's artwork twice on
+/// every launch to answer a question that a changed file already answers.
+///
+/// The era is in here because it is the same bug without any mod involved: the
+/// two translation trees carry different text under identical filenames, so a
+/// client that cached `itemInfo.lua` as pre-renewal keeps serving it after a
+/// switch to renewal.
+fn overlay_fingerprint(cfg: &Config) -> String {
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    fnv(&mut hash, era_tag(cfg).as_bytes());
+    for m in crate::mods::enabled(cfg) {
+        let roots = client_roots(&m.dir);
+        // A mod that reaches only the server has nothing the client could be
+        // holding a stale copy of. Skipping its name as well as its files is
+        // the difference between toggling a drop-rate mod and re-downloading
+        // the client's whole working set to find nothing had changed.
+        if roots.is_empty() {
+            continue;
+        }
+        // The name, and in order: two mods overlaying the same path resolve by
+        // load order, so the same set in a different order is a different tree.
+        fnv(&mut hash, m.name.as_bytes());
+        for sub in roots {
+            hash_tree(&mut hash, &m.dir.join(sub), Path::new(sub));
+        }
+    }
+    format!("{hash:016x}")
+}
+
+/// The roots a mod can reach the *client* through, of those it actually has.
+///
+/// `db/`, `npc/` and `conf/` are deliberately not here: they are the server's,
+/// the client never sees them, and a mod built only from those must not cost
+/// the player their cache.
+fn client_roots(dir: &Path) -> Vec<&'static str> {
+    ["data", "BGM", "System", "client"]
+        .into_iter()
+        .filter(|sub| dir.join(sub).is_dir())
+        .collect()
+}
+
+fn era_tag(cfg: &Config) -> &'static str {
+    if crate::cmds::is_prerenewal(cfg) {
+        "pre-re"
+    } else {
+        "re"
+    }
 }
 
 /// ASCII names a mod may use in place of the client's own directory names.
@@ -595,6 +695,70 @@ mod tests {
         );
         // 인간족/몸통 -- and the longer prefix has to win over `sprite/human`.
         assert!(apply_aliases("sprite/human/body/x.spr").ends_with("/\u{b8}\u{f6}\u{c5}\u{eb}/x.spr"));
+    }
+
+    /// The property the cache invalidation rests on: the same tree is the same
+    /// number, and any change to it is a different one.
+    ///
+    /// This is what decides whether the client keeps a cache that may be
+    /// serving a file the mod has replaced, so a false "unchanged" is the login
+    /// screen that would not update.
+    #[test]
+    fn a_changed_mod_tree_is_a_changed_fingerprint() {
+        let tmp = std::env::temp_dir().join(format!("ro-fp-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&tmp);
+        let art = tmp.join("data/texture/ui/login/bg.bmp");
+        write(&art, "first");
+
+        let of = |dir: &Path| {
+            let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+            hash_tree(&mut h, &dir.join("data"), Path::new("data"));
+            format!("{h:016x}")
+        };
+
+        let before = of(&tmp);
+        assert_eq!(before, of(&tmp), "the same tree hashed twice must agree");
+
+        // A different size is a different file.
+        write(&art, "second, and longer");
+        assert_ne!(before, of(&tmp), "an edited file went unnoticed");
+
+        // And so is a new one, even at the same total size.
+        let two = of(&tmp);
+        write(&tmp.join("data/texture/ui/login/bg2.bmp"), "x");
+        assert_ne!(two, of(&tmp), "an added file went unnoticed");
+
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    /// A mod the client never sees must not cost the player their cache.
+    #[test]
+    fn only_the_roots_the_client_reads_count() {
+        let tmp = std::env::temp_dir().join(format!("ro-roots-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&tmp);
+
+        // A drop-rate mod: server tables and a script, nothing else.
+        write(&tmp.join("server-only/db/mob_db.yml"), "Body:");
+        write(&tmp.join("server-only/npc/x.txt"), "");
+        write(&tmp.join("server-only/conf/battle.conf"), "");
+        assert!(client_roots(&tmp.join("server-only")).is_empty());
+
+        // One that replaces artwork, and one that only ships a plugin.
+        write(&tmp.join("art/data/texture/x.bmp"), "");
+        assert_eq!(client_roots(&tmp.join("art")), vec!["data"]);
+        write(&tmp.join("ui/client/index.js"), "");
+        write(&tmp.join("ui/db/item_db.yml"), "Body:");
+        assert_eq!(client_roots(&tmp.join("ui")), vec!["client"]);
+
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    /// An absent root is not an error: most mods ship one or two of the four.
+    #[test]
+    fn missing_roots_hash_to_nothing_rather_than_panicking() {
+        let mut h: u64 = 7;
+        hash_tree(&mut h, Path::new("/nonexistent/mod/BGM"), Path::new("BGM"));
+        assert_eq!(h, 7);
     }
 
     /// Only whole segments are translated, so a mod with its own folder called


### PR DESCRIPTION
## The bug

A mod that replaced a stock client file changed nothing on screen. This was
found with `login-screen` and `loading-screens` both enabled: the server was
serving the mod's bytes (verified by md5 against the mod's own files, on both
URL encodings the client could use), the mods listed as `on`, and the client
drew Gravity's art anyway.

roBrowser saves every file it downloads into the browser's sandboxed
filesystem and looks there before asking the server again — **keyed by
filename**. Once a stock `t_배경1-1.bmp` or `loading01.jpg` was saved, no mod
could replace it, because the request that would have fetched the new one was
never made.

Two things made this the nastiest failure in the mod system:

- **It survives restarts.** The documented advice was "restart the app", which
  fixes the *server's* in-memory cache and does nothing to this one.
- **Every status says it is working.** The mod loads on the server, shows `on`
  in Settings, and the asset server returns the right bytes to anyone who asks.
  Only the screen disagrees.

On the machine this was found on, 169 MB of art cached on Sep 1 was still being
drawn on Sep 4. Clearing the cache by hand fixed it immediately.

## The fix

`link-assets` writes `state/assets/overlay.id`: FNV-1a over the era, plus the
name, size and mtime of every file each enabled mod puts under `data/`, `BGM/`,
`System/` or `client/`. Before loading the game page the app compares it with
the stamp it saved last launch and, when it differs, clears the sandboxed
filesystem, cache storage and the HTTP cache.

The HTTP cache is in there because `Config.local.js` and the plugin bundles are
ordinary requests — a stale one loads the previous mod's client code, or a
plugin the player has since switched off.

**Only the four roots the client actually reads count.** A mod built from `db/`,
`npc/` or `conf/` alone leaves the number alone, so toggling a drop-rate mod
does not cost the player a re-download of the client's whole working set.

**The era is in the fingerprint too.** Same bug, no mod involved: the two
translation trees carry different text under identical filenames, so a client
that cached `itemInfo.lua` as pre-renewal kept serving it after a switch to
renewal.

## Verification

Against a local build, launching from source:

| case | expected | result |
|---|---|---|
| relaunch, nothing changed | cache kept | kept (51 files, grew by one) |
| `mod-disable login-screen` | cleared, stamp updated | every cached game file gone; only the `Origins/` leveldb bookkeeping remained, rewritten during the launch |
| `mod-disable tougher-monsters` (server-only) | untouched | fingerprint unchanged |
| era switch | cleared | fingerprint changed |

`cargo test`: 35 passed. Three new tests cover the fingerprint moving on an
edited or added file, an absent root not panicking, and only client-facing
roots counting.

`docs/MODDING.md` — the "The client caches, hard" section said the asset
server's memory cache was the whole story and told people to restart the app.
Rewritten to describe both caches and the automatic invalidation.

## Not covered

A guest joining someone else's host caches that host's assets, and nothing
invalidates it when the host changes mods. Worth a follow-up: the host could
serve its `overlay.id` and the guest could compare.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P8Y5BSZh9gydDhfe32gjcF
