### PR TITLE
Put a working stylist where the broken ones stand

### DIFF
--- a/mods/stylist-fallback/mod.json
+++ b/mods/stylist-fallback/mod.json
@@ -1,0 +1,11 @@
+{
+  "name": "stylist-fallback",
+  "version": "1.0.0",
+  "author": "Ragnarok Offline",
+  "description": "Makes the seven renewal stylists work. They normally open a window this client cannot draw, leaving you facing an NPC that does nothing.",
+  "default": "on",
+  "requires": {
+    "app": ">=1.0.6",
+    "era": "renewal"
+  }
+}

--- a/mods/stylist-fallback/npc/stylist-fallback.txt
+++ b/mods/stylist-fallback/npc/stylist-fallback.txt
@@ -1,0 +1,54 @@
+// Put a working stylist where the broken ones stand.
+//
+// Renewal has seven stylists and every one of them ends in openstylist(),
+// which sends ZC_UI_OPEN with ui_type OUT_UI_STYLIST (1). roBrowser's
+// onUIOpen implements exactly three ui_types -- 7 attendance, 8 enchant grade,
+// 10 enchant -- and logs "not implemented" for everything else. So the NPC
+// closes its dialogue, asks for a window nobody draws, and the player is left
+// looking at a stylist who does nothing. #32.
+//
+// There is no flag for this the way there was for the refine window: the
+// client has no stylist UI to switch on. The fix has to be to stop sending
+// players to it.
+//
+// So: switch the seven off, and stand rAthena's own script-driven stylist on
+// the same squares. That script is `npc/custom/stylist.txt`, which upstream
+// ships and leaves unloaded; this mod's stock-npc.txt turns it on. It does the
+// same three things through `setlook`, which needs no window at all.
+//
+// Each duplicate keeps the sprite and facing of the NPC it replaces, so
+// nothing about the town looks different -- the stylist is simply one that
+// answers.
+//
+// This mod is renewal-only, declared in mod.json. Pre-renewal never had the
+// problem: its stylists are the old menu-driven ones already, and two NPCs on
+// one square would be a collision for no reason.
+
+-	script	StylistFallback	-1,{
+OnInit:
+	// The seven that call openstylist(). Names, not coordinates: disablenpc
+	// takes the unique name, and these are stable across rAthena releases in a
+	// way the coordinates are not.
+	disablenpc "Stylist#alberta";
+	disablenpc "Stylist#prontera";
+	disablenpc "Stylist#lhz";
+	disablenpc "Stylist#lasagna";
+	disablenpc "Stylist#rachel";
+	disablenpc "Stylist#yuno";
+	disablenpc "Stylist#cash";
+
+	// And the one the replacement script places itself, in Prontera at
+	// 170,180. Loading that file is how we get the script; the NPC it comes
+	// with is not part of the deal, and leaving it would put a stylist in a
+	// spot the game never had one.
+	disablenpc "Stylist#custom_stylist";
+	end;
+}
+
+alberta_in,55,142,7	duplicate(Stylist#custom_stylist)	Stylist#alberta_ro	4_F_02
+prt_in,243,168,4	duplicate(Stylist#custom_stylist)	Stylist#prontera_ro	4_F_02
+lhz_in02,100,143,4	duplicate(Stylist#custom_stylist)	Stylist#lhz_ro	2_M_DYEINGER
+lasagna,134,113,3	duplicate(Stylist#custom_stylist)	Stylist#lasagna_ro	4_DR_F_02
+ra_in01,186,148,5	duplicate(Stylist#custom_stylist)	Stylist#rachel_ro	4_F_MASK1
+yuno_in04,186,21,1	duplicate(Stylist#custom_stylist)	Stylist#yuno_ro	4_M_BARBER
+itemmall,19,74,5	duplicate(Stylist#custom_stylist)	Stylist#cash_ro	91

--- a/mods/stylist-fallback/stock-npc.txt
+++ b/mods/stylist-fallback/stock-npc.txt
@@ -1,0 +1,7 @@
+# rAthena's own script-driven stylist, which it ships and does not load.
+#
+# It is the replacement the NPCs below get: a plain menu of hair style, hair
+# colour and clothes colour, built from `setlook` calls that every client
+# generation has understood. Nothing here is written by us -- the point is to
+# use the version upstream already maintains and tests.
+npc/custom/stylist.txt


### PR DESCRIPTION
Stacked on #33 — base is `refine-ui`, which is itself stacked on #30. Review
in that order. Fixes the stylist half of #32.

## The bug

Prince Shami in Lighthalzen (`lhz_in02 100,143`) closes his dialogue and
nothing opens. Same for six other stylists.

Every renewal stylist ends in `close2; openstylist(); end`. That sends
`ZC_UI_OPEN` with `ui_type = OUT_UI_STYLIST` (1). roBrowser's `onUIOpen`
implements exactly three:

```js
case 7:  // attendance
case 8:  // enchant grade
case 10: // enchant
default: console.error(`[PACKET.ZC.UI_OPEN] not implemented (${pkt.ui_type})`);
```

Unlike the refine window in #33, **there is no flag to turn on** — the client
has no stylist UI to enable. The only fix available to us is to stop sending
players to one.

## The fix

Switch the seven off; stand rAthena's own script-driven stylist on the same
squares.

`npc/custom/stylist.txt` is upstream's, shipped and left commented out of
`scripts_custom.conf`. It does the same three things — hair, hair colour,
clothes colour — through `setlook`, which needs no window. The mod's
`stock-npc.txt` turns it on and the duplicates carry the sprite and facing of
each NPC they replace, so the towns look unchanged; the stylist simply
answers.

The NPC that script plants in Prontera at 170,180 is disabled too — loading
the file is how we get the script, and the game never had a stylist there.

| Decision | Why |
|---|---|
| Renewal-only, in the manifest | Pre-renewal's stylists are already menu-driven. Its `Hair Dresser#li` sits on the same square, and a second NPC there would be a collision for nothing. |
| Default **on** | What it replaces is a dead end. One toggle in Settings gets the stock NPCs back. |
| Reuse upstream's script | It is maintained and tested there. Writing our own stylist to fix a client gap is how you get a second bug. |

Incidentally this is also the mechanism Flux159 asked for in #31 — a mod that
declares the era it works in and is refused in the other. `stylist-fallback`
is the first bundled mod to use `requires.era`.

## Verification

On a running server, mods rebuilt and stack restarted:

- both `npc:` lines reach `conf/import/map_conf.txt` (`npc/custom/stylist.txt`
  and `npc/mods/stylist-fallback/stylist-fallback.txt`)
- the map-server parses it with **no errors**, and no `npc_parse_duplicate` or
  "No such NPC" complaints
- `OnInit` executed across 3174 NPCs
- `ragnarok-stack mods` lists it as `on` under renewal

**Not verified in game** — that needs somebody to stand in front of one.

## Still open from these issues

- **#31, NPC sprites rendering as floating item icons.** Not era-related, as
  far as I can tell. The bundled `common-npcs` mod turns on rAthena's
  `npc/custom/` scripts, which use sprite ids 811 and 909. Decoding
  `npcidentity.lub` out of a real client gives 811 → `JT_4_F_VALKYRIE` and
  909 → `JT_4_PORING`, and both sprites exist and serve correctly here — so on
  the reporter's older client data those ids very likely mean something else.
  Their `state/assets/logs/missing-files.log` would settle it; asked on the
  issue.
- **#32, the quest journal.** The display table is present and correct
  (`data/questid2display.txt`, 1.4 MB), the packet structs match rAthena's
  `0x9f8` field for field, and roBrowser hooks it. On this machine every quest
  row for the character under test had `state = 2` (complete), and rAthena
  only sends `avail_quests` — so an empty ACTIVE tab was correct there. Needs
  a character with an active quest before calling it a bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P8Y5BSZh9gydDhfe32gjcF
