### PR TITLE
The _M/_F suffix does not pick a character's gender

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,14 +72,18 @@ screen, type your username with **`_M`** or **`_F`** on the end, pick a
 password, and press Login:
 
 ```
-myname_M     ← male          myname_F     ← female
+myname_M
 ```
 
-The account is created and you are logged straight in — there is no separate
+The suffix is only how you ask the server to make the account. It is not part of
+the name and it does not decide anything about your characters — either letter
+works, and you still pick each character's gender and appearance when you create
+it.
+
+The account is created and you are logged straight in; there is no separate
 sign-up step and nothing to confirm. **From then on you log in as `myname`,
-without the suffix.** The letter only sets the account's gender at registration;
-it is not part of the name. Both the name and the password need at least four
-characters, counted without the suffix.
+without the suffix.** Both the name and the password need at least four
+characters, counted without it.
 
 Ordinary accounts have almost no `@` commands — rAthena keeps `@autoloot` and
 `@showexp` for GMs. Settings → Mods → **player-commands** hands them to


### PR DESCRIPTION
Correcting my own wording from #49, which read as though the suffix decides what
your characters can be:

```
myname_M     ← male          myname_F     ← female
```

It does not. The letter sets a sex field on the **account**; characters carry
their own. Straight out of a running server — one account, both genders:

| userid | account_sex | char_name | char_sex |
|---|---|---|---|
| ragnarok | M | Alpha | F |
| ragnarok | M | Delta | M |

`login.cpp` strips the suffix before calling `login_mmo_auth_new`, so it is only
the signal that asks the login server to create the account. Either letter
works, and the character screen is where gender is actually chosen.

Reworded to say that, keeping the two things that are true and easy to get
wrong: the suffix is used only the first time, and the four-character minimum is
counted without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MwcCPSzxbKHkPEaT9Q7W87