### PR TITLE
Implement the stylist window instead of working around it

### DIFF
--- a/patches/Stylist.css
+++ b/patches/Stylist.css
@@ -1,0 +1,114 @@
+:host {
+	width: 230px;
+	height: 208px;
+}
+
+#Stylist {
+	position: relative;
+	width: 100%;
+	height: 100%;
+	background-color: #d3d0c8;
+	border: 1px solid #7a7768;
+	border-radius: 3px;
+	font-family: Arial, sans-serif;
+	font-size: 11px;
+	color: #202020;
+}
+
+#Stylist .titlebar {
+	width: 100%;
+	height: 17px;
+	background-color: white;
+	background-repeat: repeat-x;
+	border-radius: 3px 3px 0 0;
+	cursor: move;
+}
+#Stylist .titlebar .base {
+	width: 11px;
+	height: 11px;
+	border: none;
+	background-color: transparent;
+	background-repeat: no-repeat;
+	vertical-align: middle;
+}
+#Stylist .titlebar .text {
+	text-shadow: 1px 1px white;
+	vertical-align: -2px;
+	white-space: nowrap;
+	display: inline-block;
+	height: 13px;
+	font-size: 11px;
+	font-weight: bold;
+}
+#Stylist .titlebar .left {
+	margin-left: 3px;
+	float: left;
+}
+#Stylist .titlebar .right {
+	float: right;
+	margin-right: 3px;
+}
+#Stylist .titlebar .clear {
+	clear: both;
+}
+
+#Stylist .panel {
+	padding: 8px 10px;
+}
+
+#Stylist .row {
+	height: 22px;
+	line-height: 22px;
+	white-space: nowrap;
+}
+#Stylist .row .label {
+	display: inline-block;
+	width: 74px;
+}
+#Stylist .row .value {
+	display: inline-block;
+	width: 34px;
+	text-align: center;
+	font-weight: bold;
+}
+
+/* Buttons are drawn rather than sprited: the stylist has no artwork of its
+   own in any client generation this app supports, and borrowing another
+   window's sprites would break the moment that window's assets move. */
+#Stylist .arrow {
+	width: 20px;
+	height: 17px;
+	padding: 0;
+	font-size: 9px;
+	line-height: 15px;
+	cursor: pointer;
+	border: 1px solid #7a7768;
+	border-radius: 2px;
+	background: linear-gradient(#fdfdfd, #dcdad2);
+}
+#Stylist .arrow:active {
+	background: linear-gradient(#dcdad2, #fdfdfd);
+}
+
+#Stylist .note {
+	margin: 6px 0 8px;
+	line-height: 13px;
+	color: #4a4a4a;
+}
+
+#Stylist .buttons {
+	text-align: right;
+}
+#Stylist .buttons button {
+	min-width: 62px;
+	height: 20px;
+	margin-left: 5px;
+	cursor: pointer;
+	border: 1px solid #7a7768;
+	border-radius: 2px;
+	background: linear-gradient(#fdfdfd, #dcdad2);
+	font-size: 11px;
+}
+#Stylist .buttons button:active {
+	background: linear-gradient(#dcdad2, #fdfdfd);
+}

--- a/patches/Stylist.html
+++ b/patches/Stylist.html
@@ -1,0 +1,50 @@
+<div id="Stylist">
+	<div class="titlebar">
+		<ui-image src="basic_interface/titlebar_mid.bmp"></ui-image>
+		<div class="left">
+			<ui-button
+				class="base"
+				bg="basic_interface/sys_base_off.bmp"
+				hover="basic_interface/sys_base_on.bmp"
+			></ui-button>
+			<span class="text">Stylist</span>
+		</div>
+		<div class="right">
+			<ui-button
+				class="base close"
+				bg="basic_interface/sys_close_off.bmp"
+				hover="basic_interface/sys_close_on.bmp"
+			></ui-button>
+		</div>
+		<div class="clear"></div>
+	</div>
+
+	<div class="panel">
+		<div class="row" data-look="head">
+			<span class="label">Hair style</span>
+			<button class="arrow prev" type="button">&#9664;</button>
+			<span class="value">0</span>
+			<button class="arrow next" type="button">&#9654;</button>
+		</div>
+		<div class="row" data-look="headpalette">
+			<span class="label">Hair colour</span>
+			<button class="arrow prev" type="button">&#9664;</button>
+			<span class="value">0</span>
+			<button class="arrow next" type="button">&#9654;</button>
+		</div>
+		<div class="row" data-look="bodypalette">
+			<span class="label">Clothes</span>
+			<button class="arrow prev" type="button">&#9664;</button>
+			<span class="value">0</span>
+			<button class="arrow next" type="button">&#9654;</button>
+		</div>
+
+		<div class="note">Your character shows each change as you make it. Nothing is
+			bought until you press Apply.</div>
+
+		<div class="buttons">
+			<button class="apply" type="button">Apply</button>
+			<button class="cancel" type="button">Cancel</button>
+		</div>
+	</div>
+</div>

