### PR TITLE
Read Windows process identity without launching PowerShell

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -15,6 +15,10 @@ node --check electron/main.js
 ```
 
 On Windows, run the script in Git Bash and append `.exe` to `REMOTECLIENT_BIN`.
+Build the supervisor with `cargo build --manifest-path stack/Cargo.toml` and set
+`STACK_BIN` to its absolute `.exe` path for Windows tests. The shell uses the
+bundled supervisor's `process-identity PID` command to read native process
+creation time and executable path; PowerShell startup is no longer involved.
 The unit fixtures use temporary directories and random ports. The two Rust
 integration tests use synthetic GRFs, including a real force-killed-parent
 test; they do not use your characters, assets or running game. Without

--- a/electron/asset-server.js
+++ b/electron/asset-server.js
@@ -27,17 +27,15 @@ function sameMac(a, b) {
 		&& crypto.timingSafeEqual(Buffer.from(a, 'hex'), Buffer.from(b, 'hex'));
 }
 
-async function processIdentity(pid) {
+async function processIdentity(pid, inspector = process.env.STACK_BIN) {
 	if (!Number.isSafeInteger(pid) || pid <= 0) throw new Error('invalid process ID');
 	if (process.platform === 'linux') {
 		const stat = await fs.promises.readFile(`/proc/${pid}/stat`, 'utf8');
 		return { start: stat.slice(stat.lastIndexOf(')') + 2).split(' ')[19], executable: await fs.promises.readlink(`/proc/${pid}/exe`) };
 	}
 	if (process.platform === 'win32') {
-		// Query the process directly; WMI/CIM startup can exceed several seconds
-		// on a cold Windows machine even when the child itself is already ready.
-		const command = `$ErrorActionPreference='Stop'; $p=[System.Diagnostics.Process]::GetProcessById(${pid}); @{start=$p.StartTime.ToUniversalTime().ToString('o');executable=$p.MainModule.FileName} | ConvertTo-Json -Compress`;
-		const { stdout } = await exec('powershell.exe', ['-NoProfile', '-NonInteractive', '-Command', command], { timeout: 10000, windowsHide: true });
+		if (!inspector) throw new Error('Windows process identity needs the bundled supervisor (STACK_BIN for tests)');
+		const { stdout } = await exec(inspector, ['process-identity', String(pid)], { timeout: 3000, windowsHide: true, maxBuffer: 131072 });
 		const identity = JSON.parse(stdout);
 		if (!identity.start || !identity.executable) throw new Error('cannot verify process identity');
 		return identity;

--- a/electron/main.js
+++ b/electron/main.js
@@ -490,8 +490,8 @@ function runStack(rawArgs) {
 // Asset server
 // ---------------------------------------------------------------------------
 
-const { AssetServer, sha256 } = require('./asset-server');
-const assetServer = new AssetServer({ log: message => appLog(message) });
+const { AssetServer, sha256, processIdentity } = require('./asset-server');
+const assetServer = new AssetServer({ log: message => appLog(message), identify: pid => processIdentity(pid, stackBin()) });
 let assetLinkQueue = Promise.resolve();
 
 function assetsReady() { return assetServer.ready(); }

--- a/stack/src/json.rs
+++ b/stack/src/json.rs
@@ -13,6 +13,28 @@
 use std::collections::BTreeMap;
 use std::fmt;
 
+/// A JSON string literal, also used by small host-only command responses.
+#[cfg(any(windows, test))]
+pub fn quote(value: &str) -> String {
+    let mut result = String::from("\"");
+    for ch in value.chars() {
+        match ch {
+            '"' => result.push_str("\\\""),
+            '\\' => result.push_str("\\\\"),
+            c if (c as u32) < 0x20 => result.push_str(&format!("\\u{:04x}", c as u32)),
+            c => result.push(c),
+        }
+    }
+    result.push('"');
+    result
+}
+
+#[test]
+fn quoted_host_paths_round_trip_quotes_controls_and_unicode() {
+    let value = "C:\\game files 한글\\\"name\"\n\0";
+    assert_eq!(parse(&quote(value)).unwrap(), Value::String(value.to_string()));
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum Value {
     Null,

--- a/stack/src/main.rs
+++ b/stack/src/main.rs
@@ -17,6 +17,7 @@ mod docker;
 mod json;
 mod mapcache;
 mod mods;
+mod process_identity;
 
 use config::Config;
 use docker::Docker;
@@ -53,6 +54,17 @@ fn main() {
     config::widen_path();
     let args: Vec<String> = env::args().skip(1).collect();
     let verb = args.first().map(String::as_str).unwrap_or("status");
+
+    if verb == "process-identity" {
+        let result = args.get(1).and_then(|s| s.parse::<u32>().ok())
+            .ok_or_else(|| "process-identity needs a numeric PID".to_string())
+            .and_then(process_identity::query);
+        match result {
+            Ok(identity) => println!("{identity}"),
+            Err(error) => { eprintln!("{error}"); exit(1); }
+        }
+        return;
+    }
 
     let loaded = if verb == "link-assets" {
         Config::load_for_assets(project_root())

--- a/stack/src/process_identity.rs
+++ b/stack/src/process_identity.rs
@@ -1,0 +1,112 @@
+//! One-shot OS identity query for the shell. No VM, Docker or PowerShell.
+
+pub fn query(pid: u32) -> Result<String, String> {
+    if pid == 0 {
+        return Err("invalid process ID".into());
+    }
+    #[cfg(windows)]
+    {
+        windows::query(pid)
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = pid;
+        Err("native process identity helper is only needed on Windows".into())
+    }
+}
+
+#[cfg(windows)]
+mod windows {
+    use std::ffi::c_void;
+    type Handle = *mut c_void;
+    #[repr(C)]
+    #[derive(Default)]
+    struct FileTime {
+        low: u32,
+        high: u32,
+    }
+
+    // Signatures and access rights:
+    // https://learn.microsoft.com/windows/win32/api/processthreadsapi/nf-processthreadsapi-getprocesstimes
+    // https://learn.microsoft.com/windows/win32/api/winbase/nf-winbase-queryfullprocessimagenamew
+    #[link(name = "kernel32")]
+    unsafe extern "system" {
+        fn OpenProcess(access: u32, inherit: i32, pid: u32) -> Handle;
+        fn CloseHandle(handle: Handle) -> i32;
+        fn GetProcessTimes(
+            handle: Handle,
+            creation: *mut FileTime,
+            exit: *mut FileTime,
+            kernel: *mut FileTime,
+            user: *mut FileTime,
+        ) -> i32;
+        fn QueryFullProcessImageNameW(
+            handle: Handle,
+            flags: u32,
+            name: *mut u16,
+            size: *mut u32,
+        ) -> i32;
+    }
+    struct Process(Handle);
+    impl Drop for Process {
+        fn drop(&mut self) {
+            // SAFETY: this owns a successful OpenProcess handle, closed once.
+            unsafe {
+                CloseHandle(self.0);
+            }
+        }
+    }
+    fn failure(operation: &str) -> String {
+        format!("{operation}: {}", std::io::Error::last_os_error())
+    }
+
+    pub fn query(pid: u32) -> Result<String, String> {
+        // SAFETY: numeric PID; query-only access, no inherited handle.
+        let raw = unsafe { OpenProcess(0x1000, 0, pid) }; // PROCESS_QUERY_LIMITED_INFORMATION
+        if raw.is_null() {
+            return Err(failure("opening process for identity"));
+        }
+        let process = Process(raw);
+        let (mut creation, mut exit, mut kernel, mut user) = (
+            FileTime::default(),
+            FileTime::default(),
+            FileTime::default(),
+            FileTime::default(),
+        );
+        // SAFETY: live owned handle and distinct valid output structures.
+        if unsafe { GetProcessTimes(process.0, &mut creation, &mut exit, &mut kernel, &mut user) }
+            == 0
+        {
+            return Err(failure("reading process creation time"));
+        }
+        let mut name = vec![0u16; 32768];
+        let mut size = name.len() as u32;
+        // SAFETY: size names the allocated UTF-16 buffer; Win32 reports the
+        // number of initialized characters excluding its trailing NUL.
+        if unsafe { QueryFullProcessImageNameW(process.0, 0, name.as_mut_ptr(), &mut size) } == 0 {
+            return Err(failure("reading process executable"));
+        }
+        if size as usize >= name.len() {
+            return Err("oversized executable path".into());
+        }
+        let executable = String::from_utf16(&name[..size as usize]).map_err(|e| e.to_string())?;
+        let stamp = (u64::from(creation.high) << 32) | u64::from(creation.low);
+        Ok(format!(
+            "{{\"start\":\"windows-filetime:{stamp:016x}\",\"executable\":{}}}",
+            crate::json::quote(&executable)
+        ))
+    }
+
+    #[test]
+    fn current_process_identity_is_stable_and_names_this_executable() {
+        let first = query(std::process::id()).unwrap();
+        assert_eq!(query(std::process::id()).unwrap(), first);
+        let value = crate::json::parse(&first).unwrap();
+        assert!(value.str("start").unwrap().starts_with("windows-filetime:"));
+        assert_eq!(
+            std::path::Path::new(value.str("executable").unwrap()),
+            std::env::current_exe().unwrap()
+        );
+        assert!(query(u32::MAX).is_err());
+    }
+}

--- a/tests/asset-server.test.cjs
+++ b/tests/asset-server.test.cjs
@@ -40,6 +40,11 @@ test('OS identity includes the current process creation time and executable', as
 	assert.ok(id.executable.includes('node'));
 });
 
+test('parallel OS identity queries agree without a shell startup dependency', async () => {
+	const identities = await Promise.all(Array.from({ length: 8 }, () => processIdentity(process.pid)));
+	for (const id of identities) assert.deepEqual(id, identities[0]);
+});
+
 test('concurrent starts share one owned process; stop awaits actual exit', async t => {
 	const { server, options, dir } = await fixture(t);
 	const [a, b] = await Promise.all([server.start(options), server.start(options)]);


### PR DESCRIPTION
Windows asset readiness could time out while launching PowerShell to identify a child process, especially when several startup checks ran concurrently. The shell now asks the bundled Rust supervisor for the process creation time and executable path using query-only Win32 calls. No PowerShell, WMI, VM startup, new executable, or crate dependency is required.

The helper validates the PID, owns/closes its process handle, and JSON-encodes the result. Existing authenticated identity and PID-reuse checks remain in place. The local suite adds parallel process queries and JSON path round-trips; Windows CI also checks the native helper against its current process.

Stacked on #53 (`codex/issues-5-24-cross-drive-assets`), as a focused follow-up to #22. Validation: 47 supervisor tests and 19 real-binary/Node tests pass locally on macOS. Native Windows execution is covered by the PR CI and remains pending at creation. Do not merge until the combined application is tested and the user authorizes merging.
