### PR TITLE
Keep accessory/robe resource names as EUC-KR bytes

### DIFF
--- a/scripts/patch-client.sh
+++ b/scripts/patch-client.sh
@@ -470,4 +470,97 @@ else:
         s = s.replace(a, b)
     p.write_text(s)
     print(f"patched QuestCommon.js ({n} quest lists now actually shown)")
+
+# 0008 - Hats and garments stop rendering once their name comes from a lua
+# name table.
+#
+# Every sprite request 404s with a path whose directory is EUC-KR
+# ("data/sprite/\xbe\xc7\xbc\xbc\xbb\xe7\xb8\xae/...") but whose item-name tail is
+# Unicode Hangul, so the two halves cannot both be right and the file is never
+# found. The asset server does exactly what it should -- it has no such file --
+# and missing-files.log names it.
+#
+# loadLuaTable() decodes every value with the user charpage. That is correct
+# for display tables (job names, skill descriptions), but accname.lub and
+# spriterobename.lub do not hold display text: their values are GRF filenames.
+# getHatPath()/getRobePath() concatenate them onto an EUC-KR byte-string
+# prefix, so they have to stay bytes -- which is exactly what itemInfo's
+# AddItem already does for identifiedResourceName, decoding it without a
+# charpage.
+#
+# The tables are module singletons that outlive a relogin without a page
+# reload, which is why the headgear vanished only after relogging and came
+# back on F5 -- and why the symptom reads as "hats not appearing until server
+# restart".
+p = rb / "src/DB/DBManager.js"
+s = p.read_text()
+if "isResourceTable" in s:
+    print("DBManager.js resource names already patched")
+else:
+    subs = [
+        (
+"""function loadLuaTable(file_list, table_name, callback, onEnd, contextFunc) {""",
+"""function loadLuaTable(file_list, table_name, callback, onEnd, contextFunc, isResourceTable = false) {""",
+        ),
+        (
+"""			ctx.addKeyAndValueToTable = (key, value) => {
+				table[key] = userStringDecoder.decode(value, userCharpage);
+				return 1;
+			};""",
+"""			ctx.addKeyAndValueToTable = (key, value) => {
+				// Resource-name tables (accname, robename) hold GRF sprite filenames, not
+				// display text. They must stay as raw EUC-KR byte-strings so the paths built
+				// in getHatPath/getRobePath match the files -- decoding with the charpage
+				// turns them into Unicode Hangul and every sprite request 404s. Display
+				// tables (job names, skill descriptions...) still decode with the charpage.
+				table[key] = userStringDecoder.decode(value, isResourceTable ? null : userCharpage);
+				return 1;
+			};""",
+        ),
+        (
+"""			loadLuaTable(
+				[DB.LUA_PATH + 'datainfo/accessoryid.lub', DB.LUA_PATH + 'datainfo/accname.lub'],
+				'AccNameTable',
+				function (json) {
+					Object.assign(HatTable, json);
+				},
+				onLoad()
+			);
+			loadLuaTable(
+				[DB.LUA_PATH + 'datainfo/spriterobeid.lub', DB.LUA_PATH + 'datainfo/spriterobename.lub'],
+				'RobeNameTable',
+				function (json) {
+					Object.assign(RobeTable, json);
+				},
+				onLoad()
+			);""",
+"""			loadLuaTable(
+				[DB.LUA_PATH + 'datainfo/accessoryid.lub', DB.LUA_PATH + 'datainfo/accname.lub'],
+				'AccNameTable',
+				function (json) {
+					Object.assign(HatTable, json);
+				},
+				onLoad(),
+				null,
+				true
+			);
+			loadLuaTable(
+				[DB.LUA_PATH + 'datainfo/spriterobeid.lub', DB.LUA_PATH + 'datainfo/spriterobename.lub'],
+				'RobeNameTable',
+				function (json) {
+					Object.assign(RobeTable, json);
+				},
+				onLoad(),
+				null,
+				true
+			);""",
+        ),
+    ]
+    for old, new in subs:
+        if s.count(old) != 1:
+            sys.exit("DBManager.js: resource-name anchor no longer matches (%d hits); re-check the patch" % s.count(old))
+        s = s.replace(old, new, 1)
+    p.write_text(s)
+    print("patched DBManager.js (accessory/robe names stay EUC-KR bytes)")
+
 PY


### PR DESCRIPTION
Fixes #23.

### The symptom

Headgear and garments stop being drawn on the character. It survives a page
reload (F5) but not a relogin, which is what makes the title of #23 read the
way it does: the hats come back "after a server restart" because the restart
takes the page down with it.

### The cause

`loadLuaTable()` decodes every value it reads with the user charpage. That is
correct for display tables — job names, skill descriptions — but
`accname.lub` and `spriterobename.lub` do not hold display text. Their values
are GRF filenames.

`getHatPath()` / `getRobePath()` concatenate those values onto an EUC-KR
byte-string prefix, so the resulting path ends up half EUC-KR (the directory)
and half Unicode Hangul (the item-name tail):

    data/sprite/<euckr accessory dir>/<sex>/<sex>_스팀펑크햇.spr

No such file exists in any GRF, so every request 404s and the sprite is never
drawn. The asset server is behaving correctly here — it has the right file
under the right (EUC-KR) name and is being asked for a different one.

`itemInfo`'s `AddItem` already treats `identifiedResourceName` this way: it
decodes without a charpage, precisely because it is a filename. The lua name
tables were the one place that did not.

The reason a relogin is needed to see it is that `AccNameTable` and
`RobeNameTable` are module singletons. They are populated once and outlive a
relogin, so the corrupted values persist until the page itself reloads.

### The change

Adds an `isResourceTable` flag to `loadLuaTable()`. `AccNameTable` and
`RobeNameTable` pass it, and their values are decoded without the charpage.
Every display table is untouched.

Follows the existing convention in `scripts/patch-client.sh`: idempotent, and
it exits with a clear message if the upstream text it anchors to ever moves.

### Testing

Built the client from the pinned commit with the patch applied and ran it
against a local server (renewal, packetver 20221005):

- equipped a Hat (2220) and a Manteau (2505), returned to character select and
  logged back in **without reloading the page** — both are still drawn, where
  before they disappeared until F5
- verified the patch applies cleanly on top of the 15 existing blocks in
  `patch-client.sh`, and that running the script twice is a no-op
- `node --check` on the resulting `DBManager.js`