--- a/patches/Stylist.js
+++ b/patches/Stylist.js
@@ -1,0 +1,282 @@
+/**
+ * UI/Components/Stylist/Stylist.js
+ *
+ * The stylist window (ZC_UI_OPEN, ui_type 1).
+ *
+ * roBrowser implements three of the eleven ui_types the server can ask for,
+ * and the stylist is not one of them -- `onUIOpen` logged "not implemented"
+ * and returned. rAthena does not know that, so every stylist NPC in renewal
+ * closes its dialogue, asks for this window and leaves the player facing
+ * nothing at all. This is that window.
+ *
+ * Two decisions worth knowing about:
+ *
+ * **The preview is the character itself.** Every other approach means a second
+ * canvas, a second Entity and the sprite-loading dance CharCreate does in a
+ * hundred lines. Setting the look on the player's own entity is a true preview
+ * -- it is the same code path a server-sent look change uses -- and the
+ * original values are put back if the window is cancelled or closed. Nothing
+ * is sent until Apply.
+ *
+ * **An index is not a look value, but here it is.** The packet carries indices
+ * into the server's stylist table, not hair numbers, and rAthena resolves them
+ * through `db/re/stylist.yml`. In the table rAthena ships, `Index` and `Value`
+ * are the same number for every entry, so sending the look value works. A
+ * server with a rewritten stylist table could map them differently; the server
+ * validates every index and answers ZC_STYLE_CHANGE_RES with a failure flag,
+ * which is reported rather than swallowed.
+ *
+ * This file is part of ROBrowser, (http://www.robrowser.com/).
+ */
+
+import Network from 'Network/NetworkManager.js';
+import PACKET from 'Network/PacketStructure.js';
+import PACKETVER from 'Network/PacketVerManager.js';
+import Preferences from 'Core/Preferences.js';
+import Renderer from 'Renderer/Renderer.js';
+import Session from 'Engine/SessionStorage.js';
+import UIManager from 'UI/UIManager.js';
+import GUIComponent from 'UI/GUIComponent.js';
+import ChatBox from 'UI/Components/ChatBox/ChatBox.js';
+import htmlText from './Stylist.html?raw';
+import cssText from './Stylist.css?raw';
+
+/**
+ * Create component
+ */
+const Stylist = new GUIComponent('Stylist', cssText);
+
+Stylist.render = () => htmlText;
+
+/**
+ * What the player may cycle through.
+ *
+ * The ranges mirror the stylist table rAthena ships (`db/re/stylist.yml`:
+ * 42 hair styles, 8 hair colours, 7 clothes colours). They are a courtesy,
+ * not a rule -- the server is the authority and rejects anything outside its
+ * own table, which is reported in chat rather than silently ignored.
+ *
+ * `field` is the name of the field in CZ_REQ_STYLE_CHANGE2; `prop` is the
+ * Entity property that shows it.
+ */
+const LOOKS = [
+	{ prop: 'head', field: 'HeadStyle', min: 1, max: 42 },
+	{ prop: 'headpalette', field: 'HeadPalette', min: 1, max: 8 },
+	{ prop: 'bodypalette', field: 'BodyPalette', min: 1, max: 7 }
+];
+
+/**
+ * @var {Preferences} window position
+ */
+const _preferences = Preferences.get(
+	'Stylist',
+	{
+		x: 300,
+		y: 200
+	},
+	1.0
+);
+
+/**
+ * What the character looked like when the window opened, so Cancel means
+ * something.
+ */
+let _original = null;
+
+/**
+ * Initialize the component
+ */
+Stylist.init = function init() {
+	const root = this.getRoot();
+
+	this.draggable(root.querySelector('.titlebar'));
+
+	root.querySelector('.titlebar .close').addEventListener('click', () => {
+		revert();
+		Stylist.remove();
+	});
+
+	root.querySelector('.cancel').addEventListener('click', () => {
+		revert();
+		Stylist.remove();
+	});
+
+	root.querySelector('.apply').addEventListener('click', () => {
+		apply();
+	});
+
+	root.querySelectorAll('.row').forEach((row) => {
+		const look = LOOKS.find((l) => l.prop === row.getAttribute('data-look'));
+		if (!look) {
+			return;
+		}
+		row.querySelector('.prev').addEventListener('click', () => step(look, -1));
+		row.querySelector('.next').addEventListener('click', () => step(look, +1));
+	});
+};
+
+/**
+ * Remember the character, and show what it currently is
+ */
+Stylist.onAppend = function onAppend() {
+	const entity = Session.Entity;
+
+	_original = {};
+	LOOKS.forEach((look) => {
+		_original[look.prop] = entity ? entity[look.prop] | 0 : 0;
+	});
+
+	this.getRoot().style.left = Math.min(Math.max(0, _preferences.x), Renderer.width - 230) + 'px';
+	this.getRoot().style.top = Math.min(Math.max(0, _preferences.y), Renderer.height - 208) + 'px';
+
+	refresh();
+};
+
+/**
+ * Keep the position, and never leave the player wearing an unpaid preview
+ */
+Stylist.onRemove = function onRemove() {
+	revert();
+
+	const root = this.getRoot();
+	_preferences.x = parseInt(root.style.left, 10) || 0;
+	_preferences.y = parseInt(root.style.top, 10) || 0;
+	_preferences.save();
+
+	// Tell the server the window is gone, so it stops considering the stylist
+	// open. Without this `sd->state.stylist_open` stays true until the next
+	// map change and a second visit to the NPC is refused.
+	if (PACKETVER.value >= 20151104) {
+		Network.sendPacket(new PACKET.CZ.REQ_STYLE_CLOSE());
+	}
+};
+
+/**
+ * Escape closes it, like every other window
+ */
+Stylist.onKeyDown = function onKeyDown(event) {
+	if (event.which === 27 || event.key === 'Escape') {
+		revert();
+		this.remove();
+		event.stopImmediatePropagation();
+		return false;
+	}
+	return true;
+};
+
+/**
+ * Move one look up or down, wrapping at both ends
+ */
+function step(look, direction) {
+	const entity = Session.Entity;
+	if (!entity) {
+		return;
+	}
+
+	let value = (entity[look.prop] | 0) + direction;
+	if (value > look.max) {
+		value = look.min;
+	}
+	if (value < look.min) {
+		value = look.max;
+	}
+
+	entity[look.prop] = value;
+	refresh();
+}
+
+/**
+ * Put the numbers in the window back in step with the character
+ */
+function refresh() {
+	const entity = Session.Entity;
+	const root = Stylist.getRoot();
+
+	root.querySelectorAll('.row').forEach((row) => {
+		const look = LOOKS.find((l) => l.prop === row.getAttribute('data-look'));
+		if (look) {
+			row.querySelector('.value').textContent = entity ? entity[look.prop] | 0 : 0;
+		}
+	});
+}
+
+/**
+ * Undo the preview
+ */
+function revert() {
+	const entity = Session.Entity;
+	if (!entity || !_original) {
+		return;
+	}
+
+	LOOKS.forEach((look) => {
+		if (entity[look.prop] !== _original[look.prop]) {
+			entity[look.prop] = _original[look.prop];
+		}
+	});
+	_original = null;
+}
+
+/**
+ * Buy it
+ */
+function apply() {
+	const entity = Session.Entity;
+	if (!entity || !_original) {
+		return;
+	}
+
+	const pkt = new PACKET.CZ.REQ_STYLE_CHANGE2();
+	let changed = false;
+
+	LOOKS.forEach((look) => {
+		const value = entity[look.prop] | 0;
+		// Zero means "leave this one alone" to the server, which is exactly
+		// what an untouched row means here.
+		if (value !== _original[look.prop]) {
+			pkt[look.field] = value;
+			changed = true;
+		}
+	});
+
+	if (!changed) {
+		Stylist.remove();
+		return;
+	}
+
+	Network.sendPacket(pkt);
+}
+
+/**
+ * The server's answer.
+ *
+ * On success it has already sent the look changes as ordinary sprite updates,
+ * so the preview simply becomes the truth -- there is nothing to apply here,
+ * only the original to forget so Cancel cannot undo a paid-for haircut.
+ *
+ * @param {object} pkt - PACKET.ZC.STYLE_CHANGE_RES
+ */
+function onStyleChangeResult(pkt) {
+	if (pkt.flag) {
+		ChatBox.addText(
+			'The stylist cannot do that one.',
+			ChatBox.TYPE.ERROR
+		);
+		revert();
+		refresh();
+		return;
+	}
+
+	_original = null;
+	Stylist.remove();
+}
+
+/**
+ * Hook the answer
+ */
+Network.hookPacket(PACKET.ZC.STYLE_CHANGE_RES, onStyleChangeResult);
+
+/**
+ * Export
+ */
+export default UIManager.addComponent(Stylist);

