### PR TITLE
Run one copy of the app at a time

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -2041,6 +2041,9 @@ function buildMenu() {
 // ---------------------------------------------------------------------------
 
 let tearingDown = false;
+// Set when a launch arrives while we are quitting: see the second-instance
+// handler. Guarded because two clicks must not queue two copies.
+let relaunchQueued = false;
 
 function stackEnv() {
 	const root = projectRoot();
@@ -2101,6 +2104,53 @@ function teardownSync() {
 // "name" field, which is the old project identifier, and every platform that
 // draws an application menu labels it with that.
 app.setName(productName());
+
+// One copy at a time. Two are not merely redundant: both drive the same
+// microVM and the same containers, and both own the same Chromium profile.
+// A player who quits and relaunches straight away gets exactly that, because
+// quitting is not instant -- the first copy is still stopping the stack, and
+// the second one starts on top of it. The report that made this obvious was
+// "it forgot my volume and where I put my windows": the second copy read
+// localStorage before the first had flushed it, then wrote its own stale view
+// back over it on the way out.
+//
+// The database pays a higher price. Two supervisors racing over one data disk
+// is how a MariaDB volume ends up with a redo log it cannot recover
+// ("Missing FILE_CHECKPOINT"), which no amount of restarting or repairing
+// fixes -- the characters are simply gone.
+//
+// app.exit, not app.quit: quit would run before-quit in the *second* copy,
+// and its teardown would stop the stack the first copy is still using.
+if (!app.requestSingleInstanceLock()) {
+	app.exit(0);
+} else {
+	app.on('second-instance', () => {
+		// Quitting is not instant -- the stack takes the better part of a
+		// minute to stop -- and this copy holds the lock for all of it. A
+		// player who closes the game and opens it again straight away would
+		// otherwise get nothing at all: no window, no error, no clue that
+		// anything happened, because the launch they just made ended in a
+		// process that exited on the spot. They click again, and again, and
+		// eventually one lands after this copy is gone.
+		//
+		// So take the click as what it plainly means and come back on our own
+		// once the teardown is finished. app.relaunch only queues it; the
+		// exit already scheduled is what carries it out.
+		if (tearingDown) {
+			if (!relaunchQueued) {
+				relaunchQueued = true;
+				app.relaunch();
+			}
+			return;
+		}
+		// Otherwise it is "show me the game", and the window already exists.
+		const win = windows.game || BrowserWindow.getAllWindows()[0];
+		if (win && !win.isDestroyed()) {
+			if (win.isMinimized()) win.restore();
+			win.focus();
+		}
+	});
+}
 
 app.whenReady().then(() => {
 	// Before anything reads a path: an existing install still has its data


### PR DESCRIPTION
Nothing stopped a second copy of the app from starting.

Two are not merely redundant: both drive the same microVM and the same
containers, and both own the same Chromium profile. A player who quits and
relaunches straight away gets exactly that, because quitting is not instant --
the first copy is still stopping the stack while the second one starts on top
of it.

The visible symptom is lost settings: the second copy reads localStorage
before the first has flushed it, then writes its own stale view back over it
on the way out.

The database pays a higher price. Two supervisors racing over one data disk is
how a MariaDB volume ends up with a redo log it cannot recover:

    [ERROR] InnoDB: Missing FILE_CHECKPOINT(414250) at 414250
    [ERROR] Unknown/unsupported storage engine: InnoDB

The container then exits within two seconds of every start, the app sits on
"Starting the database…" until it times out on the schema, and Repair does not
help. The characters are simply gone.

### Two details

`app.exit` rather than `app.quit` for the second copy: `quit` would run
`before-quit` in it, and its teardown would stop the stack the first copy is
still using.

A launch that arrives while we are quitting is not refused silently. Holding
the lock for the whole teardown means such a click produces no window, no
error and no clue that anything happened -- the player clicks again, and
again, and eventually one lands after the first copy is gone. It queues a
relaunch instead, and the app comes back on its own once the teardown
finishes.

### Testing

- launching twice: the second exits, the first keeps its window and its stack
- quitting and relaunching immediately: one click, and the app returns by
  itself once the teardown is done
