### PR TITLE
Pin rAthena, like the other two

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Build rAthena
         run: |
           set -e
-          git clone --depth 1 https://github.com/rathena/rathena.git /tmp/rathena
+          ./scripts/vendor-fetch.sh rathena /tmp/rathena
           ./scripts/apply-server-mods.sh /tmp/rathena
           cp containers/rathena/Dockerfile /tmp/rathena/Dockerfile.ragnarokmac
           docker build -f /tmp/rathena/Dockerfile.ragnarokmac \

--- a/config/VENDOR_PINS
+++ b/config/VENDOR_PINS
@@ -7,3 +7,4 @@
 #   name              url                                                    commit
 roBrowserLegacy   https://github.com/MrAntares/roBrowserLegacy.git   6a177d9b4e8da41d6af76f6e7c527d52beb781c3
 ROenglishRE       https://github.com/llchrisll/ROenglishRE.git       66cdfec631603fda6a90ba4bbe26ab07b5204c84
+rathena           https://github.com/rathena/rathena.git             e985006171d2eb320ee512a653f4c83aea3d81b6

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -21,7 +21,7 @@ clone() {
 mkdir -p "$VENDOR"
 "$ROOT/scripts/vendor-fetch.sh" roBrowserLegacy "$VENDOR/roBrowserLegacy"
 clone https://github.com/FranciscoWallison/roBrowserLegacy-RemoteClient-JS.git roBrowserLegacy-RemoteClient-JS
-clone https://github.com/rathena/rathena.git                                  rathena
+"$ROOT/scripts/vendor-fetch.sh" rathena "$VENDOR/rathena"
 "$ROOT/scripts/vendor-fetch.sh" ROenglishRE "$VENDOR/ROenglishRE"
 
 echo "==> applying client patches"


### PR DESCRIPTION
Step 1 of #40, and the cheap half of it.

## The gap

`VENDOR_PINS` pins roBrowserLegacy and ROenglishRE, with the reasoning stated
in the file — *a clone of a moving branch means the tag we ship does not say
what was built, and it has already broken a release build once*. rAthena was
cloned from master in **both** places it gets built:

```
.github/workflows/images.yml:88   git clone --depth 1 .../rathena.git /tmp/rathena
scripts/bootstrap.sh:24           clone .../rathena.git   rathena
```

So the server image is whatever master was on the day the image workflow last
ran, and nothing records which day that was. The images shipping in 1.0.8 were
built that way, and the commit inside them can't now be recovered — which is
its own argument for fixing it.

**rAthena deserves the pin more than the other two, not less:**

- it owns the database schema — 73 scripts in `sql-files/upgrades/`, none of
  which we apply — so an unnoticed move can hand a long-time player a server
  whose C++ expects columns their database has never had (#40)
- it is the tree `apply-server-mods.sh` patches the population engine into,
  and those patches are written against a particular version

## The change

Pinned at `e985006`, dated 2026-08-21 — **the commit this repository's checkout
is already on**, so the pin records what has actually been built and tested
rather than moving anything:

```
$ ./scripts/vendor-fetch.sh rathena vendor/rathena
    rathena: already at e985006171d2
```

Both build paths now go through `vendor-fetch.sh`, so CI and a local bootstrap
resolve the same source the same way — which is what the comment above the CI
step already claimed was happening.

## What this does not do

It does not apply rAthena's schema upgrades, and it does not back up before an
update. Both are in #40. What it does is make moving rAthena a **deliberate
commit** — which is the moment those two become noticeable rather than
something that arrives inside an unrelated patch release.

No behaviour change: same source, same images, now recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P8Y5BSZh9gydDhfe32gjcF