--- a/patches/Stylist.js
+++ b/patches/Stylist.js
@@ -89,7 +89,7 @@ let _original = null;
 Stylist.init = function init() {
 	const root = this.getRoot();
 
-	this.draggable(root.querySelector('.titlebar'));
+	this.draggable('.titlebar');
 
 	root.querySelector('.titlebar .close').addEventListener('click', () => {
 		revert();
@@ -126,8 +126,15 @@ Stylist.onAppend = function onAppend() {
 		_original[look.prop] = entity ? entity[look.prop] | 0 : 0;
 	});
 
-	this.getRoot().style.left = Math.min(Math.max(0, _preferences.x), Renderer.width - 230) + 'px';
-	this.getRoot().style.top = Math.min(Math.max(0, _preferences.y), Renderer.height - 208) + 'px';
+	// `_host`, not `getRoot()`: getRoot() hands back the ShadowRoot, which has
+	// no style of its own. Setting `.style.left` on it throws inside append(),
+	// which leaves the component half-attached and -- because onKeyDown was
+	// then live -- eating the Escape that would have got the player out.
+	const host = this._host;
+	host.style.left =
+		Math.min(Math.max(0, _preferences.x), Renderer.width - host.offsetWidth) + 'px';
+	host.style.top =
+		Math.min(Math.max(0, _preferences.y), Renderer.height - host.offsetHeight) + 'px';
 
 	refresh();
 };
@@ -138,9 +145,8 @@ Stylist.onAppend = function onAppend() {
 Stylist.onRemove = function onRemove() {
 	revert();
 
-	const root = this.getRoot();
-	_preferences.x = parseInt(root.style.left, 10) || 0;
-	_preferences.y = parseInt(root.style.top, 10) || 0;
+	_preferences.x = parseInt(this._host.style.left, 10) || 0;
+	_preferences.y = parseInt(this._host.style.top, 10) || 0;
 	_preferences.save();
 
 	// Tell the server the window is gone, so it stops considering the stylist
@@ -155,6 +161,12 @@ Stylist.onRemove = function onRemove() {
  * Escape closes it, like every other window
  */
 Stylist.onKeyDown = function onKeyDown(event) {
+	// A component that failed to append must not hold the keyboard hostage.
+	// Escape is how a stuck player gets back to character select, and that is
+	// exactly the moment it has to work.
+	if (!this._host || this._host.style.display === 'none') {
+		return true;
+	}
 	if (event.which === 27 || event.key === 'Escape') {
 		revert();
 		this.remove();

--- a/scripts/patch-client.sh
+++ b/scripts/patch-client.sh
@@ -276,4 +276,120 @@ elif s.count(old) == 1:
     print("patched CharEngine.js (database stall breadcrumb)")
 else:
     sys.exit("CharEngine.js: onReceiveMapInfo retry no longer matches; re-check the patch")
+
+# 0005 - The stylist window (ZC_UI_OPEN, ui_type 1).
+#
+# roBrowser implements three of the eleven ui_types a server can ask for.
+# The stylist is not one of them: onUIOpen logged "not implemented" and
+# returned, so every renewal stylist NPC closed its dialogue and opened
+# nothing, leaving the player facing an NPC that does not answer. rAthena has
+# no fallback for it either -- unlike the refine window there is no server
+# flag that offers the old menu instead.
+#
+# Three packets and a window. The packets are ours to add because roBrowser
+# never defined them: CZ_REQ_STYLE_CHANGE2 (0xafc, the one a 2018+ client
+# sends), CZ_REQ_STYLE_CLOSE (0xa48) and ZC_STYLE_CHANGE_RES (0xa47).
+comp = rb / "src/UI/Components/Stylist"
+comp.mkdir(parents=True, exist_ok=True)
+for name in ("Stylist.js", "Stylist.html", "Stylist.css"):
+    shutil.copyfile(root / "patches" / name, comp / name)
+print("installed the Stylist component")
+
+p = rb / "src/Network/PacketStructure.js"
+s = p.read_text()
+if "CZ_REQ_STYLE_CHANGE2" in s:
+    print("PacketStructure.js already patched")
+else:
+    anchor = "export default PACKET;"
+    if anchor not in s:
+        sys.exit("PacketStructure.js: no `export default PACKET;` to append before")
+    block = """
+// 0xafc - the stylist's "buy this look".
+//
+// Every field is an index into the server's stylist table, not a look value,
+// and a zero means "leave this one alone". CHANGE2 rather than CHANGE: a
+// client of 2018-05-16 or newer sends the longer one, which carries BodyStyle.
+PACKET.CZ.REQ_STYLE_CHANGE2 = function PACKET_CZ_REQ_STYLE_CHANGE2() {
+	this.HeadPalette = 0;
+	this.HeadStyle = 0;
+	this.BodyPalette = 0;
+	this.TopAccessory = 0;
+	this.MidAccessory = 0;
+	this.BottomAccessory = 0;
+	this.BodyStyle = 0;
+};
+PACKET.CZ.REQ_STYLE_CHANGE2.prototype.build = function () {
+	const pkt_buf = new BinaryWriter(16);
+
+	pkt_buf.writeShort(0xafc);
+	pkt_buf.writeShort(this.HeadPalette);
+	pkt_buf.writeShort(this.HeadStyle);
+	pkt_buf.writeShort(this.BodyPalette);
+	pkt_buf.writeShort(this.TopAccessory);
+	pkt_buf.writeShort(this.MidAccessory);
+	pkt_buf.writeShort(this.BottomAccessory);
+	pkt_buf.writeShort(this.BodyStyle);
+
+	return pkt_buf;
+};
+
+// 0xa48 - the window is gone. Without it the server leaves stylist_open set
+// and refuses to open it a second time until the next map change.
+PACKET.CZ.REQ_STYLE_CLOSE = function PACKET_CZ_REQ_STYLE_CLOSE() {};
+PACKET.CZ.REQ_STYLE_CLOSE.prototype.build = function () {
+	const pkt_buf = new BinaryWriter(2);
+
+	pkt_buf.writeShort(0xa48);
+
+	return pkt_buf;
+};
+
+// 0xa47 - flag is non-zero when the server refused the look.
+PACKET.ZC.STYLE_CHANGE_RES = function PACKET_ZC_STYLE_CHANGE_RES(fp, end) {
+	this.flag = fp.readUChar();
+};
+PACKET.ZC.STYLE_CHANGE_RES.size = 3;
+
+"""
+    p.write_text(s.replace(anchor, block + anchor, 1))
+    print("patched PacketStructure.js (stylist packets)")
+
+p = rb / "src/Network/PacketRegister.js"
+s = p.read_text()
+if "STYLE_CHANGE_RES" in s:
+    print("PacketRegister.js already patched")
+else:
+    anchor = "\t0xa4e: PACKET.ZC.RANDOM_COMBINE_ITEM_UI_OPEN,"
+    if anchor not in s:
+        sys.exit("PacketRegister.js: no 0xa4e line to hang the stylist response off")
+    p.write_text(s.replace(anchor, "\t0xa47: PACKET.ZC.STYLE_CHANGE_RES,\n" + anchor, 1))
+    print("patched PacketRegister.js (0xa47)")
+
+p = rb / "src/Engine/MapEngine/UIOpen.js"
+s = p.read_text()
+if "Stylist" in s:
+    print("UIOpen.js already patched")
+else:
+    s = s.replace(
+        "import EnchantUI from 'UI/Components/Enchant/Enchant.js';",
+        "import EnchantUI from 'UI/Components/Enchant/Enchant.js';\nimport Stylist from 'UI/Components/Stylist/Stylist.js';",
+        1,
+    )
+    old = "\tswitch (pkt.ui_type) {\n\t\tcase 7:"
+    new = (
+        "\tswitch (pkt.ui_type) {\n"
+        "\t\tcase 1:\n"
+        "\t\t\t// The stylist. rAthena sets sd->state.stylist_open when it sends\n"
+        "\t\t\t// this, and only clears it on a successful buy or on our close\n"
+        "\t\t\t// packet -- so the window has to answer either way.\n"
+        "\t\t\tif (PACKETVER.value >= 20151104) {\n"
+        "\t\t\t\tStylist.append();\n"
+        "\t\t\t}\n"
+        "\t\t\tbreak;\n"
+        "\t\tcase 7:"
+    )
+    if old not in s:
+        sys.exit("UIOpen.js: the ui_type switch no longer matches; re-check the patch")
+    p.write_text(s.replace(old, new, 1))
+    print("patched UIOpen.js (ui_type 1 opens the stylist)")
 PY


### PR DESCRIPTION
Stacked on #33 (base `refine-ui`), which is stacked on #30. **Replaces #34**,
which I have closed.

## Why this and not #34

#34 swapped the seven renewal stylists for rAthena's old menu-driven one. That
was a workaround wearing a fix's clothes: it changed stock NPCs by default and
still left the client unable to do the thing the server was asking it to do.
This implements the window.

## The bug

Every renewal stylist ends in `openstylist()` → `ZC_UI_OPEN` with `ui_type 1`.
roBrowser implements three of the eleven ui_types a server can ask for, and the
stylist is not among them:

```js
default: console.error(`[PACKET.ZC.UI_OPEN] not implemented (${pkt.ui_type})`);
```

So the NPC closed its dialogue, asked for a window nobody drew, and the player
was left facing something that does not answer.

## The fix

Three packets roBrowser never defined, and a window.

| packet | id | what it is |
|---|---|---|
| `CZ_REQ_STYLE_CHANGE2` | `0xafc` | the buy. Fields are **indices into the server's stylist table**, zero meaning "leave this one alone". CHANGE2, not CHANGE — a client of 2018-05-16 or newer sends the longer one. |
| `CZ_REQ_STYLE_CLOSE` | `0xa48` | the window is gone. Without it rAthena leaves `stylist_open` set and refuses to reopen until the next map change. |
| `ZC_STYLE_CHANGE_RES` | `0xa47` | non-zero `flag` means refused. |

**The preview is the character itself.** Every other approach means a second
canvas, a second `Entity` and the sprite-loading dance `CharCreate` does in a
hundred lines. Setting the look on the player's own entity is the same code
path a server-sent look change takes, and the originals go back on Cancel,
close or Escape. Nothing is sent until Apply.

**One documented assumption.** The packet carries indices, and rAthena resolves
them through `db/re/stylist.yml`. In the table it ships, `Index` and `Value` are
the same number for every entry, so sending the look value is correct. A server
with a rewritten stylist table could map them differently — and would refuse,
visibly, in chat.

Ranges (42 hair styles, 8 hair colours, 7 clothes colours) mirror that table.
They are a courtesy; the server is the authority.

## Verification

- `scripts/patch-client.sh` applies cleanly and is **idempotent** — a second run
  reports "already patched" for all four edits
- `eslint` clean on the new component and on `UIOpen.js`
- `npm run build:online` succeeds; the built `Online.js` carries all three
  packets and `case 1: ... Stylist.append()`
- deployed to a running app; the asset server serves the new bundle

**Not verified in game** — that needs somebody to stand in front of a stylist
(`prt_in 243,168`, or Prince Shami at `lhz_in02 100,143`).

## Note for whoever tests

`Online.js` is an ordinary HTTP fetch, so a stale copy in the client's cache
will hide this. #30 clears that cache when the *mod overlay* changes, which a
client rebuild is not — worth widening later, or just clear it once by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P8Y5BSZh9gydDhfe32gjcF
