### PR TITLE
Equipment drag-and-drop, and how to make a non-GM account

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,29 @@ server and drops you at the login screen.
 Log in with **`ragnarok`** / **`ragnarok`** — the account is created for you on
 first run — and make a character.
 
+**`ragnarok` is a GM account.** That is usually what you want on your own
+server: it can use every `@` command. The catch is that the client draws a GM in
+a fixed operator outfit instead of your character's own body, so whatever you
+equip, you look like a GM.
+
+**To play as an ordinary character, make your own account.** On the login
+screen, type your username with **`_M`** or **`_F`** on the end, pick a
+password, and press Login:
+
+```
+myname_M     ← male          myname_F     ← female
+```
+
+The account is created and you are logged straight in — there is no separate
+sign-up step and nothing to confirm. **From then on you log in as `myname`,
+without the suffix.** The letter only sets the account's gender at registration;
+it is not part of the name. Both the name and the password need at least four
+characters, counted without the suffix.
+
+Ordinary accounts have almost no `@` commands — rAthena keeps `@autoloot` and
+`@showexp` for GMs. Settings → Mods → **player-commands** hands them to
+everybody.
+
 First launch takes a few minutes: it unpacks the runtime, boots the microVM, loads
 the container images and initialises the database. The window names each step as it
 goes, so you can see where it is. Every launch after that is seconds.

--- a/scripts/patch-client.sh
+++ b/scripts/patch-client.sh
@@ -620,4 +620,64 @@ import UIManager from 'UI/UIManager.js';"""
     p.write_text(s)
     print("patched Online.js (save the window layout when the page goes away)")
 
+# 0010 - Drag and drop onto the equipment window did nothing.
+#
+# Dragging a hat from the inventory onto the character never equipped it. The
+# drag started, the slot highlighted, and the drop was silently ignored --
+# double-clicking the item worked, which is what made it look like a quirk of
+# the equipment window rather than a bug.
+#
+# onDragOver ends with `event.stopImmediatePropagation(); return false;` and
+# never calls preventDefault(). Under the HTML5 drag-and-drop model an element
+# is only a drop target if its dragover handler *cancels* the event, so without
+# it the browser never fires `drop` and onDrop is dead code. `return false`
+# would have done exactly that under jQuery, which treats it as preventDefault
+# plus stopPropagation -- but this is an addEventListener callback, where a
+# falsy return means nothing at all. The handler was correct once and quietly
+# stopped being correct when the binding changed.
+#
+# Every other named dragover handler in roBrowser's component tree calls
+# preventDefault, including SwitchEquip's own onDragOver, which is the same
+# window family. This one is the only one that does not.
+#
+# Anchored on the tail of onDragOver rather than on the two lines themselves:
+# onDragLeave ends identically, and patching that one instead would leave the
+# real bug in place while looking applied.
+p = rb / "src/UI/Components/Equipment/EquipmentCommon.js"
+s = p.read_text()
+if "// preventDefault, not `return false`" in s:
+    print("EquipmentCommon.js drag-and-drop already patched")
+else:
+    old = """					Client.loadFile(DB.INTERFACE_PATH + 'basic_interface/item_invert.bmp', _data => {
+						cells.forEach(c => {
+							c.style.backgroundImage = `url(${_data})`;
+						});
+					});
+				}
+			}
+		}
+		event.stopImmediatePropagation();
+		return false;
+	}"""
+    new = """					Client.loadFile(DB.INTERFACE_PATH + 'basic_interface/item_invert.bmp', _data => {
+						cells.forEach(c => {
+							c.style.backgroundImage = `url(${_data})`;
+						});
+					});
+				}
+			}
+		}
+		// preventDefault, not `return false`: a drop only fires on a target
+		// whose dragover cancelled the event, and a falsy return from an
+		// addEventListener callback cancels nothing. Without this the window
+		// is never a drop target and onDrop below never runs.
+		event.preventDefault();
+		event.stopImmediatePropagation();
+		return false;
+	}"""
+    if s.count(old) != 1:
+        sys.exit("EquipmentCommon.js: onDragOver no longer matches (%d hits); re-check the patch" % s.count(old))
+    p.write_text(s.replace(old, new, 1))
+    print("patched EquipmentCommon.js (drag and drop onto the equipment window)")
+
 PY


### PR DESCRIPTION
Two unrelated fixes, both from the same testing session.

### 1. Drag and drop onto the equipment window did nothing

Dragging a hat from the inventory onto the character never equipped it. The drag
started, the slot highlighted, and the drop was silently ignored — double-click
worked, which is what made it look like a quirk of that window.

`onDragOver` in `EquipmentCommon.js` ends:

```js
event.stopImmediatePropagation();
return false;
```

and never calls `preventDefault()`. Under the HTML5 drag-and-drop model an
element is only a drop target if its `dragover` handler **cancels** the event, so
the browser never fires `drop` and `onDrop` below it is dead code.

`return false` would have done exactly that under jQuery, which treats it as
`preventDefault` + `stopPropagation`. This is an `addEventListener` callback,
where a falsy return means nothing at all. The handler was correct once and
quietly stopped being correct when the binding changed.

I audited every named `dragover` handler in the component tree: **this is the
only one missing `preventDefault`.** Sixteen others have it, `SwitchEquip`'s own
`onDragOver` included — same window family. That is also why the hotkey bar has
always worked; `ShortCut.js` calls it explicitly.

Anchored on the tail of `onDragOver` rather than the two lines themselves:
`onDragLeave` ends identically, and patching that one would leave the real bug in
place while looking applied.

### 2. The README only offered the GM account

`ragnarok` is account `2000000`, which `config/Config.local.js` lists in
`adminList`. roBrowser turns that into `entity.isAdmin`, and `EntityView.js`
then does:

```js
path = this.isAdmin ? DB.getAdminPath(this._sex) : DB.getBodyPath(job, this._sex, look, cashMountCostume);
```

`getAdminPath` is a fixed operator body, so a GM is drawn in it **instead of**
their own — everything you equip is invisible on you. It is entirely client-side
and has nothing to do with rAthena's player groups, which is why it is confusing.

Step 3 now says so and gives the `_M` / `_F` registration, with the two details
that are easy to get wrong:

- the suffix is used **only** the first time; afterwards you log in as `myname`
- the four-character minimum is checked **after** the suffix is stripped
  (`login_mmo_auth_new` is called with it already removed)

Creation returns `-1`, and the caller falls through to normal auth — so the
first login just works, with no failed attempt to explain away. I had written
the opposite before checking `login.cpp`.

It closes by pointing at `player-commands`, since an ordinary account has almost
no `@` commands without it.

### Testing

Against a pristine checkout of the pinned commit:

- all blocks apply, and a second run is a no-op
- `DBManager.js`, `Online.js`, `EquipmentCommon.js` and `QuestCommon.js` all parse
- `onDragLeave` is confirmed untouched
- no broken relative links in the README

The drag itself still wants a click-test in the running app — the static case is
airtight, but nobody has dragged a hat with this build yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MwcCPSzxbKHkPEaT9Q7W87