### PR TITLE
player-commands: @autoloot and @showexp for everybody, not just GMs

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -1527,7 +1527,7 @@ const handlers = {
 		// the app would not run it, and the difference is the whole point of
 		// having a reason to show.
 		return out.split('\n').filter(Boolean).map(l => {
-			const [state, name, description, reason, origin, version, author] = l.split('\t');
+			const [state, name, description, reason, origin, version, author, grants] = l.split('\t');
 			return {
 				name,
 				enabled: state === 'on',
@@ -1537,6 +1537,10 @@ const handlers = {
 				bundled: origin === 'bundled',
 				version: version || '',
 				author: author || '',
+				// Supplies groups.yml or atcommands.yml, so it decides what
+				// commands players get. Said next to the checkbox because a
+				// mod's own description is not a trustworthy place to learn it.
+				grantsCommands: grants === 'grants-commands',
 			};
 		});
 	},

--- a/mods/player-commands/README.md
+++ b/mods/player-commands/README.md
@@ -1,0 +1,92 @@
+# player-commands
+
+`@autoloot` and `@showexp` for everybody, not just the account the app made.
+
+**It ships switched off.** Settings → Mods → tick it → Apply, then relog.
+
+## The problem it fixes
+
+rAthena sorts atcommands into player groups. Group 1, *Super Player*, holds the
+quality-of-life set — `@autoloot`, `@showexp`, `@mobinfo` and friends. Group 0,
+*Player*, is what every new account gets, and it holds exactly two commands:
+
+```yaml
+- Id: 0
+  Name: Player
+  Commands:
+    changedress: true
+    resurrect: true
+```
+
+Playing on your own you never notice, because `sql/03-account.sql` creates the
+`ragnarok` account as group 99 (Admin, `all_commands: true`) and everything
+works. It shows up the moment somebody joins your LAN server and makes their own
+account with `_M` / `_F`: they land in group 0, type `@autoloot`, and get
+*Unknown command*.
+
+GM level is per **account**, not per character, so this is not something a
+player can fix by making a new character.
+
+## What it grants
+
+Seventeen commands, all of them ones rAthena already considers player-safe —
+every one is taken from Super Player, nothing is invented here.
+
+| | |
+|---|---|
+| Loot | `@autoloot` `@alootid` `@autoloottype` |
+| What a kill was worth | `@showexp` `@showzeny` `@showdelay` |
+| Discoverability | `@commands` `@help` |
+| Information | `@rates` `@mobinfo` `@iteminfo` `@whodrops` `@servertime` `@uptime` |
+| Convenience | `@noks` `@noask` `@refresh` |
+
+`@commands` and `@help` are in there on purpose: without them a player has no
+way to discover that any of the rest arrived.
+
+**`@go` is deliberately left out.** Free warping to any town changes how the
+game is played, and that belongs behind its own decision — see `common-npcs`,
+which ships its warper switched off for the same reason. If you want it, add
+`go: true` to `conf/groups.yml`.
+
+Also left out: `@autotrade`, `@request`, `@breakguild`, `@channel`, `@langtype`,
+`@whereis`, `@jailtime`, `@hominfo`, `@homstats`. Nothing is wrong with them;
+they are just not what this mod is for.
+
+## How it works
+
+`conf/groups.yml` is one of only two files a mod may supply **whole** rather
+than key by key — `atcommands.yml` is the other. Both are documents, not lists
+of settings, so there is no sensible way to express them as `key: value` lines.
+See `CONF_WHOLE_FILE` in `stack/src/mods.rs`.
+
+The supervisor writes it to `state/conf/groups.yml`, which is bound into the
+container at `/rathena/conf/import`, and rAthena's own `conf/groups.yml` already
+ends with:
+
+```yaml
+Footer:
+  Imports:
+  - Path: conf/import/groups.yml
+```
+
+So dropping the file in place is the entire mechanism. Switching the mod off
+**removes** the file, so a grant cannot outlive the mod that made it.
+
+## Two things to know if you edit it
+
+**It merges, it does not replace.** `PlayerGroupDatabase::parseBodyNode` looks
+the group up first, and for one that already exists neither `Name` nor `Level`
+is required — only the fields present are touched. That is why this file lists
+no `Permissions`: group 0 keeps `can_trade`, `can_party` and `attendance` from
+the base file. Redefining them here would be a way to take them away by
+accident.
+
+**Never list a command the group already has.** `parseCommands` treats that as
+an error and returns false, which aborts the *whole* group node — the server
+starts, logs one warning, and group 0 is left exactly as it was. This is why
+`@changedress` and `@resurrect` do not appear above.
+
+Adding commands to group 0 is safe for the groups above it. Groups 1, 2 and the
+rest inherit Player, and inheritance skips anything the child already has
+(`if( !util::vector_exists( group->commands, command ) )`), so no duplicate is
+ever created.

--- a/mods/player-commands/conf/groups.yml
+++ b/mods/player-commands/conf/groups.yml
@@ -1,0 +1,46 @@
+# Player group 0 -- everybody, unless an account was given a GM group.
+#
+# rAthena puts @autoloot and @showexp in group 1 (Super Player) and leaves
+# group 0 with two commands: @changedress and @resurrect. On a server you run
+# for yourself and a few friends that split is backwards -- the account the app
+# creates is group 99 and has everything, and anyone who joins and makes their
+# own account gets almost nothing.
+#
+# rAthena merges this into the group rather than replacing it, so Name, Level
+# and Permissions are deliberately absent: group 0 keeps can_trade, can_party
+# and attendance from the base file. Only the commands listed here are added.
+#
+# Every command below must be one group 0 does *not* already have. Listing
+# @changedress or @resurrect here would abort the whole group with "Group
+# already has command", and the server would start with group 0 unchanged.
+Header:
+  Type: PLAYER_GROUP_DB
+  Version: 1
+
+Body:
+  - Id: 0
+    Commands:
+      # Picking loot up. The reason this mod exists.
+      autoloot: true
+      alootid: true
+      autoloottype: true
+      # Seeing what a kill was worth.
+      showexp: true
+      showzeny: true
+      showdelay: true
+      # So the grant is discoverable: without these a player has no way to
+      # find out any of the rest arrived.
+      commands: true
+      help: true
+      # Information. None of these change anything.
+      rates: true
+      mobinfo: true
+      iteminfo: true
+      whodrops: true
+      servertime: true
+      uptime: true
+      # Convenience. @noks and @noask refuse other people rather than granting
+      # anything; @refresh re-syncs a character the client has drawn wrong.
+      noks: true
+      noask: true
+      refresh: true

--- a/mods/player-commands/mod.json
+++ b/mods/player-commands/mod.json
@@ -1,0 +1,8 @@
+{
+  "name": "player-commands",
+  "version": "1.0.0",
+  "author": "Ragnarok Offline",
+  "description": "Gives every account @autoloot, @showexp and the rest of the information commands, instead of reserving them for GMs. Off until you turn it on.",
+  "default": "off",
+  "requires": { "app": ">=1.0.6", "era": "any" }
+}

--- a/src/settings.html
+++ b/src/settings.html
@@ -621,6 +621,11 @@ async function refreshMods() {
       + (m.bundled ? ' <span style="color:var(--dim); font-size:11px">included</span>' : '')
       + (by ? ` <span style="color:var(--dim); font-size:11px">${esc(by)}</span>` : '')
       + (m.description ? `<br><span style="color:var(--dim)">${esc(m.description)}</span>` : '')
+      // Not from the mod's own description: a mod that changes what commands
+      // players may use should say so in text the mod did not write.
+      + (m.grantsCommands
+        ? '<br><span style="color:var(--dim)">Changes which commands players can use.</span>'
+        : '')
       + (m.refused
         ? `<br><span style="color:var(--bad, #e5534b)">Not loaded — ${esc(m.reason)}</span>`
         : '');

--- a/stack/src/mods.rs
+++ b/stack/src/mods.rs
@@ -367,6 +367,24 @@ pub struct Installed {
     pub bundled: bool,
 }
 
+impl Installed {
+    /// Whether this mod decides what commands players may use.
+    ///
+    /// `groups.yml` and `atcommands.yml` are the two files a mod may supply
+    /// whole, and between them they say which atcommands each player group
+    /// gets. That is a bigger grant than the rest of the conf allowlist, and
+    /// it is not visible in a description the mod wrote about itself -- so the
+    /// Settings window says it, next to the checkbox, rather than the player
+    /// finding out by being surprised later.
+    ///
+    /// Read from the folder rather than from an assembled layer, because the
+    /// list is drawn for mods that are switched *off* too, and nothing has
+    /// been assembled for those.
+    pub fn grants_commands(&self) -> bool {
+        CONF_WHOLE_FILE.iter().any(|f| self.dir.join("conf").join(f).is_file())
+    }
+}
+
 /// Every mod folder, in merge order, with its manifest checked.
 ///
 /// The single place that decides what is applied. `assemble`, `list` and the
@@ -761,7 +779,7 @@ fn one_line(s: &str) -> String {
     s.replace(['\t', '\n', '\r'], " ")
 }
 
-pub fn list(cfg: &Config) -> Vec<[String; 7]> {
+pub fn list(cfg: &Config) -> Vec<[String; 8]> {
     scan(cfg)
         .into_iter()
         .map(|m| {
@@ -770,6 +788,7 @@ pub fn list(cfg: &Config) -> Vec<[String; 7]> {
                 Status::Off => ("off", String::new()),
                 Status::Refused(r) => ("refused", r.clone()),
             };
+            let grants = m.grants_commands();
             [
                 state.to_string(),
                 one_line(&m.name),
@@ -778,6 +797,9 @@ pub fn list(cfg: &Config) -> Vec<[String; 7]> {
                 if m.bundled { "bundled" } else { "installed" }.to_string(),
                 one_line(&m.manifest.version),
                 one_line(&m.manifest.author),
+                // Last, so an older shell that splits off the first seven
+                // fields reads exactly what it did before.
+                if grants { "grants-commands" } else { "" }.to_string(),
             ]
         })
         .collect()
@@ -897,6 +919,62 @@ mod tests {
         read_conf(&d, "x", &mut out);
         let got = out.get("char_conf.txt").unwrap();
         assert_eq!(got, &vec![("start_point".into(), "my_town,50,50".into())]);
+    }
+
+    /// groups.yml is copied whole rather than filtered through the key
+    /// allowlist. Worth pinning: read line by line it would be discarded
+    /// entirely -- "Header:" and "Body:" are not `key: value` settings the
+    /// allowlist knows -- and the mod would look installed and do nothing.
+    #[test]
+    fn groups_yml_is_taken_whole_rather_than_key_by_key() {
+        let d = tmp("whole");
+        fs::create_dir_all(d.join("conf")).unwrap();
+        let body = "Header:\n  Type: PLAYER_GROUP_DB\n  Version: 1\n\nBody:\n  - Id: 0\n    Commands:\n      autoloot: true\n";
+        fs::write(d.join("conf/groups.yml"), body).unwrap();
+        // An ordinary conf file alongside it still goes through the allowlist.
+        fs::write(d.join("conf/char_conf.txt"), "start_point: my_town,50,50\n").unwrap();
+
+        let mut out = BTreeMap::new();
+        read_conf(&d, "x", &mut out);
+
+        let whole = out.get("file:groups.yml").expect("groups.yml is recorded as a whole file");
+        assert_eq!(whole, &vec![("x".to_string(), body.to_string())]);
+        assert!(out.get("groups.yml").is_none(), "it must not also be parsed as settings");
+        assert_eq!(
+            out.get("char_conf.txt").unwrap(),
+            &vec![("start_point".to_string(), "my_town,50,50".to_string())]
+        );
+    }
+
+    /// A whole-file conf layer is a permission grant, and the Settings window
+    /// only labels it because `list` reports it. Pinned in both directions:
+    /// missing the label on a mod that writes groups.yml hides the grant, and
+    /// showing it on an ordinary mod teaches players to ignore it.
+    #[test]
+    fn a_mod_that_writes_groups_yml_is_reported_as_granting_commands() {
+        let plain = tmp("grants-plain");
+        fs::create_dir_all(plain.join("conf")).unwrap();
+        fs::write(plain.join("conf/battle_conf.txt"), "base_exp_rate: 200\n").unwrap();
+        let m = Installed {
+            name: "plain".into(),
+            dir: plain,
+            status: Status::Off,
+            manifest: Manifest::default(),
+            bundled: true,
+        };
+        assert!(!m.grants_commands(), "an ordinary conf layer is not a command grant");
+
+        let granting = tmp("grants-groups");
+        fs::create_dir_all(granting.join("conf")).unwrap();
+        fs::write(granting.join("conf/groups.yml"), "Header:\n  Type: PLAYER_GROUP_DB\n").unwrap();
+        let m = Installed {
+            name: "granting".into(),
+            dir: granting,
+            status: Status::Off,
+            manifest: Manifest::default(),
+            bundled: true,
+        };
+        assert!(m.grants_commands(), "groups.yml decides what commands players get");
     }
 
     #[test]


### PR DESCRIPTION
Adds a bundled mod that gives ordinary accounts the quality-of-life atcommands,
and implements the one piece of `mods.rs` that was documented but never written.

### The problem

rAthena sorts atcommands into player groups. Group 1, *Super Player*, holds
`@autoloot`, `@showexp` and the rest. Group 0, *Player*, is what every new
account gets, and it holds exactly two:

```yaml
- Id: 0
  Name: Player
  Commands:
    changedress: true
    resurrect: true
```

Playing alone you never notice, because `sql/03-account.sql` creates the
`ragnarok` account as group 99 (Admin, `all_commands: true`). It shows up the
moment somebody joins a LAN server and registers their own account with
`_M` / `_F`: they land in group 0, type `@autoloot`, and get *Unknown command*.
GM level is per **account**, not per character, so they cannot fix it by making
another character.

### The mod

`mods/player-commands/`, bundled and **shipped off** — it is a permission
change, and that should be a decision, the same reasoning `common-npcs` uses.

Seventeen commands, every one of them already in Super Player: the autoloot
family, the show family, `@commands` and `@help` so the grant is discoverable at
all, six informational commands and three conveniences.

**`@go` is deliberately excluded.** Free warping to any town changes how the game
is played, which is exactly why `common-npcs` ships its warper off. One line in
the yml for anyone who disagrees.

### Two rAthena behaviours that decided the file's shape

Both read out of `pc_groups.cpp` rather than assumed, and both would have bitten:

- **`parseBodyNode` merges rather than replaces.** For a group that already
  exists neither `Name` nor `Level` is required, and only fields that are present
  are touched. So the file lists **no `Permissions`** and group 0 keeps
  `can_trade`, `can_party` and `attendance`. Restating them would have been a way
  to remove them by accident.
- **`parseCommands` aborts the whole group node** on a command the group already
  has (`"Group already has command"` → `return false`). So `@changedress` and
  `@resurrect` are absent on purpose — listing them would leave group 0 silently
  unchanged behind one warning.

Adding commands to group 0 is safe for the groups above it: `loadingFinished`
skips anything the child already has, so no duplicate is created.

All seventeen were checked programmatically against `atcommand.cpp` and against
group 0's existing list — all real commands, none already present, all in Super
Player.

### `Installed::grants_commands`

`mods.rs` has referred to this in a comment since whole-file conf was added:

> `groups.yml` in particular is a permission boundary: a mod that writes it
> decides what every player can do. The mods list says so, rather than the grant
> being silent -- see `Installed::grants_commands`.

It did not say so. The method never existed, and this is the first shipped mod to
use the boundary — so it is implemented here. `list()` gains an eighth field,
**appended** so an older shell destructuring seven reads exactly what it did
before, and Settings prints one line the mod did not write:

> Changes which commands players can use.

### Testing

Built and run against a real server, mod enabled:

```
Loading 'conf/groups.yml'...        Done reading '8' entries
Loading 'conf/import/groups.yml'... Done reading '1' entries
```

No `Group already has command`, no `Unknown atcommand`, no parse warnings. The
whole chain is exercised: mod folder → `read_conf` whole-file → `assemble` →
`state/conf/groups.yml` → bind mount at `/rathena/conf/import` → rAthena import.

- `cargo test`: 38 pass (was 36), including two new ones — one pinning that
  `groups.yml` is taken whole rather than filtered through the key allowlist
  (read line by line it would be discarded entirely and the mod would look
  installed and do nothing), one pinning `grants_commands` in both directions.
- `node --check` on `electron/main.js` and on the `settings.html` script.
- `ragnarok-stack mods` lists it `off / bundled / grants-commands`, with the
  other two bundled mods correctly unflagged.

Not tested: a real group-0 login proving `@autoloot` works in game — that needs a
second account, and the server-side evidence above is what I could reach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MwcCPSzxbKHkPEaT9Q7W87