### PR TITLE
Remember the window, and the layout inside it

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -10,7 +10,7 @@
 // sprites render doubled on WebKit (roBrowserLegacy #1350). One engine
 // everywhere is worth ~60 MB of download.
 //
-const { app, BrowserWindow, ipcMain, dialog, Menu, shell, clipboard, session } = require('electron');
+const { app, BrowserWindow, ipcMain, dialog, Menu, shell, clipboard, screen, session } = require('electron');
 const path = require('path');
 const fs = require('fs');
 const os = require('os');
@@ -1185,13 +1185,107 @@ function productName() {
 
 const windows = {};
 
+// Where a window was last left. The game window is the only one worth
+// remembering -- setup is fixed-size and settings is a dialog -- but the store
+// is keyed by window id so adding another is a one-line change.
+//
+// It lives beside settings.json rather than in the Chromium profile: this is
+// the shell's own state, and a player clearing the client's cache to fix a
+// stale mod should not also lose the size of their window.
+function windowStatePath() {
+	return path.join(stateDir(), 'window.json');
+}
+
+function readWindowState(id) {
+	try {
+		const all = JSON.parse(fs.readFileSync(windowStatePath(), 'utf8'));
+		const st = all && all[id];
+		if (!st || typeof st.width !== 'number' || typeof st.height !== 'number') return null;
+		return st;
+	} catch {
+		return null;
+	}
+}
+
+// A saved position is only usable if it still lands on a display that exists.
+// Unplugging the monitor a window was left on, or a resolution change, would
+// otherwise reopen it somewhere the player cannot reach it. Size is kept
+// either way; only the position is dropped.
+function usableWindowState(st) {
+	if (!st) return null;
+	const out = { width: st.width, height: st.height, maximized: !!st.maximized };
+	if (typeof st.x !== 'number' || typeof st.y !== 'number') return out;
+	const visible = screen.getAllDisplays().some(d => {
+		const b = d.workArea;
+		return st.x < b.x + b.width && st.x + st.width > b.x && st.y < b.y + b.height && st.y + st.height > b.y;
+	});
+	if (visible) {
+		out.x = st.x;
+		out.y = st.y;
+	}
+	return out;
+}
+
+function saveWindowState(id, win) {
+	if (!win || win.isDestroyed()) return;
+	try {
+		let all = {};
+		try {
+			all = JSON.parse(fs.readFileSync(windowStatePath(), 'utf8')) || {};
+		} catch {
+			all = {};
+		}
+		// getNormalBounds, not getBounds: a maximized window reports the screen,
+		// and restoring that would leave nothing to un-maximize back to.
+		all[id] = { ...win.getNormalBounds(), maximized: win.isMaximized() };
+		fs.mkdirSync(stateDir(), { recursive: true });
+		fs.writeFileSync(windowStatePath(), JSON.stringify(all, null, 2));
+	} catch {
+		// Losing the window size is not worth failing a quit over.
+	}
+}
+
+// Windows whose geometry is remembered, so quitting can write them even when
+// no `close` event is coming -- see saveTrackedWindows.
+const trackedWindows = new Map();
+
+// Resize and move fire continuously while dragging, so the write is debounced.
+// `close` writes immediately, because the debounce timer would not survive it.
+function trackWindowState(id, win) {
+	let timer = null;
+	const later = () => {
+		clearTimeout(timer);
+		timer = setTimeout(() => saveWindowState(id, win), 400);
+	};
+	for (const ev of ['resize', 'move', 'maximize', 'unmaximize']) win.on(ev, later);
+	win.on('close', () => {
+		clearTimeout(timer);
+		saveWindowState(id, win);
+	});
+	trackedWindows.set(id, win);
+	win.on('closed', () => trackedWindows.delete(id));
+}
+
+// Quitting from the menu ends at app.exit and a signal ends at process.exit;
+// neither closes the windows first, so `close` never fires and the last
+// geometry would be lost. Clicking the red button does fire it -- this is for
+// the other two ways out.
+function saveTrackedWindows() {
+	for (const [id, win] of trackedWindows) saveWindowState(id, win);
+}
+
 function makeWindow(id, file, opts) {
 	if (windows[id] && !windows[id].isDestroyed()) {
 		windows[id].focus();
 		return windows[id];
 	}
+	// A remembered size and position wins over the defaults the caller passes.
+	const saved = opts && opts.rememberBounds ? usableWindowState(readWindowState(id)) : null;
+	const { rememberBounds, ...winOpts } = opts || {};
 	const win = new BrowserWindow({
-		...opts,
+		...winOpts,
+		...(saved ? { width: saved.width, height: saved.height } : {}),
+		...(saved && typeof saved.x === 'number' ? { x: saved.x, y: saved.y } : {}),
 		webPreferences: {
 			preload: path.join(__dirname, 'preload.js'),
 			contextIsolation: true,
@@ -1243,6 +1337,8 @@ function makeWindow(id, file, opts) {
 	// the host's own client, served over HTTP, not a local copy of it.
 	if (opts && opts.url) win.loadURL(opts.url);
 	else win.loadFile(path.join(__dirname, '..', 'src', file));
+	if (saved && saved.maximized) win.maximize();
+	if (opts && opts.rememberBounds) trackWindowState(id, win);
 	win.on('closed', () => delete windows[id]);
 	windows[id] = win;
 	return win;
@@ -1326,7 +1422,7 @@ function gameTitle() {
 // nothing to act on. Where it navigates *to* is decided in launch_game.
 const openGame = () => {
 	const c = getClientPaths();
-	const win = makeWindow('game', 'index.html', { width: 1280, height: 800, title: gameTitle() });
+	const win = makeWindow('game', 'index.html', { width: 1280, height: 800, title: gameTitle(), rememberBounds: true });
 	// Also on an existing window: makeWindow only applies the title when it
 	// creates one, and the whole point is that this changes when you switch.
 	if (win && !win.isDestroyed()) win.setTitle(gameTitle());
@@ -2152,6 +2248,22 @@ app.whenReady().then(() => {
 // in the background, and only then really exits. Without the cancel, Electron
 // tears the process down while `stack.sh down` is still running and leaves four
 // containers and a microVM behind.
+// DOMStorage is written lazily: Chromium batches it and commits on its own
+// schedule. Both exits below are immediate -- app.exit skips the normal quit
+// path and process.exit skips Electron entirely -- so anything the player
+// changed in the last seconds before quitting was still in memory and went
+// with it. That is the whole of "it forgets my volume and where I put the
+// windows": roBrowser saves those to localStorage the moment they change, and
+// the save simply never reached disk.
+function flushClientStorage() {
+	saveTrackedWindows();
+	try {
+		session.defaultSession.flushStorageData();
+	} catch {
+		// Best effort; never worth failing a quit over.
+	}
+}
+
 app.on('before-quit', e => {
 	if (tearingDown) return; // second pass: let it go
 	e.preventDefault();
@@ -2159,6 +2271,7 @@ app.on('before-quit', e => {
 	for (const win of BrowserWindow.getAllWindows()) {
 		if (!win.isDestroyed()) win.setTitle(`${productName()} — shutting down…`);
 	}
+	flushClientStorage();
 	teardownAsync().finally(() => app.exit(0));
 });
 
@@ -2170,6 +2283,7 @@ for (const sig of ['SIGTERM', 'SIGINT', 'SIGHUP']) {
 	process.on(sig, () => {
 		if (!tearingDown) {
 			tearingDown = true;
+			flushClientStorage();
 			teardownSync();
 		}
 		process.exit(0);

--- a/electron/main.js
+++ b/electron/main.js
@@ -2264,6 +2264,27 @@ function flushClientStorage() {
 	}
 }
 
+// Ask the game page to write its window layout before the process ends.
+//
+// roBrowser saves each window's position and size in that component's
+// onRemove hook and nowhere else, so the layout reaches localStorage only
+// when something removes the components -- a return to character select, or
+// the page going away. Quitting from inside the game does neither: this
+// process exits and takes the renderer with it, and nothing was ever written.
+// The client exposes roPersistUI for exactly this call.
+//
+// Fire-and-forget on purpose. It runs in the renderer while the stack is
+// still being torn down, which takes long enough for the write to land, and
+// the flush before exit is what puts it on disk.
+function persistClientUi() {
+	for (const win of BrowserWindow.getAllWindows()) {
+		if (win.isDestroyed()) continue;
+		win.webContents
+			.executeJavaScript('window.roPersistUI && window.roPersistUI(), 0')
+			.catch(() => {});
+	}
+}
+
 app.on('before-quit', e => {
 	if (tearingDown) return; // second pass: let it go
 	e.preventDefault();
@@ -2271,8 +2292,16 @@ app.on('before-quit', e => {
 	for (const win of BrowserWindow.getAllWindows()) {
 		if (!win.isDestroyed()) win.setTitle(`${productName()} — shutting down…`);
 	}
-	flushClientStorage();
-	teardownAsync().finally(() => app.exit(0));
+	// Order matters: ask the page to write its layout, let the teardown run
+	// (which is what gives that write time to happen), and only then flush and
+	// exit. Flushing first would commit a localStorage that does not yet have
+	// the layout in it.
+	persistClientUi();
+	saveTrackedWindows();
+	teardownAsync().finally(() => {
+		flushClientStorage();
+		app.exit(0);
+	});
 });
 
 app.on('window-all-closed', () => app.quit());
@@ -2283,8 +2312,9 @@ for (const sig of ['SIGTERM', 'SIGINT', 'SIGHUP']) {
 	process.on(sig, () => {
 		if (!tearingDown) {
 			tearingDown = true;
-			flushClientStorage();
+			persistClientUi();
 			teardownSync();
+			flushClientStorage();
 		}
 		process.exit(0);
 	});

--- a/scripts/patch-client.sh
+++ b/scripts/patch-client.sh
@@ -470,4 +470,62 @@ else:
         s = s.replace(a, b)
     p.write_text(s)
     print(f"patched QuestCommon.js ({n} quest lists now actually shown)")
+
+# 0011 - The window layout is never written unless something removes the
+# windows first.
+#
+# Every component saves its position, size and open/closed state in its
+# onRemove hook -- InventoryCommon, EquipmentCommon and the rest all do it
+# there, and nowhere else. onRemove runs when UIManager tears the components
+# down, which happens on a return to character select and on nothing else.
+#
+# So quitting from inside the game never wrote the layout at all: the process
+# ends, the renderer goes with it, and the values were still only in the
+# components. It reads as "it forgot where I put my windows", and it is not a
+# flushing problem -- there was nothing in localStorage to flush. Volume
+# survives the same quit because Audio preferences are saved as they change.
+#
+# pagehide covers a browser tab and any normal navigation. The desktop shell
+# exits the process outright, which fires no page event at all, so the same
+# work is exposed for it to call before it starts tearing the stack down.
+p = rb / "src/App/Online.js"
+s = p.read_text()
+if "roPersistUI" in s:
+    print("Online.js already patched")
+else:
+    old = """import GameEngine from 'Engine/GameEngine.js';
+import Plugins from 'Plugins/PluginManager.js';"""
+    new = """import GameEngine from 'Engine/GameEngine.js';
+import Plugins from 'Plugins/PluginManager.js';
+import UIManager from 'UI/UIManager.js';"""
+    if s.count(old) != 1:
+        sys.exit("Online.js: imports no longer match; re-check the patch")
+    s = s.replace(old, new, 1)
+
+    old = """	window.onbeforeunload = function () {
+		return 'Are you sure to exit roBrowser ?';
+	};"""
+    new = """	window.onbeforeunload = function () {
+		return 'Are you sure to exit roBrowser ?';
+	};
+
+	// Components write their layout in onRemove and nowhere else, so the
+	// layout only survives if something removes them. Nothing does when the
+	// page simply goes away.
+	const persistUI = function () {
+		try {
+			UIManager.removeComponents();
+		} catch (e) {
+			console.warn('could not save the window layout', e);
+		}
+	};
+	window.addEventListener('pagehide', persistUI);
+	// For a host that ends the process without a page event of any kind.
+	window.roPersistUI = persistUI;"""
+    if s.count(old) != 1:
+        sys.exit("Online.js: onbeforeunload no longer matches; re-check the patch")
+    s = s.replace(old, new, 1)
+    p.write_text(s)
+    print("patched Online.js (save the window layout when the page goes away)")
+
 PY


### PR DESCRIPTION
Two ways the app forgot what the player had set up. Both are in the shell, and
one needs a matching client patch.

### The game window opened at 1280x800 every time

Nothing read or wrote its geometry. It is now stored in `state/window.json` --
beside `settings.json` rather than in the Chromium profile, so clearing the
client cache to pick up a changed mod does not also reset the window.

Three details worth calling out: `getNormalBounds()` rather than `getBounds()`,
because a maximized window reports the screen and restoring that leaves nothing
to un-maximize back to; a saved position is used only if it still intersects a
display that exists, so unplugging a monitor cannot reopen the window out of
reach; and the write is debounced, because resize and move fire continuously
while dragging.

### The window layout was never written at all

Where the player put the inventory and the equipment window was lost on every
quit, while the volume beside it survived. The difference is where each is
written: Audio preferences are saved as they change, but a window's position,
size and open/closed state are written in that component's `onRemove` hook and
nowhere else. `onRemove` runs when `UIManager` tears the components down, which
happens on a return to character select and on nothing else.

So quitting from inside the game never wrote the layout: the process ends, the
renderer goes with it, and the values were still only in the components. It
reads as a flushing problem and is not one -- there was nothing in
localStorage to flush.

The client now persists on `pagehide`, and exposes `roPersistUI` for a host
that ends the process without firing a page event at all. The shell calls it
before the teardown starts (the teardown is what gives the write time to land)
and flushes DOMStorage afterwards rather than before -- flushing first would
commit a localStorage that does not yet have the layout in it. Neither exit
path closes its windows either, so the same point writes the window geometry.

### Testing

With `npm start`, and then against a packaged build:

- a window state written by hand is restored on the next launch instead of
  being overwritten with the defaults
- a position on no existing display is dropped while the size is kept
- maximized is restored as maximized, and un-maximizing returns to the size
  the window had before
- moving the inventory and equipment windows, quitting from inside the game
  and reopening brings the layout back; returning to character select first,
  which already worked, still does
- volume survives a quit made immediately after changing it
