### PR TITLE
Reflow phone UI and preserve independent touch controls

### DIFF
--- a/docs/MODDING.md
+++ b/docs/MODDING.md
@@ -561,11 +561,15 @@ It is a supported interface, not a sandbox for untrusted JavaScript.
 | `api.movement.register(name, onCancel)` | Returns `begin(x,y)`, `update(x,y)`, `end()`, `dispose()`. Screen-up is positive Y. Only a deliberate `begin` can take ownership; a stale `update` cannot. |
 | `api.input.state()` / `.shortcutConflict(keyCode)` | Read input eligibility and the active native battle-shortcut mapping. |
 | `api.input.suspend()` | Suspend movement while showing a plugin dialog. Returns an idempotent release function, also released at disposal. |
-| `api.actions.perform(name, payload)` | Native actions: `attack`, `target` (toggle auto-target), `interact`, `pickup`, `menu` (game options), `shortcut` with `{ index: 0…35 }`, `shortcut:assign` (below), or `window` with an allowed `{ name }`. Returns whether the action was dispatched, not whether the server accepted it. |
+| `api.actions.perform(name, payload)` | Native actions: `attack`, `target` (toggle auto-target), `interact`, `pickup`, `menu` (game options), `shortcut` with `{ index: 0…35 }`, `shortcut:assign` and `storage:transfer` (below), or `window` with an allowed `{ name }`. Returns whether the action was dispatched, not whether the server accepted it. |
 | `api.cleanup(fn)` | Register idempotent cleanup immediately after allocating a resource. The returned function can release it early. Runs on failure, scope replacement and page teardown. |
 
 Allowed window actions currently cover Inventory, Equipment, SkillList, Quest,
-WorldMap, PartyFriends and WinStats. Map and connection events clear movement;
+WorldMap, PartyFriends, WinStats and already-open Storage. Set `{ name, open: true }`
+to focus an existing window instead of toggling it closed. Storage must first be
+opened by the server; this action cannot create a storage session.
+
+Map and connection events clear movement;
 blur, hidden page, text entry, IME and modal UI also cancel it. Directional
 requests use native pathfinding and packets, with a 180 ms cadence and at most
 three path steps per destination. The server remains authoritative.
@@ -574,6 +578,13 @@ three path steps per destination. The server remains authoritative.
 For items, `id` is a current inventory **index**, not the item type ID; for skills
 it is the learned skill ID. The adapter validates the live item/learned level and
 uses the native shortcut assignment callbacks, including server persistence.
+
+`storage:transfer` accepts `{ direction: 'deposit' | 'withdraw', index, count }`.
+The index belongs to the live source inventory/storage list. Count must be a
+positive integer within the available stack or `'all'`. The adapter requires
+an open storage session, rejects equipped deposits, and invokes native storage
+callbacks. A `true` result means a request was sent; only the server's item
+updates establish success. The mobile controls show “Transfer requested.”
 
 Host mod enable/disable still requires the normal reload. Arbitrary older
 plugins cannot be safely hot-unloaded if they never registered cleanup. The
@@ -588,7 +599,10 @@ Geometry preferences use a separate phone key selected before UI initialization,
 so a mode change cannot save phone coordinates into the desktop preferences.
 The phone HUD retains the native joystick, action handlers and shortcuts. Tap
 an inventory/equipment/skill entry, then its explicit action button; F1–F4 can
-be assigned from the inventory and skills toolbars.
+be assigned from the inventory and skills toolbars. Storage adds quantity and
+whole-stack deposit/withdraw controls, with explicit focus buttons between it
+and inventory. Shops reuse the native buy/sell selection, quantity dialog and
+transaction callbacks. Their nested geometry also has a separate phone bank.
 
 ---
 

--- a/docs/MODDING.md
+++ b/docs/MODDING.md
@@ -555,13 +555,13 @@ It is a supported interface, not a sandbox for untrusted JavaScript.
 | API | Contract |
 | --- | --- |
 | `api.on(event, listener, { replay: true })` | Returns an unsubscribe function; subscriptions also end at disposal. Events: `map:enter`, `map:leave`, `connection`, `ui:append`, `ui:remove`, `movement:clear`, `preferences:change`. |
-| `api.snapshot()` | Frozen copy of map, connection, player position/HP/SP, camera, packet version and movement counters. Server movement acknowledgements are read-only evidence. |
+| `api.snapshot()` | Frozen copy of map, connection, player position/HP/SP, selected target identity/name/HP, camera, packet version and movement counters. Server movement acknowledgements are read-only evidence. |
 | `api.components.current()` | Mounted `{ name, root, host }` descriptors. DOM references support styling; do not retain detached components after `ui:remove`. |
 | `api.preferences.get(key, fallback)` / `.set(key, value)` | JSON values isolated by plugin, browser and server origin. Storage failure is reported by `set`. Do not store secrets. |
 | `api.movement.register(name, onCancel)` | Returns `begin(x,y)`, `update(x,y)`, `end()`, `dispose()`. Screen-up is positive Y. Only a deliberate `begin` can take ownership; a stale `update` cannot. |
 | `api.input.state()` / `.shortcutConflict(keyCode)` | Read input eligibility and the active native battle-shortcut mapping. |
 | `api.input.suspend()` | Suspend movement while showing a plugin dialog. Returns an idempotent release function, also released at disposal. |
-| `api.actions.perform(name, payload)` | Native actions: `attack`, `target` (toggle auto-target), `interact`, `pickup`, `shortcut` with `{ index: 0…35 }`, or `window` with an allowed `{ name }`. Returns whether the action was dispatched, not whether the server accepted it. |
+| `api.actions.perform(name, payload)` | Native actions: `attack`, `target` (toggle auto-target), `interact`, `pickup`, `menu` (game options), `shortcut` with `{ index: 0…35 }`, `shortcut:assign` (below), or `window` with an allowed `{ name }`. Returns whether the action was dispatched, not whether the server accepted it. |
 | `api.cleanup(fn)` | Register idempotent cleanup immediately after allocating a resource. The returned function can release it early. Runs on failure, scope replacement and page teardown. |
 
 Allowed window actions currently cover Inventory, Equipment, SkillList, Quest,
@@ -570,10 +570,25 @@ blur, hidden page, text entry, IME and modal UI also cancel it. Directional
 requests use native pathfinding and packets, with a 180 ms cadence and at most
 three path steps per destination. The server remains authoritative.
 
+`shortcut:assign` accepts `{ slot: 0…35, kind: 'item' | 'skill', id }`.
+For items, `id` is a current inventory **index**, not the item type ID; for skills
+it is the learned skill ID. The adapter validates the live item/learned level and
+uses the native shortcut assignment callbacks, including server persistence.
+
 Host mod enable/disable still requires the normal reload. Arbitrary older
 plugins cannot be safely hot-unloaded if they never registered cleanup. The
 in-game **Controls** button from [`wasd-movement`](../mods/wasd-movement) offers
 per-browser activation, rebinding, arrows and battle-shortcut priority.
+
+The bundled `mobile-ui` mod provides **Display** settings before login and under
+the phone's in-game **Menu**. Auto selects a phone layout on a touch-capable
+screen whose shorter side is at most 900 pixels. On/Off overrides that choice.
+Mode changes reload the client; control size changes apply immediately.
+Geometry preferences use a separate phone key selected before UI initialization,
+so a mode change cannot save phone coordinates into the desktop preferences.
+The phone HUD retains the native joystick, action handlers and shortcuts. Tap
+an inventory/equipment/skill entry, then its explicit action button; F1–F4 can
+be assigned from the inventory and skills toolbars.
 
 ---
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -217,7 +217,18 @@ recorded after login. Run with the same `RO_E2E_WORLD` and `RO_E2E_BUILD` settin
 as the other suites, using `node node_modules/@playwright/test/cli.js test
 mobile-commerce.spec.cjs`.
 
-Full combat, player vending and remaining NPC/quest flows, plus
+`mobile-actions.spec.cjs` checks native item/shortcut healing and inventory
+counts, distant one-tap pickup, cancellation of a queued pickup by a new touch
+joystick direction, and Poring combat. Damage and experience messages come from
+received server packets; a button click or unknown monster HP does not prove a
+kill. The fixture clears old floor loot in its disposable town, adds five Red
+Potions, damages/heals the test character, drops the healing stack and spawns a
+Poring. Successful runs restore potion count and HP; experience and F2's potion
+assignment persist. It records browser/viewport, page and console errors, HTTP
+failures, WebSocket lifecycle (not frames), screenshots and a post-login trace.
+`phone.cjs` shares native phone login/menu/chat/warp helpers with commerce tests.
+
+Learned skill use/targeting, further combat cases, player vending and remaining NPC/quest flows, plus
 orientation/keyboard transitions, death/IME/background gameplay cases, Firefox,
 packaged Electron and physical Android/iPhone testing remain release gates for
 issue #6. Chromium device emulation is not a physical Safari/Android pass.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -203,7 +203,21 @@ suspension in Display, saved size, Off/On reloads, separate geometry banks and
 the legacy first-touch detector respecting Off. It seeds only a browser window
 preference; gameplay still uses the real server.
 
-Full combat, shop/storage transactions, NPC/quest flows and
+`mobile-commerce.spec.cjs` uses portrait and landscape phone profiles with an
+ordinary NPC tool dealer and real GM fixture commands in the disposable world.
+It rejects an excessive deposit quantity, verifies item conservation across
+quantity and whole-stack deposit/withdraw operations, checks server-confirmed
+inventory and Zeny changes for buying/selling, and checks the shop's separate
+phone preference bank. It also exercises rapid native-panel taps near NPCs,
+which must not click through into the map. The fixture adds Red Potions/Zeny
+to the test character, restores those amounts after a successful run, and uses
+the pinned renewal dealer at `prt_in (126,76)`;
+run it with a GM account and the renewal test world. Screenshots and traces are
+recorded after login. Run with the same `RO_E2E_WORLD` and `RO_E2E_BUILD` settings
+as the other suites, using `node node_modules/@playwright/test/cli.js test
+mobile-commerce.spec.cjs`.
+
+Full combat, player vending and remaining NPC/quest flows, plus
 orientation/keyboard transitions, death/IME/background gameplay cases, Firefox,
 packaged Electron and physical Android/iPhone testing remain release gates for
 issue #6. Chromium device emulation is not a physical Safari/Android pass.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -159,7 +159,10 @@ npm run test:e2e
 ```
 
 Optional `RO_E2E_ACCOUNT` and `RO_E2E_PASSWORD` select another disposable test
-account. The harness authenticates the private asset ownership control endpoint,
+GM account. Keep a playable character in slot 1 and slot 3 empty. The layout
+suite opens creation in the empty slot and cancels; the two-thumb suite uses a
+real `@warp prontera 150 180` command to start on a repeatable walkable path.
+The harness authenticates the private asset ownership control endpoint,
 checks the executable hash and OS process identity, then uses the actual login
 UI. It never records authentication fill actions or raw WebSocket frames.
 Tracing starts after login/map entry. Reports include browser/packet versions,
@@ -180,6 +183,27 @@ Current automated coverage: desktop login/relogin, W/A/S/D and arrows, actual
 server movement, release, chat typing, per-browser disable/persistence and
 stable source counts after reload. Unit tests additionally cover diagonals,
 opposing directions, camera rotation, input ownership, cancellation, shortcut
-priority and plugin cleanup/timeouts. The mobile viewport/two-thumb tests, real
-phone testing, warp/death/IME/hidden-tab gameplay cases and previous-version
-screenshot matrix remain release gates for issue #6.
+priority and plugin cleanup/timeouts.
+
+`mobile.spec.cjs` uses Chromium CDP multi-touch input with distinct pointer IDs,
+checks both release orders and cancellation, and verifies exactly one delivery
+to the native attack handler. It also requires server movement acknowledgements
+and unchanged camera direction; dispatching an attack with no nearby monster
+does not establish combat correctness.
+
+`mobile-layout.spec.cjs` captures desktop, two phone portrait sizes, their
+landscape sizes and tablet. It exercises tap login/selection, creation-screen
+access, map and inventory; it checks viewport bounds and primary target sizes.
+Review the screenshots as well as assertions. Run a subset with
+`npx playwright test mobile.spec.cjs` or `mobile-layout.spec.cjs` while the owned
+test world is running.
+
+`mobile-preferences.spec.cjs` checks 125% controls without overlap, input
+suspension in Display, saved size, Off/On reloads, separate geometry banks and
+the legacy first-touch detector respecting Off. It seeds only a browser window
+preference; gameplay still uses the real server.
+
+Full combat, shop/storage transactions, NPC/quest flows and
+orientation/keyboard transitions, death/IME/background gameplay cases, Firefox,
+packaged Electron and physical Android/iPhone testing remain release gates for
+issue #6. Chromium device emulation is not a physical Safari/Android pass.

--- a/mods/mobile-ui/README.md
+++ b/mods/mobile-ui/README.md
@@ -1,44 +1,34 @@
 # mobile-ui
 
-Ships with the app and is on by default. It is also the shortest complete
-example of the `client/` layer, so it is worth reading even if you never touch
-a phone.
+Bundled and enabled by default. **Display → Phone layout** offers Auto, On and
+Off. Auto selects touch screens with a shorter side of at most 900 pixels.
+Changing layout reloads the client; control size (85–125%) applies immediately.
+Phone and desktop window positions are saved separately in each browser.
 
-## What it does
+The phone layout provides a compact HP/SP display, native movement joystick,
+Attack/Talk/Pickup buttons, four native shortcuts and a game menu. Login,
+character selection/creation, inventory, equipment, skills, quests and NPC
+windows get touch controls. Tap an item or skill before using its action
+buttons. Inventory and skills can assign F1–F4 without dragging.
 
-On a touch device with a screen under 900 points on its short side:
+When storage is open, select an item and use Deposit/Withdraw with a quantity,
+or Deposit all/Withdraw all. Open inventory and Back to storage bring the
+respective panel forward. The server still authorizes each transfer; the
+request message is not a success acknowledgement. Shops use Add selected,
+the native quantity dialog, then Buy or Sell; Remove selected edits the cart.
 
-- sets a real `viewport` meta, so the browser stops pretending to be 980px wide
-  and scaling the whole canvas down to fit
-- stops the page from panning, pinch-zooming and text-selecting under a drag,
-  which is otherwise what a swipe does instead of moving your character
-- brings buttons up to a 44px touch target
-- sets login inputs to 16px, because iOS Safari zooms the page when it focuses
-  anything smaller and does not zoom back out
-- keeps the game clear of the notch and the home indicator
+Viewport and safe-area handling keep controls within the visible game. Small
+touch devices retain a real viewport even with the phone layout Off. Default
+desktop mode preserves the native layout. Physical phone keyboard/orientation
+behavior and complete gameplay coverage remain release gates; see
+[testing](../../docs/TESTING.md).
 
-On a desktop it does nothing at all.
+The ES module exports `default(params, api)`. Client API 1 supplies scoped
+component append/remove events, native actions, input suspension, preferences
+and cleanup. Styles are attached inside each native component's shadow root;
+there is no document-wide MutationObserver. See
+[the API contract](../../docs/MODDING.md#client-api-1).
 
-## What to look at first
-
-`client/index.js`, and specifically two things:
-
-**The default export is a function.** The plugin manager `import()`s the file
-and calls `module.default(params)`. A plugin written as `define(function(){…})`
-— the form older roBrowser plugins use, and the form this mod itself used until
-0.2.0 — throws on import, gets caught, and is reported to a console that the
-client has muted. It loads, it does nothing, and nothing says so.
-
-**Shadow roots need the stylesheet handed to them.** Every roBrowser window is
-a custom element with its own shadow root, and a `<style>` in the document head
-does not cross that boundary. The plugin builds one `CSSStyleSheet` and adopts
-it into each shadow root as it appears, with a `MutationObserver` to catch the
-windows created later. This is the part to copy if you want to restyle the
-interface rather than the page.
-
-## Related
-
-Issue [#6](https://github.com/Flux159/ragnarokoffline.app/issues/6) also asks
-for WASD movement and controller support. Keyboard movement is already built
-into the client (`patches/KeyboardMove.js`); a controller mod would be another
-`client/` plugin, and would start from the same two facts above.
+Keyboard movement is provided by the separate `wasd-movement` mod and shares
+movement ownership with the native joystick. Controller support remains future
+work; it is not implemented by this mod.

--- a/mods/mobile-ui/README.md
+++ b/mods/mobile-ui/README.md
@@ -16,6 +16,8 @@ or Deposit all/Withdraw all. Open inventory and Back to storage bring the
 respective panel forward. The server still authorizes each transfer; the
 request message is not a success acknowledgement. Shops use Add selected,
 the native quantity dialog, then Buy or Sell; Remove selected edits the cart.
+Pick up approaches a distant item and collects it after the walk finishes. Moving
+with the joystick or keyboard cancels that pending pickup.
 
 Viewport and safe-area handling keep controls within the visible game. Small
 touch devices retain a real viewport even with the phone layout Off. Default

--- a/mods/mobile-ui/client/commerce.js
+++ b/mods/mobile-ui/client/commerce.js
@@ -1,0 +1,158 @@
+// Tap actions around native shop/storage handlers. DOM references and listeners
+// are owned by the component attachment and released with it.
+export function attachCommerce({
+  component,
+  api,
+  on,
+  add,
+  button,
+  label,
+  attribute,
+}) {
+  const { name, root } = component;
+  let selected = null;
+  const select = (selector) =>
+    on(root, "click", (event) => {
+      const item = event.target.closest?.(selector);
+      if (!item) return;
+      selected?.classList.remove("ro-mobile-selected");
+      selected = item;
+      selected.classList.add("ro-mobile-selected");
+    });
+  const act = (callback) => {
+    if (selected?.isConnected) callback(selected);
+  };
+  const toolbar = () => {
+    const node = document.createElement("div");
+    node.className = "ro-mobile-toolbar";
+    return node;
+  };
+  if (root.querySelector("#win_popup")) {
+    for (const [key, text] of [
+      ["buy", "Buy"],
+      ["sell", "Sell"],
+      ["cancel", "Cancel"],
+      ["ok", "OK"],
+      ["close", "Close"],
+    ]) {
+      label(
+        root.querySelector(`button[data-background="btn_${key}.bmp"]`),
+        text,
+      );
+    }
+  }
+  if (name === "InputBox") {
+    label(root.querySelector("ui-button"), "OK");
+    attribute(root.querySelector("input"), "aria-label", "Value");
+  }
+  if (name === "NpcStore") {
+    label(root.querySelector(".btn.buy"), "Buy");
+    label(root.querySelector(".btn.sell"), "Sell");
+    label(root.querySelector(".btn.cancel"), "Cancel");
+    label(root.querySelector(".btn.ok"), "OK");
+    select(".item[data-index]");
+    for (const [selector, text] of [
+      [".InputWindow", "Add selected"],
+      [".OutputWindow", "Remove selected"],
+    ]) {
+      const panel = root.querySelector(selector),
+        bar = toolbar();
+      add(
+        bar,
+        button(text, () =>
+          act((item) => {
+            if (panel.contains(item))
+              item.dispatchEvent(new MouseEvent("dblclick", { bubbles: true }));
+          }),
+        ),
+      );
+      add(
+        bar,
+        button("Item info", () =>
+          act((item) => {
+            item.querySelector(".icon")?.dispatchEvent(
+              new MouseEvent("contextmenu", {
+                bubbles: true,
+                cancelable: true,
+                button: 2,
+              }),
+            );
+          }),
+        ),
+      );
+      add(panel, bar);
+    }
+  }
+  if (name === "Storage" || /^Inventory/.test(name)) {
+    const deposit = name !== "Storage",
+      bar = toolbar();
+    bar.classList.add("ro-storage-controls");
+    if (deposit) bar.hidden = true;
+    const quantity = document.createElement("input");
+    quantity.type = "number";
+    quantity.inputMode = "numeric";
+    quantity.min = "1";
+    quantity.step = "1";
+    quantity.value = "1";
+    quantity.setAttribute(
+      "aria-label",
+      deposit ? "Deposit quantity" : "Withdraw quantity",
+    );
+    const message = document.createElement("output");
+    message.setAttribute("aria-live", "polite");
+    const transfer = (count) =>
+      act((item) => {
+        const dispatched = api.actions.perform("storage:transfer", {
+          direction: deposit ? "deposit" : "withdraw",
+          index: Number(item.dataset.index),
+          count,
+        });
+        message.textContent = dispatched
+          ? "Transfer requested."
+          : "Choose an available quantity of an unequipped item.";
+      });
+    add(bar, quantity);
+    add(
+      bar,
+      button(deposit ? "Deposit" : "Withdraw", () =>
+        transfer(Number(quantity.value)),
+      ),
+    );
+    add(
+      bar,
+      button(deposit ? "Deposit all" : "Withdraw all", () => transfer("all")),
+    );
+    add(
+      bar,
+      button(deposit ? "Back to storage" : "Open inventory", () =>
+        api.actions.perform("window", {
+          name: deposit ? "Storage" : "Inventory",
+          open: true,
+        }),
+      ),
+    );
+    add(bar, message);
+    add(root.querySelector(".ui-component-root"), bar);
+    select(".content .item[data-index]");
+    if (!deposit) {
+      label(root.querySelector(".close"), "Close storage");
+      label(root.querySelector(".search-button"), "Search");
+      attribute(
+        root.querySelector(".search-input"),
+        "aria-label",
+        "Search storage",
+      );
+      for (const [key, title] of [
+        ["item", "Use"],
+        ["kafra", "Cash"],
+        ["armor", "Armor"],
+        ["arms", "Weapon"],
+        ["ammo", "Ammo"],
+        ["card", "Card"],
+        ["etc", "Etc"],
+      ])
+        label(root.querySelector(`.tabs button.${key}`), title);
+    }
+  }
+  return () => selected?.classList.remove("ro-mobile-selected");
+}

--- a/mods/mobile-ui/client/index.js
+++ b/mods/mobile-ui/client/index.js
@@ -1,4 +1,5 @@
 import { componentStyle } from "./styles.js";
+import { attachCommerce } from "./commerce.js";
 
 function readLayout(api) {
   const value = api.preferences.get("layout", {});
@@ -85,7 +86,7 @@ export default function mobileUI(parameters, api) {
   if (phone) {
     const pageStyle = document.createElement("style");
     pageStyle.textContent =
-      'html,body{overflow:clip!important;width:100%;height:100%;margin:0}.cursor{display:none!important}.ro-background{background-size:cover!important;background-position:center!important}.ro-background[data-ro-tiled="true"]{width:max(100vw,calc(100vh * 4 / 3))!important;height:max(100vh,calc(100vw * 3 / 4))!important;left:50%!important;top:50%!important;transform:translate(-50%,-50%)}';
+      'html,body{overflow:clip!important;width:100%;height:100%;margin:0}.win_popup_overlay{z-index:4999!important;background:#0005}.cursor{display:none!important}.ro-background{background-size:cover!important;background-position:center!important}.ro-background[data-ro-tiled="true"]{width:max(100vw,calc(100vh * 4 / 3))!important;height:max(100vh,calc(100vw * 3 / 4))!important;left:50%!important;top:50%!important;transform:translate(-50%,-50%)}';
     document.head.append(pageStyle);
     api.cleanup(() => pageStyle.remove());
   }
@@ -149,7 +150,7 @@ export default function mobileUI(parameters, api) {
   <div class="skills" aria-label="Quick shortcuts">${[1, 2, 3, 4].map((n) => `<button data-shortcut="${n - 1}" aria-label="Use shortcut ${n}">F${n}</button>`).join("")}</div>
   <div class="actions"><button id="attack">Attack</button><button id="interact">Talk</button><button id="pickup">Pick up</button></div>
   <nav class="menu" aria-label="Game menu" hidden>
-   ${["Inventory", "Equipment", "Skills", "Quests", "Stats", "Map", "Friends", "Chat", "Target", "Display", "Game options", "Close"].map((name) => `<button data-menu="${name}">${name}</button>`).join("")}
+   ${["Inventory", "Equipment", "Skills", "Quests", "Stats", "Map", "Friends", "Storage", "Chat", "Target", "Display", "Game options", "Close"].map((name) => `<button data-menu="${name}">${name}</button>`).join("")}
   </nav>
  </div>
  <button id="displayButton" aria-haspopup="dialog">Display</button>
@@ -218,7 +219,15 @@ export default function mobileUI(parameters, api) {
     if (save()) location.reload();
   });
   const menu = root.querySelector(".menu");
+  let releaseMenu = null;
+  api.cleanup(() => releaseMenu?.());
   const toggleMenu = (value) => {
+    releaseMenu?.();
+    releaseMenu = null;
+    if (value) {
+      releaseMenu = api.input.suspend();
+      host.style.zIndex = "4600";
+    } else host.style.removeProperty("z-index");
     menu.hidden = !value;
     root
       .querySelector("#menuButton")
@@ -267,8 +276,10 @@ export default function mobileUI(parameters, api) {
         Stats: "WinStats",
         Map: "WorldMap",
         Friends: "PartyFriends",
+        Storage: "Storage",
       };
-      if (windows[name]) api.actions.perform("window", { name: windows[name] });
+      if (windows[name])
+        api.actions.perform("window", { name: windows[name], open: true });
     });
   const setPlaying = (playing) => {
     root.querySelector(".hud").hidden = !phone || !playing;
@@ -283,6 +294,20 @@ export default function mobileUI(parameters, api) {
     const state = api.snapshot(),
       player = state.player;
     if (!state.map || !player) return;
+    const storage = components.get("Storage");
+    const storageOpen = Boolean(
+      storage?.host.isConnected &&
+      storage.host.getClientRects().length &&
+      getComputedStyle(storage.host).display !== "none",
+    );
+    root.querySelector('[data-menu="Storage"]').hidden = !storageOpen;
+    for (const [name, component] of components)
+      if (/^Inventory/.test(name)) {
+        const controls = component.root.querySelector(".ro-storage-controls");
+        if (controls) controls.hidden = !storageOpen;
+        const itemActions = component.root.querySelector(".ro-item-actions");
+        if (itemActions) itemActions.hidden = storageOpen;
+      }
     for (const [key, maxKey, label] of [
       ["hp", "maxHp", "HP"],
       ["sp", "maxSp", "SP"],
@@ -354,7 +379,9 @@ export default function mobileUI(parameters, api) {
         attribute(node, "tabindex", "0");
       }
     };
-    let css = componentStyle(name);
+    let css = componentStyle(
+      ui.querySelector("#win_popup") ? "WinPopup" : name,
+    );
     if (name === "ChatBox")
       css +=
         ":host{display:none!important;}:host([data-ro-chat-open]){display:block!important;}";
@@ -381,6 +408,10 @@ export default function mobileUI(parameters, api) {
     // browser scrolling instead of global touch-action:none.
     for (const event of ["touchstart", "touchmove", "touchend", "touchcancel"])
       on(ui, event, (e) => e.stopPropagation());
+    // Native hover-based Mouse.intersect can be stale during fast touch taps.
+    // Keep compatibility mousedown inside the GUI after its own focus/drag
+    // handlers run. Mouseup still reaches the global drag/walk cleanup.
+    on(element, "mousedown", (event) => event.stopPropagation());
     if (name === "MobileUI") {
       const base = ui.querySelector("#joystickBase");
       attribute(base, "aria-label", "Movement joystick");
@@ -518,7 +549,7 @@ export default function mobileUI(parameters, api) {
     if (/^(Inventory|Equipment|SkillList)/.test(name)) {
       let selected = null;
       const toolbar = document.createElement("div");
-      toolbar.className = "ro-mobile-toolbar";
+      toolbar.className = "ro-mobile-toolbar ro-item-actions";
       const skills = /^SkillList/.test(name);
       const use = button(
         /^Equipment/.test(name)
@@ -589,6 +620,9 @@ export default function mobileUI(parameters, api) {
       [".btns .ok", "OK"],
     ])
       label(ui.querySelector(selector), text);
+    cleanups.push(
+      attachCommerce({ component, api, on, add, button, label, attribute }),
+    );
     owned.set(element, () => {
       for (const cleanup of cleanups.reverse()) cleanup();
       if (components.get(name)?.host === element) components.delete(name);

--- a/mods/mobile-ui/client/index.js
+++ b/mods/mobile-ui/client/index.js
@@ -1,117 +1,609 @@
-/**
- * mobile-ui -- make the client usable on a phone.
- *
- * A roBrowser plugin, and the shape of every one: an ES module whose *default
- * export is a function*. The plugin manager `import()`s this file, calls that
- * function once with whatever parameters the config passed, and takes a truthy
- * return as "loaded". An older generation of roBrowser plugins wrapped
- * themselves in `define(...)` instead; those load and do nothing at all here,
- * with the error swallowed by the console manager. If a plugin seems inert,
- * that is the first thing to check.
- *
- * The game is a canvas, so this cannot reflow the interface the way a web page
- * would. What it can do is the handful of things that stand between a phone
- * and a playable window, and nothing on a desktop.
- *
- * Loaded by name from Config.local.js, which `stack link-assets` generates
- * from whichever mods are installed. Files beside this one are served from
- * `plugins/mobile-ui/`.
- */
+import { componentStyle } from "./styles.js";
 
-/** Is this a screen worth changing anything for? */
-function isHandheld() {
-	// Both halves matter. A phone in landscape is 844 points wide and would
-	// pass a width test; a desktop browser window dragged narrow would fail
-	// one. The touch check is what separates them.
-	const smallSide = Math.min(window.screen.width, window.screen.height);
-	const touch = navigator.maxTouchPoints > 0 || 'ontouchstart' in window;
-	return touch && smallSide <= 900;
+function readLayout(api) {
+  const value = api.preferences.get("layout", {});
+  return {
+    mode: ["auto", "on", "off"].includes(value?.mode) ? value.mode : "auto",
+    scale: Math.max(0.85, Math.min(1.25, Number(value?.scale) || 1)),
+  };
+}
+function usePhone(mode) {
+  return (
+    mode === "on" ||
+    (mode === "auto" &&
+      Math.min(screen.width, screen.height) <= 900 &&
+      (navigator.maxTouchPoints > 0 || "ontouchstart" in window))
+  );
 }
 
-const CSS = `
-	/* Without this the canvas is dragged around instead of the character, and
-	   a two-finger pinch zooms the page rather than the camera. */
-	html, body {
-		overscroll-behavior: none;
-		touch-action: none;
-		-webkit-user-select: none;
-		user-select: none;
-		-webkit-touch-callout: none;
-		-webkit-tap-highlight-color: transparent;
-	}
+export default function mobileUI(parameters, api) {
+  if (api?.version !== 1) throw new Error("mobile-ui requires client API 1");
+  let settings = readLayout(api);
+  const phone = usePhone(settings.mode);
+  const abort = new AbortController();
+  const listen = (node, event, fn, options = {}) =>
+    node.addEventListener(event, fn, { ...options, signal: abort.signal });
+  // A second touch does not reliably generate a compatibility click. Activate
+  // HUD actions on their own pointer release and deduplicate the primary click.
+  const activate = (node, fn) => {
+    const pointers = new Set();
+    let lastTouch = -Infinity;
+    listen(node, "pointerdown", (event) => {
+      if (event.pointerType !== "touch" || node.disabled) return;
+      pointers.add(event.pointerId);
+      node.setPointerCapture(event.pointerId);
+    });
+    listen(node, "pointerup", (event) => {
+      if (!pointers.delete(event.pointerId)) return;
+      lastTouch = event.timeStamp;
+      const box = node.getBoundingClientRect();
+      if (
+        !node.disabled &&
+        event.clientX >= box.left &&
+        event.clientX <= box.right &&
+        event.clientY >= box.top &&
+        event.clientY <= box.bottom
+      )
+        fn(event);
+    });
+    for (const type of ["pointercancel", "lostpointercapture"])
+      listen(node, type, (event) => pointers.delete(event.pointerId));
+    listen(node, "click", (event) => {
+      if (event.detail !== 0 && event.timeStamp - lastTouch < 1000) return;
+      fn(event);
+    });
+  };
+  api.cleanup(() => abort.abort());
+  const owned = new Map();
+  const components = new Map();
+  const rootStyle = document.documentElement.style;
+  const propertyNames = [
+    "--ro-view-width",
+    "--ro-view-height",
+    "--ro-view-top",
+    "--ro-keyboard-height",
+    "--ro-ui-scale",
+  ];
+  const oldProperties = propertyNames.map((name) => [
+    name,
+    rootStyle.getPropertyValue(name),
+  ]);
+  const viewport = () => {
+    const view = window.visualViewport;
+    rootStyle.setProperty("--ro-view-width", `${view?.width || innerWidth}px`);
+    rootStyle.setProperty(
+      "--ro-view-height",
+      `${view?.height || innerHeight}px`,
+    );
+    rootStyle.setProperty("--ro-view-top", `${view?.offsetTop || 0}px`);
+    rootStyle.setProperty(
+      "--ro-keyboard-height",
+      `${Math.max(0, innerHeight - (view?.height || innerHeight) - (view?.offsetTop || 0))}px`,
+    );
+    rootStyle.setProperty("--ro-ui-scale", settings.scale);
+  };
+  if (phone) {
+    const pageStyle = document.createElement("style");
+    pageStyle.textContent =
+      'html,body{overflow:clip!important;width:100%;height:100%;margin:0}.cursor{display:none!important}.ro-background{background-size:cover!important;background-position:center!important}.ro-background[data-ro-tiled="true"]{width:max(100vw,calc(100vh * 4 / 3))!important;height:max(100vh,calc(100vw * 3 / 4))!important;left:50%!important;top:50%!important;transform:translate(-50%,-50%)}';
+    document.head.append(pageStyle);
+    api.cleanup(() => pageStyle.remove());
+  }
+  // Keep a device-sized viewport when a phone user opts into desktop layout.
+  // The generated api.html has no viewport meta; otherwise the browser falls
+  // back to a 980px layout and touch hit testing changes after the reload.
+  if (phone || usePhone("auto")) {
+    viewport();
+    listen(window, "resize", viewport);
+    if (window.visualViewport) {
+      listen(visualViewport, "resize", viewport);
+      listen(visualViewport, "scroll", viewport);
+    }
+    let meta = document.querySelector("meta[name=viewport]");
+    const hadMeta = Boolean(meta),
+      content = meta?.getAttribute("content");
+    if (!meta) {
+      meta = document.createElement("meta");
+      meta.name = "viewport";
+      document.head.append(meta);
+    }
+    meta.content = "width=device-width, initial-scale=1, viewport-fit=cover";
+    api.cleanup(() => {
+      if (hadMeta) meta.setAttribute("content", content || "");
+      else meta.remove();
+    });
+    api.cleanup(() => {
+      for (const [name, value] of oldProperties)
+        if (value) rootStyle.setProperty(name, value);
+        else rootStyle.removeProperty(name);
+    });
+  }
 
-	/* Chat is sized for a monitor an arm's length away. */
-	#chat, .chat, .chatbox, #ChatBox { font-size: 15px !important; }
+  const host = document.createElement("div");
+  host.id = "ragnarok-mobile";
+  const root = host.attachShadow({ mode: "open" });
+  root.innerHTML = `<style>
+ :host{position:fixed;inset:0;pointer-events:none;z-index:1400;font:14px system-ui;color:#fff6df;}
+ button,select,input {font:inherit;} button{pointer-events:auto;touch-action:manipulation;min-width:44px;min-height:44px;border:1px solid #d4bd8688;border-radius:9px;background:#29241fdf;color:#fff4d8;padding:8px 10px;box-sizing:border-box;}
+ button:active{background:#715835;}button:focus-visible{outline:2px solid #edc778;outline-offset:2px;}
+ [hidden]{display:none!important;}
+ .hud{position:absolute;inset:0;pointer-events:none;}
+ .vitals{position:absolute;left:calc(env(safe-area-inset-left) + 8px);top:calc(env(safe-area-inset-top) + 8px);width:calc(100vw - 188px);max-width:230px;border:1px solid #c6b18177;background:#1b1b18da;border-radius:7px;padding:6px;box-sizing:border-box;}
+ .meter{height:7px;background:#080a0d;border-radius:4px;overflow:hidden;margin:3px 0;}.meter>div{height:100%;background:#63bf72;width:0;}#spbar{background:#619cdb;}
+ .values{font-size:11px;line-height:14px;font-variant-numeric:tabular-nums;white-space:nowrap;}
+ #target{font-size:12px;color:#e6cc8d;max-width:220px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;position:absolute;top:68px;left:8px;text-shadow:0 1px 3px #000;}
+ #menuButton{position:absolute;top:calc(env(safe-area-inset-top) + 8px);right:96px;}
+ .actions{position:absolute;right:calc(env(safe-area-inset-right) + 12px);bottom:calc(env(safe-area-inset-bottom) + 16px);display:grid;grid-template-columns:repeat(2,64px);gap:6px;pointer-events:auto;}
+ .actions button{min-height:max(44px,calc(48px * var(--ro-ui-scale,1)));font-size:calc(14px * var(--ro-ui-scale,1));}#attack{grid-row:span 2;background:#6a3924e8;font-weight:600;font-size:16px;}
+ .skills{position:absolute;right:calc(env(safe-area-inset-right) + 12px);bottom:calc(env(safe-area-inset-bottom) + 30px + max(88px,96px * var(--ro-ui-scale,1)));display:flex;gap:5px;pointer-events:auto;}
+ .skills button{width:46px;height:46px;padding:4px;font-size:12px;background:#252c35e8;}
+ .menu{position:absolute;right:8px;top:calc(env(safe-area-inset-top) + 62px);width:min(260px,calc(100vw - 16px));max-height:calc(var(--ro-view-height,100dvh) - 84px);overflow:auto;pointer-events:auto;background:#24221df5;border:1px solid #b4a27e;border-radius:10px;padding:8px;box-sizing:border-box;display:grid;grid-template-columns:1fr 1fr;gap:6px;}
+ #displayButton{position:fixed;right:8px;bottom:8px;z-index:100;}
+ dialog{pointer-events:auto;color:#312b21;background:#fff7e8;border:1px solid #ae976c;border-radius:10px;padding:18px;width:min(330px,calc(100vw - 60px));max-height:calc(var(--ro-view-height,100dvh) - 64px);overflow:auto;font:15px/1.45 system-ui;}
+ dialog::backdrop{background:#0008;}dialog h2{margin:0 0 12px;font-size:22px;}dialog label{display:block;margin:14px 0 5px;}dialog select{width:100%;min-height:44px;}dialog input{width:100%;min-height:44px;}dialog button{background:#59472c;color:#fff8e6;margin:10px 4px 0 0;}dialog p{margin:10px 0;}output{display:block;min-height:20px;}
+ @media(max-height:480px){.skills{right:164px;bottom:20px;}.vitals{width:190px;}.actions{grid-template-columns:repeat(2,60px);}.menu{grid-template-columns:repeat(3,1fr);width:350px;}}
+ </style>
+ <div class="hud" hidden>
+  <div class="vitals" aria-label="Health and skill points"><div class="values" id="hptext"></div><div class="meter"><div id="hpbar"></div></div><div class="values" id="sptext"></div><div class="meter"><div id="spbar"></div></div></div>
+  <div id="target"></div><button id="menuButton" aria-expanded="false">Menu</button>
+  <div class="skills" aria-label="Quick shortcuts">${[1, 2, 3, 4].map((n) => `<button data-shortcut="${n - 1}" aria-label="Use shortcut ${n}">F${n}</button>`).join("")}</div>
+  <div class="actions"><button id="attack">Attack</button><button id="interact">Talk</button><button id="pickup">Pick up</button></div>
+  <nav class="menu" aria-label="Game menu" hidden>
+   ${["Inventory", "Equipment", "Skills", "Quests", "Stats", "Map", "Friends", "Chat", "Target", "Display", "Game options", "Close"].map((name) => `<button data-menu="${name}">${name}</button>`).join("")}
+  </nav>
+ </div>
+ <button id="displayButton" aria-haspopup="dialog">Display</button>
+ <dialog aria-labelledby="displayTitle"><h2 id="displayTitle">Display settings</h2>
+  <label for="layoutMode">Phone layout</label><select id="layoutMode"><option value="auto">Auto — touch screens</option><option value="on">On</option><option value="off">Off — desktop layout</option></select>
+  <label for="uiScale">Control size</label><input id="uiScale" type="range" min="0.85" max="1.25" step="0.05"><output id="scaleValue"></output>
+  <p>Phone and desktop window positions are saved separately. Changing layout mode takes effect when you reload the game.</p><output id="message" aria-live="polite"></output>
+  <button id="reload">Save and reload</button><button id="done">Done</button>
+ </dialog>`;
+  document.body.append(host);
+  api.cleanup(() => host.remove());
+  // Keep both thumbs out of roBrowser's whole-window camera gesture handler.
+  for (const event of [
+    "pointerdown",
+    "pointerup",
+    "mousedown",
+    "mouseup",
+    "touchstart",
+    "touchmove",
+    "touchend",
+    "touchcancel",
+  ]) {
+    listen(root, event, (e) => e.stopPropagation());
+  }
+  let releaseDialog = null;
+  const dialog = root.querySelector("dialog");
+  const save = () => {
+    try {
+      api.preferences.set("layout", settings);
+      root.querySelector("#message").textContent = "Saved on this browser.";
+      return true;
+    } catch {
+      root.querySelector("#message").textContent =
+        "Browser storage is unavailable; changes apply only for this session.";
+      return false;
+    }
+  };
+  const openDisplay = () => {
+    if (dialog.open) return;
+    releaseDialog = api.input.suspend();
+    dialog.showModal();
+  };
+  listen(root.querySelector("#displayButton"), "click", openDisplay);
+  listen(dialog, "close", () => {
+    releaseDialog?.();
+    releaseDialog = null;
+  });
+  api.cleanup(() => releaseDialog?.());
+  root.querySelector("#layoutMode").value = settings.mode;
+  root.querySelector("#uiScale").value = settings.scale;
+  root.querySelector("#scaleValue").textContent =
+    `${Math.round(settings.scale * 100)}%`;
+  listen(root.querySelector("#layoutMode"), "change", (e) => {
+    settings.mode = e.target.value;
+    save();
+  });
+  listen(root.querySelector("#uiScale"), "input", (e) => {
+    settings.scale = Number(e.target.value);
+    root.querySelector("#scaleValue").textContent =
+      `${Math.round(settings.scale * 100)}%`;
+    if (phone) viewport();
+    save();
+  });
+  listen(root.querySelector("#done"), "click", () => dialog.close());
+  listen(root.querySelector("#reload"), "click", () => {
+    if (save()) location.reload();
+  });
+  const menu = root.querySelector(".menu");
+  const toggleMenu = (value) => {
+    menu.hidden = !value;
+    root
+      .querySelector("#menuButton")
+      .setAttribute("aria-expanded", String(value));
+  };
+  listen(root.querySelector("#menuButton"), "click", () =>
+    toggleMenu(menu.hidden),
+  );
+  for (const name of ["attack", "interact", "pickup"])
+    activate(root.querySelector(`#${name}`), () => api.actions.perform(name));
+  for (const button of root.querySelectorAll("[data-shortcut]"))
+    activate(button, () =>
+      api.actions.perform("shortcut", {
+        index: Number(button.dataset.shortcut),
+      }),
+    );
+  for (const button of root.querySelectorAll("[data-menu]"))
+    listen(button, "click", () => {
+      const name = button.dataset.menu;
+      toggleMenu(false);
+      if (name === "Display") {
+        openDisplay();
+        return;
+      }
+      if (name === "Target") {
+        api.actions.perform("target");
+        return;
+      }
+      if (name === "Game options") {
+        api.actions.perform("menu");
+        return;
+      }
+      if (name === "Chat") {
+        const chat = components.get("ChatBox");
+        if (chat) {
+          chat.host.dataset.roChatOpen = "true";
+          chat.root.querySelector(".input-chatbox")?.focus();
+        }
+        return;
+      }
+      const windows = {
+        Inventory: "Inventory",
+        Equipment: "Equipment",
+        Skills: "SkillList",
+        Quests: "Quest",
+        Stats: "WinStats",
+        Map: "WorldMap",
+        Friends: "PartyFriends",
+      };
+      if (windows[name]) api.actions.perform("window", { name: windows[name] });
+    });
+  const setPlaying = (playing) => {
+    root.querySelector(".hud").hidden = !phone || !playing;
+    root.querySelector("#displayButton").hidden = phone && playing;
+    toggleMenu(false);
+  };
+  api.on("map:enter", () => setPlaying(true));
+  api.on("map:leave", () => setPlaying(false));
+  setPlaying(Boolean(api.snapshot().map));
+  const update = () => {
+    if (!phone || document.hidden) return;
+    const state = api.snapshot(),
+      player = state.player;
+    if (!state.map || !player) return;
+    for (const [key, maxKey, label] of [
+      ["hp", "maxHp", "HP"],
+      ["sp", "maxSp", "SP"],
+    ]) {
+      root.querySelector(`#${key}text`).textContent =
+        `${label} ${Math.max(0, player[key])} / ${Math.max(0, player[maxKey])}`;
+      root.querySelector(`#${key}bar`).style.width =
+        `${Math.max(0, Math.min(100, (100 * player[key]) / Math.max(1, player[maxKey])))}%`;
+    }
+    root.querySelector("#target").textContent = state.target?.name || "";
+    const shortcuts = components.get("ShortCut");
+    if (shortcuts)
+      for (const button of root.querySelectorAll("[data-shortcut]")) {
+        const slot = shortcuts.root.querySelector(
+          `.container[data-index="${button.dataset.shortcut}"]`,
+        );
+        const image = slot?.querySelector(".img")?.style.backgroundImage || "";
+        button.style.backgroundImage = image;
+        button.style.backgroundSize = "30px";
+        button.style.backgroundPosition = "center";
+        button.style.backgroundRepeat = "no-repeat";
+        button.textContent = image
+          ? ""
+          : `F${Number(button.dataset.shortcut) + 1}`;
+        button.setAttribute(
+          "aria-label",
+          image
+            ? `Use ${slot.getAttribute("data-tooltip")}`
+            : `Use shortcut ${Number(button.dataset.shortcut) + 1}`,
+        );
+      }
+  };
+  const interval = setInterval(update, 200);
+  api.cleanup(() => clearInterval(interval));
 
-	/* Anything clickable, brought up to the 44px that a thumb can actually
-	   hit. Scoped to buttons so it cannot stretch a layout table. */
-	button, .btn, .ui button, [role="button"] {
-		min-width: 44px !important;
-		min-height: 44px !important;
-	}
-
-	/* The login form is the first thing a phone sees, and its inputs are
-	   16px-or-larger here for a specific reason: iOS Safari zooms the whole
-	   page when it focuses an input with a smaller font, and never zooms back
-	   out. */
-	input[type="text"], input[type="password"] {
-		font-size: 16px !important;
-		min-height: 40px !important;
-	}
-
-	/* Keep the game clear of the notch and the home indicator. */
-	body {
-		padding: env(safe-area-inset-top) env(safe-area-inset-right)
-		         env(safe-area-inset-bottom) env(safe-area-inset-left);
-		box-sizing: border-box;
-	}
-`;
-
-export default function mobileUI() {
-	if (!isHandheld()) {
-		// Returning true either way: the plugin ran and decided there was
-		// nothing to do, which is a success. Returning false would print
-		// "Failed to initialize plugin" on every desktop.
-		return true;
-	}
-
-	// Without this a phone reports a 980px viewport and scales the whole canvas
-	// down to fit it, which is most of what makes the game read as unusably
-	// small before anything else is wrong.
-	const meta = document.querySelector('meta[name=viewport]')
-		|| document.head.appendChild(document.createElement('meta'));
-	meta.name = 'viewport';
-	meta.content = 'width=device-width, initial-scale=1, maximum-scale=1, '
-		+ 'user-scalable=no, viewport-fit=cover';
-
-	const style = document.createElement('style');
-	style.id = 'mobile-ui';
-	style.textContent = CSS;
-	document.head.appendChild(style);
-
-	// roBrowser's own components live in shadow roots, so a stylesheet in the
-	// document head does not reach them. Adopting the same sheet into each one
-	// as it appears is the only way in from outside the bundle.
-	//
-	// The observer is left running: windows are created and destroyed for the
-	// life of the session, not once at startup.
-	const sheet = new CSSStyleSheet();
-	sheet.replaceSync(CSS);
-	const adopt = (root) => {
-		if (root.adoptedStyleSheets && !root.adoptedStyleSheets.includes(sheet)) {
-			root.adoptedStyleSheets = [...root.adoptedStyleSheets, sheet];
-		}
-	};
-	const sweep = () => {
-		document.querySelectorAll('*').forEach((el) => {
-			if (el.shadowRoot) adopt(el.shadowRoot);
-		});
-	};
-	sweep();
-	new MutationObserver(sweep).observe(document.documentElement, {
-		childList: true,
-		subtree: true,
-	});
-
-	return true;
+  function attach(component) {
+    if (!phone) return;
+    const { name, root: ui, host: element } = component;
+    components.set(name, component);
+    if (owned.has(element)) return;
+    const cleanups = [];
+    const localAbort = new AbortController();
+    cleanups.push(() => localAbort.abort());
+    const on = (node, event, fn, options = {}) =>
+      node?.addEventListener(event, fn, {
+        ...options,
+        signal: localAbort.signal,
+      });
+    const attribute = (node, key, value) => {
+      if (!node) return;
+      const old = node.getAttribute(key);
+      node.setAttribute(key, value);
+      cleanups.push(() => {
+        if (old === null) node.removeAttribute(key);
+        else node.setAttribute(key, old);
+      });
+    };
+    const label = (node, text) => {
+      if (!node) return;
+      attribute(node, "aria-label", text);
+      if (node.tagName === "BUTTON" || node.tagName === "UI-BUTTON") {
+        attribute(node, "data-mobile-label", "true");
+        const children = [...node.childNodes];
+        node.textContent = text;
+        cleanups.push(() => node.replaceChildren(...children));
+      }
+      if (node.tagName === "UI-BUTTON") {
+        attribute(node, "role", "button");
+        attribute(node, "tabindex", "0");
+      }
+    };
+    let css = componentStyle(name);
+    if (name === "ChatBox")
+      css +=
+        ":host{display:none!important;}:host([data-ro-chat-open]){display:block!important;}";
+    if (css) {
+      const style = document.createElement("style");
+      style.dataset.mobileStyle = name;
+      style.textContent = css;
+      ui.append(style);
+      cleanups.push(() => style.remove());
+    }
+    const add = (parent, node) => {
+      parent.append(node);
+      cleanups.push(() => node.remove());
+      return node;
+    };
+    const button = (text, fn) => {
+      const node = document.createElement("button");
+      node.className = "ro-mobile-button";
+      node.textContent = text;
+      on(node, "click", fn);
+      return node;
+    };
+    // Touchable controls consume their own gesture; scrollable panels retain
+    // browser scrolling instead of global touch-action:none.
+    for (const event of ["touchstart", "touchmove", "touchend", "touchcancel"])
+      on(ui, event, (e) => e.stopPropagation());
+    if (name === "MobileUI") {
+      const base = ui.querySelector("#joystickBase");
+      attribute(base, "aria-label", "Movement joystick");
+      attribute(base, "role", "group");
+    }
+    if (/^WinLogin/.test(name)) {
+      const container =
+        ui.querySelector("#WinLogin .win_login") ||
+        ui.querySelector("#WinLogin");
+      if (container) {
+        const title = document.createElement("h1");
+        title.className = "ro-mobile-title";
+        title.textContent = "Ragnarok Offline";
+        container.prepend(title);
+        cleanups.push(() => title.remove());
+      }
+      for (const [id, text] of [
+        ["user", "Account"],
+        ["pass", "Password"],
+      ]) {
+        const input = ui.querySelector(`#${id}`);
+        attribute(input, "aria-label", text);
+        attribute(input, "placeholder", text);
+      }
+      label(ui.querySelector(".connect"), "Log in");
+      label(ui.querySelector(".signup"), "Sign up");
+      label(ui.querySelector(".replay"), "Replay");
+    }
+    if (/^CharSelect/.test(name)) {
+      label(ui.querySelector(".cancel"), "Back");
+      label(ui.querySelector(".ok"), "Play");
+      const row = document.createElement("div");
+      row.className = "ro-mobile-toolbar";
+      const continueButton = button("Play / create", () => {
+        const selected =
+          ui.querySelector("canvas[data-ro-selected]") ||
+          ui.querySelector("#slot0");
+        selected?.dispatchEvent(new MouseEvent("dblclick", { bubbles: true }));
+      });
+      add(row, continueButton);
+      add(
+        ui.querySelector(".char_select_container") ||
+          ui.querySelector(".ui-component-root"),
+        row,
+      );
+      for (const canvas of ui.querySelectorAll(".char_canvas canvas")) {
+        attribute(
+          canvas,
+          "aria-label",
+          `Character slot ${Number(canvas.id.replace("slot", "")) + 1}`,
+        );
+        attribute(canvas, "role", "button");
+        attribute(canvas, "tabindex", "0");
+        cleanups.push(() => {
+          delete canvas.dataset.roSelected;
+          canvas.classList.remove("ro-mobile-selected");
+        });
+        on(canvas, "click", () => {
+          ui.querySelectorAll("canvas").forEach((c) => {
+            delete c.dataset.roSelected;
+            c.classList.remove("ro-mobile-selected");
+          });
+          canvas.dataset.roSelected = "true";
+          canvas.classList.add("ro-mobile-selected");
+          canvas.dispatchEvent(
+            new MouseEvent("mousedown", {
+              bubbles: true,
+              button: 0,
+              buttons: 1,
+            }),
+          );
+        });
+      }
+    }
+    if (/^CharCreate/i.test(name)) {
+      label(ui.querySelector(".btn.make"), "Create");
+      label(ui.querySelector(".btn.cancel"), "Back");
+      label(ui.querySelector(".btn.return"), "Return");
+      label(ui.querySelector(".rot_left"), "Rotate left");
+      label(ui.querySelector(".rot_right"), "Rotate right");
+      const input = ui.querySelector("#char_name");
+      attribute(input, "aria-label", "Character name");
+      attribute(input, "placeholder", "Character name");
+    }
+    if (name === "ChatBox") {
+      add(
+        ui.querySelector(".ui-component-root"),
+        button("Close chat", () => {
+          delete element.dataset.roChatOpen;
+          ui.activeElement?.blur();
+        }),
+      );
+      const input = ui.querySelector(".input-chatbox");
+      attribute(input, "aria-label", "Chat message");
+      cleanups.push(() => delete element.dataset.roChatOpen);
+    }
+    if (name === "NpcBox") {
+      label(ui.querySelector(".next"), "Next");
+      label(ui.querySelector(".close"), "Close");
+    }
+    if (name === "Escape") {
+      for (const [selector, text] of [
+        [".resurection", "Resurrect"],
+        [".savepoint", "Return to save point"],
+        [".charselect", "Character selection"],
+        [".graphics", "Graphics"],
+        [".sound", "Sound"],
+        [".hotkey", "Shortcuts"],
+        [".exit", "Log out"],
+        [".cancel", "Return to game"],
+      ])
+        label(ui.querySelector(selector), text);
+    }
+    if (name === "NpcMenu") {
+      label(ui.querySelector(".ok"), "Choose");
+      label(ui.querySelector(".cancel"), "Cancel");
+    }
+    if (name === "Quest") {
+      label(ui.querySelector(".close-quest-container-btn"), "Close");
+      for (const [id, text] of [
+        ["active", "Active"],
+        ["feature", "Story"],
+        ["inactive", "Inactive"],
+        ["cooldown", "Cooldown"],
+      ]) {
+        const tab = ui.querySelector(`#${id}.quest-menu-item`);
+        if (!tab) continue;
+        const children = [...tab.childNodes];
+        tab.textContent = text;
+        attribute(tab, "aria-label", text);
+        attribute(tab, "role", "button");
+        cleanups.push(() => tab.replaceChildren(...children));
+      }
+    }
+    if (/^(Inventory|Equipment|SkillList)/.test(name)) {
+      let selected = null;
+      const toolbar = document.createElement("div");
+      toolbar.className = "ro-mobile-toolbar";
+      const skills = /^SkillList/.test(name);
+      const use = button(
+        /^Equipment/.test(name)
+          ? "Unequip"
+          : skills
+            ? "Use skill"
+            : "Use / equip",
+        () => {
+          if (selected?.isConnected)
+            selected.dispatchEvent(
+              new MouseEvent("dblclick", { bubbles: true }),
+            );
+        },
+      );
+      use.disabled = true;
+      add(toolbar, use);
+      add(
+        toolbar,
+        button("Info", () => {
+          if (selected?.isConnected)
+            selected.dispatchEvent(
+              new MouseEvent("contextmenu", {
+                bubbles: true,
+                cancelable: true,
+              }),
+            );
+        }),
+      );
+      if (!/^Equipment/.test(name)) {
+        const message = document.createElement("output");
+        message.textContent = "Tap an item or skill, then choose an action.";
+        for (let slot = 0; slot < 4; slot++)
+          add(
+            toolbar,
+            button(`Set F${slot + 1}`, () => {
+              const id = Number(selected?.getAttribute("data-index"));
+              const assigned =
+                selected?.isConnected &&
+                api.actions.perform("shortcut:assign", {
+                  slot,
+                  kind: skills ? "skill" : "item",
+                  id,
+                });
+              message.textContent = assigned
+                ? `Assigned to F${slot + 1}.`
+                : "Select an item or a learned skill first.";
+            }),
+          );
+        add(toolbar, message);
+      }
+      add(ui.querySelector(".ui-component-root"), toolbar);
+      on(ui, "click", (event) => {
+        const item = event.target.closest?.(
+          skills ? ".skill[data-index]" : ".item[data-index]",
+        );
+        if (!item) return;
+        selected?.classList.remove("ro-mobile-selected");
+        selected = item;
+        selected.classList.add("ro-mobile-selected");
+        use.disabled = false;
+      });
+      cleanups.push(() => selected?.classList.remove("ro-mobile-selected"));
+    }
+    // Labels for native button controls do not change their visibility/state.
+    for (const [selector, text] of [
+      [".titlebar .close", "Close"],
+      [".btns .cancel", "Cancel"],
+      [".btns .ok", "OK"],
+    ])
+      label(ui.querySelector(selector), text);
+    owned.set(element, () => {
+      for (const cleanup of cleanups.reverse()) cleanup();
+      if (components.get(name)?.host === element) components.delete(name);
+    });
+  }
+  function detach({ host }) {
+    owned.get(host)?.();
+    owned.delete(host);
+  }
+  api.on("ui:append", attach);
+  api.on("ui:remove", detach);
+  api.cleanup(() => {
+    for (const dispose of owned.values()) dispose();
+    owned.clear();
+    components.clear();
+  });
+  return true;
 }

--- a/mods/mobile-ui/client/styles.js
+++ b/mods/mobile-ui/client/styles.js
@@ -7,15 +7,77 @@ export const buttonStyle = `
 }
 ui-button[aria-label] {width:auto!important;white-space:nowrap;}
 .ro-mobile-toolbar {display:flex;gap:6px;padding:8px;flex-wrap:wrap;background:#efe4ca;position:sticky;bottom:0;z-index:20;}
+.ro-mobile-toolbar[hidden]{display:none!important;}
+.ro-mobile-toolbar input[type=number]{width:80px!important;min-height:44px;font:16px system-ui;box-sizing:border-box;}
 .ro-mobile-selected {outline:2px solid #e0ad46!important;outline-offset:-2px;}
 `;
 const safePanel = `
 :host {position:fixed!important;left:max(8px,env(safe-area-inset-left))!important;top:calc(var(--ro-view-top,0px) + 60px)!important;
  max-width:calc(var(--ro-view-width,100vw) - 16px)!important;max-height:calc(var(--ro-view-height,100dvh) - 80px)!important;
- box-sizing:border-box;overflow:auto!important;overscroll-behavior:contain;touch-action:pan-x pan-y;font-size:14px!important;z-index:4000!important;}
+ box-sizing:border-box;overflow:auto!important;overscroll-behavior:contain;touch-action:pan-x pan-y;font-size:14px!important;z-index:calc(4000 + var(--ro-native-z,50))!important;}
 input[type=text],input[type=password],input[type=number],textarea,select {font-size:16px!important;min-height:44px;box-sizing:border-box;}
 `;
 export function componentStyle(name) {
+  if (name === "WinPopup")
+    return `${safePanel}${buttonStyle}
+:host{width:min(360px,calc(var(--ro-view-width,100vw) - 16px))!important;height:auto!important;z-index:5100!important;}
+#win_popup{position:relative!important;width:100%!important;height:auto!important;background:#fff7e8!important;border:1px solid #b4a27e;border-radius:8px;padding:12px;box-sizing:border-box;}
+#win_popup .container,#win_popup .buttonscontainer,#win_popup .btns{position:static!important;width:100%!important;height:auto!important;}
+#win_popup .text{font:16px/1.4 system-ui;padding:4px 0 16px;}
+#win_popup .btns{display:flex;flex-wrap:wrap;gap:6px;}
+#win_popup .btn{position:static!important;flex:1;width:auto!important;margin:0!important;}
+`;
+  if (name === "InputBox")
+    return `${safePanel}${buttonStyle}
+:host{width:min(320px,calc(var(--ro-view-width,100vw) - 16px))!important;height:auto!important;z-index:5100!important;top:calc(var(--ro-view-top,0px) + 72px)!important;}
+#inputbox,#inputbox .border{width:100%!important;height:auto!important;box-sizing:border-box;padding:12px;}
+#inputbox .text{width:100%!important;height:auto!important;font:16px/1.4 system-ui;margin-bottom:8px;}
+#inputbox input{width:100%!important;height:44px!important;padding:8px;margin:0;box-sizing:border-box;}
+#inputbox ui-button{position:static!important;display:block!important;margin-top:8px;}
+`;
+  if (name === "Storage")
+    return `${safePanel}${buttonStyle}
+:host{width:min(420px,calc(var(--ro-view-width,100vw) - 16px))!important;height:auto!important;}
+.ui-component-root{display:flex;flex-direction:column;height:auto!important;}
+#Storage{position:relative!important;width:100%!important;background:#fff7e8;}
+#Storage .titlebar{height:44px!important;display:flex;align-items:center;}
+#Storage .titlebar .text{font:16px system-ui!important;width:auto!important;}
+#Storage .panel table,#Storage .panel tbody,#Storage .panel tr,#Storage .panel td,#Storage .footer{display:block;width:100%!important;box-sizing:border-box;height:auto!important;}
+#Storage .tabs{display:flex!important;flex-wrap:wrap;gap:4px;background:none!important;border:0!important;padding:4px;}
+#Storage .tabs button{flex:1 0 auto;width:auto!important;min-width:44px!important;min-height:44px!important;height:auto!important;}
+#Storage .container{padding:0!important;border:0!important;}
+#Storage .content{width:100%!important;height:220px!important;min-height:100px!important;max-height:32vh;overflow:auto!important;background-image:none!important;background-color:#fff7e8;}
+#Storage .content .item{position:relative!important;display:flex!important;align-items:center;width:100%!important;min-height:48px;box-sizing:border-box;border-bottom:1px solid #d6c7a7;}
+#Storage .content .icon{position:static!important;min-width:32px!important;width:32px!important;height:32px!important;background-position:center;background-repeat:no-repeat;}
+#Storage .content .name,#Storage .content .amount{position:static!important;font:14px system-ui!important;width:auto!important;height:auto!important;margin:0 6px;}
+#Storage .filter-buttons,#Storage .extend,#Storage .item_num{display:none!important;}
+#Storage .footer{padding:8px;background:#efe4ca!important;}
+#Storage .footer .search-container{position:static!important;width:100%!important;display:flex;gap:4px;height:auto!important;padding:0!important;box-sizing:border-box;}
+#Storage .search-input{flex:1;width:0!important;min-width:0;}
+#Storage .search-button{margin:0!important;flex:none;}
+#Storage .footer .close{position:static!important;display:block;margin-top:8px;}
+`;
+  if (name === "NpcStore")
+    return `${safePanel}${buttonStyle}
+:host{width:min(640px,calc(var(--ro-view-width,100vw) - 16px))!important;height:auto!important;}
+.ui-component-root{height:auto!important;}
+#NpcStore{position:relative!important;width:100%!important;height:auto!important;display:flex;flex-direction:column;gap:8px;}
+#NpcStore > div{position:relative!important;inset:auto!important;width:100%!important;height:auto!important;box-sizing:border-box;background:#fff7e8;border:1px solid #bdac86;}
+#NpcStore .titlebar > ui-image,#NpcStore .footer > ui-image{display:none!important;}
+#NpcStore .titlebar,#NpcStore .footer{background-image:none!important;background-color:#e9dec5!important;}
+#NpcStore .titlebar{background:#e9dec5;height:auto!important;min-height:36px;display:flex;align-items:center;font:16px system-ui;}
+#NpcStore .titlebar .text{position:static!important;white-space:normal;padding:6px;}
+#NpcStore .container{padding:0!important;border:0!important;}
+#NpcStore .container > ui-image,#NpcStore .resize{display:none!important;}
+#NpcStore .content{height:160px!important;min-height:60px;max-height:25vh;overflow:auto!important;background-image:none!important;}
+#NpcStore .OutputWindow .content{height:100px!important;max-height:20vh;}
+#NpcStore .content .item{min-height:48px;box-sizing:border-box;border-bottom:1px solid #d5c7a7;}
+#NpcStore .content .item .name{width:calc(100% - 145px)!important;white-space:normal;font:14px/1.3 system-ui;top:8px!important;}
+#NpcStore .footer{height:auto!important;min-height:32px;display:flex;align-items:center;gap:5px;flex-wrap:wrap;padding:6px;box-sizing:border-box;}
+#NpcStore .footer .btn{position:static!important;min-height:44px!important;}
+#NpcStore .footer .total{position:static!important;width:100%;font:14px system-ui;}
+#NpcStore .selectall{min-width:44px;min-height:44px;}
+`;
   if (name === "Escape")
     return `${safePanel}${buttonStyle}
 :host{width:min(340px,calc(var(--ro-view-width,100vw) - 16px))!important;height:auto!important;}
@@ -165,7 +227,7 @@ export function componentStyle(name) {
 `;
   if (name === "NpcBox")
     return `${safePanel}${buttonStyle}
-:host {width:calc(var(--ro-view-width,100vw) - 16px)!important;height:auto!important;top:calc(var(--ro-view-top,0px) + 72px)!important;z-index:5000!important;}
+:host {width:calc(var(--ro-view-width,100vw) - 16px)!important;height:auto!important;top:calc(var(--ro-view-top,0px) + 72px)!important;z-index:calc(4000 + var(--ro-native-z,50))!important;}
 #NpcBox,#NpcBox .border {position:relative!important;width:auto!important;height:auto!important;box-sizing:border-box;}
 #NpcBox .content {width:auto!important;height:auto!important;min-height:100px;max-height:30vh!important;font:16px/1.5 system-ui!important;overflow:auto;}
 #NpcBox .btns {position:relative!important;inset:auto!important;display:flex;justify-content:flex-end;gap:8px;padding-top:8px;}
@@ -173,7 +235,7 @@ export function componentStyle(name) {
 `;
   if (name === "NpcMenu")
     return `${safePanel}${buttonStyle}
-:host {width:calc(var(--ro-view-width,100vw) - 16px)!important;height:auto!important;top:calc(var(--ro-view-top,0px) + var(--ro-view-height,100dvh) * .48)!important;z-index:5100!important;}
+:host {width:calc(var(--ro-view-width,100vw) - 16px)!important;height:auto!important;top:calc(var(--ro-view-top,0px) + var(--ro-view-height,100dvh) * .48)!important;z-index:calc(4000 + var(--ro-native-z,50))!important;}
 #NpcMenu,#NpcMenu .container {position:relative!important;width:auto!important;height:auto!important;box-sizing:border-box;}
 #NpcMenu .middle {max-height:24vh;overflow:auto;}
 #NpcMenu .title,#NpcMenu .content {width:auto!important;height:auto!important;font:16px/1.4 system-ui;}
@@ -182,7 +244,7 @@ export function componentStyle(name) {
 `;
   if (/^Inventory/.test(name))
     return `${safePanel}${buttonStyle}
-:host {width:min(420px,calc(var(--ro-view-width,100vw) - 16px))!important;height:auto!important;z-index:4000!important;}
+:host {width:min(420px,calc(var(--ro-view-width,100vw) - 16px))!important;height:auto!important;z-index:calc(4000 + var(--ro-native-z,50))!important;}
 #InventoryV3 {height:auto!important;min-height:260px;}
 #InventoryV3 .titlebar{min-height:44px!important;height:auto!important;display:flex;align-items:center;justify-content:space-between;}
 #InventoryV3 .titlebar .close{width:64px!important;min-height:44px!important;}
@@ -203,7 +265,7 @@ export function componentStyle(name) {
       name,
     )
   )
-    return `${safePanel}${buttonStyle}
+    return `${safePanel}${buttonStyle}${/^Win(Prompt|MSG|Error|Popup)/.test(name) ? ":host{z-index:5100!important;}" : ""}
 .ui-component-root {min-width:0;}
 .titlebar {min-height:44px!important;height:auto!important;position:sticky!important;top:0;z-index:30;}
 .titlebar .close,.titlebar .base,.titlebar .toggle {min-height:44px!important;min-width:44px!important;background-size:auto!important;}

--- a/mods/mobile-ui/client/styles.js
+++ b/mods/mobile-ui/client/styles.js
@@ -1,0 +1,215 @@
+// Styles are applied only to named native components, through client API 1.
+export const buttonStyle = `
+.ro-mobile-button, ui-button[aria-label], button[data-mobile-label] {
+ min-height:44px!important; min-width:44px!important; box-sizing:border-box; border:1px solid #b4a27e!important;
+ border-radius:6px; background:#f7f0df!important; color:#312a1d; font:14px system-ui!important;
+ padding:9px!important; text-align:center; line-height:24px!important; touch-action:manipulation;
+}
+ui-button[aria-label] {width:auto!important;white-space:nowrap;}
+.ro-mobile-toolbar {display:flex;gap:6px;padding:8px;flex-wrap:wrap;background:#efe4ca;position:sticky;bottom:0;z-index:20;}
+.ro-mobile-selected {outline:2px solid #e0ad46!important;outline-offset:-2px;}
+`;
+const safePanel = `
+:host {position:fixed!important;left:max(8px,env(safe-area-inset-left))!important;top:calc(var(--ro-view-top,0px) + 60px)!important;
+ max-width:calc(var(--ro-view-width,100vw) - 16px)!important;max-height:calc(var(--ro-view-height,100dvh) - 80px)!important;
+ box-sizing:border-box;overflow:auto!important;overscroll-behavior:contain;touch-action:pan-x pan-y;font-size:14px!important;z-index:4000!important;}
+input[type=text],input[type=password],input[type=number],textarea,select {font-size:16px!important;min-height:44px;box-sizing:border-box;}
+`;
+export function componentStyle(name) {
+  if (name === "Escape")
+    return `${safePanel}${buttonStyle}
+:host{width:min(340px,calc(var(--ro-view-width,100vw) - 16px))!important;height:auto!important;}
+#Escape{position:relative!important;width:100%!important;background:#fff7e8!important;box-sizing:border-box;padding:12px;}
+#Escape .top{height:32px!important;}#Escape .top .node{display:none;}
+#Escape .container{display:flex;flex-direction:column;gap:8px;width:auto!important;padding:0!important;}
+#Escape .container button{width:100%!important;height:auto!important;min-height:44px!important;}
+`;
+  if (/^Equipment/.test(name))
+    return `${safePanel}${buttonStyle}
+:host{width:min(420px,calc(var(--ro-view-width,100vw) - 16px))!important;height:auto!important;}
+.ui-component-root{display:flex;flex-direction:column;height:auto!important;width:100%;}
+#EquipmentV4{width:100%!important;background:#fff7e8;}
+#EquipmentV4 .titlebar{width:100%!important;height:44px!important;display:flex;align-items:center;}
+#EquipmentV4 .titlebar .left{flex:1;}#EquipmentV4 .titlebar .clear,#EquipmentV4 .titlebar .base:not(.close){display:none!important;}
+#EquipmentV4 .titlebar .text{width:auto!important;font:16px system-ui!important;}
+#EquipmentV4 .tab-manager{height:auto!important;min-height:44px;overflow:auto;}
+#EquipmentV4 .tab a{min-height:44px;min-width:64px;box-sizing:border-box;padding:12px 3px;}
+#EquipmentV4 .panel{height:auto!important;min-height:240px;}
+#EquipmentV4 table.content{width:100%!important;height:auto!important;min-height:220px;background-image:none!important;}
+#EquipmentV4 .col1,#EquipmentV4 .col3{height:44px!important;min-width:100px;}
+#EquipmentV4 .item{min-height:44px;display:flex;align-items:center;border:1px solid #d5c8ae;box-sizing:border-box;}
+#EquipmentV4 .item span{height:auto!important;min-height:32px;white-space:normal;word-break:normal;font:13px/1.3 system-ui;}
+#EquipmentV4 .view_status{display:none!important;}
+`;
+  if (/^SkillList/.test(name))
+    return `${safePanel}${buttonStyle}
+:host{width:min(480px,calc(var(--ro-view-width,100vw) - 16px))!important;height:auto!important;}
+.ui-component-root{display:flex;flex-direction:column;height:auto!important;width:100%;}
+#SkillListV2{position:relative!important;width:100%!important;box-sizing:border-box;}
+#SkillListV2 .titlebar{height:44px!important;display:flex;align-items:center;justify-content:space-between;}
+#SkillListV2 .titlebar .left{height:auto;}#SkillListV2 .titlebar .clear,#SkillListV2 .titlebar .base:not(.close),#SkillListV2 .view_skill_info{display:none!important;}
+#SkillListV2 .titlebar .text{font:16px system-ui!important;width:auto!important;}
+#SkillListV2 .content{width:100%!important;box-sizing:border-box;height:300px!important;padding:4px!important;}
+#SkillListV2 .contentbig{max-width:100%;overflow:auto;}
+#SkillListV2 .tabs-mini{display:flex;gap:3px;min-height:280px!important;}
+#SkillListV2 .tab-mini{display:contents;}
+#SkillListV2 .tab-label-mini{writing-mode:horizontal-tb!important;text-orientation:mixed;position:static!important;left:0!important;width:auto!important;min-width:44px;height:44px;box-sizing:border-box;padding:12px 6px;margin:0!important;z-index:3;}
+#SkillListV2 .tab-content-mini{top:48px!important;height:calc(100% - 48px)!important;pointer-events:none;}
+#SkillListV2 .tab-switch-mini:checked + label + .tab-content-mini{pointer-events:auto;}
+#SkillListV2 .content table{width:100%;}#SkillListV2 .content .skill{height:52px;}
+#SkillListV2 .levelup,#SkillListV2 .reduce,#SkillListV2 .increase{min-width:44px!important;min-height:44px!important;}
+`;
+  if (name === "Quest")
+    return `${safePanel}${buttonStyle}
+:host{width:min(440px,calc(var(--ro-view-width,100vw) - 16px))!important;height:auto!important;background:#fff7e8;}
+#Quest{width:100%!important;height:auto!important;min-height:320px;}
+#Quest .titlebar{display:flex;flex-direction:column;width:100%!important;height:auto!important;background-image:none!important;}
+#Quest .quest-top-panel{width:100%!important;min-height:44px;align-items:center;font:16px system-ui;}
+#Quest .quest-top-panel-text{margin:8px!important;}
+#Quest .quest-left-panel{height:auto!important;width:100%!important;}
+#Quest .quest-menu{display:flex;width:100%;gap:4px;}
+#Quest .quest-menu-item{height:44px!important;width:auto!important;flex:1;background:#eadfc6!important;text-align:center;line-height:44px;font:14px/44px system-ui;cursor:pointer;}
+#Quest .quest-right-panel{width:100%!important;height:260px!important;max-height:38vh;overflow:auto;}
+#Quest .quest-list,#Quest .quest-item{max-width:100%;box-sizing:border-box;}
+#Quest .quest-bottom-panel{position:relative!important;width:100%!important;height:52px!important;display:flex;align-items:center;justify-content:space-between;}
+#Quest .close-quest-container{position:static!important;margin-left:auto;width:auto!important;height:auto!important;}
+`;
+  if (
+    /^BasicInfo|^MiniMap|^ShortCut$|^StatusIcons$|^MapName$|^CashShopIcon$|^JoystickUI$/.test(
+      name,
+    )
+  )
+    return ":host {display:none!important;}";
+  if (name === "MobileUI")
+    return `
+:host{display:block!important;left:0!important;top:0!important;width:100%!important;height:100%!important;pointer-events:none;z-index:1200!important;}
+#MobileUI > :not(#joystickContainer) {display:none!important;}
+#MobileUI #joystickContainer {display:block!important;visibility:visible!important;position:fixed!important;
+ left:calc(env(safe-area-inset-left) + 18px)!important;bottom:calc(env(safe-area-inset-bottom) + 18px)!important;
+ width:calc(104px * var(--ro-ui-scale,1))!important;height:calc(104px * var(--ro-ui-scale,1))!important;}
+#MobileUI #joystickBase {visibility:visible!important;border:2px solid #e9d5a18c;background:#211c16aa;box-shadow:0 3px 18px #0006;touch-action:none;}
+#MobileUI #joystickThumb {width:44px!important;height:44px!important;background:radial-gradient(circle,#fff7df,#ad925d);pointer-events:none;}
+`;
+  if (/^WinLogin/.test(name))
+    return `${buttonStyle}
+:host {position:fixed!important;top:calc(var(--ro-view-top,0px) + max(12px,(var(--ro-view-height,100dvh) - 344px)/2))!important;
+ left:max(12px,calc((var(--ro-view-width,100vw) - 340px)/2))!important;width:min(340px,calc(var(--ro-view-width,100vw) - 24px))!important;
+ height:auto!important;max-height:calc(var(--ro-view-height,100dvh) - 24px)!important;overflow:auto!important;}
+#WinLogin {position:relative!important;width:100%!important;height:auto!important;background:#fff9ecef;border:1px solid #b4a27e;border-radius:12px;box-sizing:border-box;padding:16px;}
+#WinLogin > ui-image,#WinLogin .win_login > ui-image {display:none!important;}
+#WinLogin .win_login {display:grid;grid-template-columns:1fr 1fr;gap:8px;height:auto!important;width:100%!important;background-image:none!important;background-color:transparent!important;}
+#WinLogin .win_login input,#WinLogin .win_login button,#WinLogin .win_login select {position:static!important;inset:auto!important;box-sizing:border-box;}
+#WinLogin input.user,#WinLogin input.pass {grid-column:1/-1;width:100%!important;min-height:44px!important;font:16px system-ui!important;background:white!important;border:1px solid #b4a27e!important;border-radius:5px;text-align:left!important;padding:10px!important;}
+#WinLogin .connect {grid-column:1/-1;width:100%!important;height:48px!important;background:#59472c!important;color:white;font-weight:bold!important;}
+#WinLogin .save {display:none!important;}
+#WinLogin .btn {width:auto!important;height:auto!important;min-height:44px!important;background:#eee3c9!important;border:1px solid #b4a27e!important;border-radius:5px;color:#312a1d;font:14px system-ui!important;}
+#WinLogin .exit {display:none!important;}
+#WinLogin .connect {background:#59472c!important;color:white!important;}
+#WinLogin .replay {grid-column:2;grid-row:5;}
+#WinLogin .signup {grid-column:1;grid-row:5;}
+.ro-mobile-title {grid-column:1/-1;font:600 22px system-ui;color:#352a1a;margin:0 0 8px;}
+`;
+  if (/^CharSelect/.test(name))
+    return `${buttonStyle}
+:host {position:fixed!important;inset:0!important;width:100%!important;height:100%!important;min-width:0!important;min-height:0!important;overflow:auto!important;}
+#CharSelectV4 {position:relative!important;min-width:0!important;min-height:100%!important;padding:60px 8px 16px;box-sizing:border-box;display:block!important;}
+#CharSelectV4 .char_select_container {position:relative!important;display:flex!important;flex-direction:column!important;max-width:640px;margin:auto;padding:0!important;}
+#CharSelectV4 .char_list {display:grid!important;grid-template-columns:repeat(2,minmax(0,1fr));max-width:none!important;width:100%!important;min-height:200px;height:auto!important;max-height:calc(var(--ro-view-height,100dvh) - 190px)!important;gap:4px;overflow:auto;}
+#CharSelectV4 .char_canvas {width:157px!important;max-width:100%;justify-self:center;}
+#CharSelectV4 .charinfo {display:none!important;}
+#CharSelectV4 .btns {position:sticky!important;bottom:0!important;left:auto!important;right:auto!important;width:auto!important;height:auto!important;display:flex;gap:6px;background:#fff4dd;padding:8px;}
+#CharSelectV4 .btns .btn {position:static!important;}
+#CharSelectV4 .cancel {position:fixed!important;right:8px!important;top:8px!important;z-index:40;}
+#CharSelectV4 .slotinfo,#CharSelectV4 .pageinfo {display:none!important;}
+@media(min-width:600px){#CharSelectV4 .char_list{grid-template-columns:repeat(3,minmax(0,1fr));}}
+`;
+  if (/^CharCreate/i.test(name))
+    return `${safePanel}${buttonStyle}
+:host {width:calc(var(--ro-view-width,100vw) - 16px)!important;max-width:620px!important;height:auto!important;background:#fff7e8;border:1px solid #b4a27e;border-radius:8px;}
+#charcreate_v4 {position:relative!important;display:grid!important;grid-template-columns:1fr!important;gap:12px;width:auto!important;height:auto!important;padding:12px;background:#fff7e8!important;}
+#charcreate_v4 > ui-image {display:none!important;}
+#charcreate_v4 .title,#charcreate_v4 #style,#charcreate_v4 #hair_setting {position:static!important;width:auto!important;height:auto!important;}
+#charcreate_v4 .human_label,#charcreate_v4 .doram_label {position:relative!important;display:flex!important;align-items:center;width:auto!important;min-height:110px;height:auto!important;inset:auto!important;border:1px solid #b4a27e;border-radius:6px;background:#ece3d0!important;margin-bottom:8px;}
+#charcreate_v4 .human_title,#charcreate_v4 .doram_title {position:static!important;color:#32291e!important;width:64px!important;min-width:64px;font-weight:bold;}
+#charcreate_v4 .human_desc,#charcreate_v4 .doram_desc {position:static!important;width:auto!important;height:auto!important;flex:1;}
+#charcreate_v4 .chargen,#charcreate_v4 .chargen_doram {order:-1;min-width:65px;}
+#charcreate_v4 .human canvas,#charcreate_v4 .doram canvas {position:static!important;}
+#charcreate_v4 #style .gender {position:static!important;display:flex;width:auto!important;height:auto!important;gap:8px;}
+#charcreate_v4 #male_container,#charcreate_v4 #female_container {position:static!important;width:90px!important;height:44px!important;}
+#charcreate_v4 .male_button,#charcreate_v4 .female_button {position:static!important;display:block;width:90px!important;height:44px!important;background:#eee2c5!important;border:1px solid #b4a27e;line-height:44px;text-align:center;}
+#charcreate_v4 .male_button::after{content:'Male';}#charcreate_v4 .female_button::after{content:'Female';}
+#charcreate_v4 input:checked + label {outline:2px solid #997634!important;outline-offset:-2px;}
+#charcreate_v4 .model,#charcreate_v4 .model canvas {position:static!important;display:inline-block!important;}
+#charcreate_v4 #style .rot_left,#charcreate_v4 #style .rot_right {position:static!important;vertical-align:bottom;}
+#charcreate_v4 #char_name {position:static!important;display:block;width:100%!important;margin:8px 0;border:1px solid #b4a27e!important;background:white;border-radius:4px;padding:8px;}
+#charcreate_v4 #hair_setting {max-width:100%;overflow:auto;}
+#charcreate_v4 .hair_styles,#charcreate_v4 .hair_colors {position:relative!important;inset:auto!important;max-width:100%;}
+#charcreate_v4 .hair_style_title,#charcreate_v4 .hair_color_title{position:static!important;width:100%!important;height:auto!important;margin:8px 0;font:16px system-ui;}
+#charcreate_v4 .hair-style{position:relative!important;inset:auto!important;height:auto!important;}
+#charcreate_v4 .hairstyle_row,#charcreate_v4 .haircolor_row{inset:auto!important;gap:4px;flex-wrap:wrap;}
+#charcreate_v4 .styleCol,#charcreate_v4 .colorCol{width:44px!important;height:44px!important;min-width:44px;margin:0 0 4px!important;}
+#charcreate_v4 .hstyle_button,#charcreate_v4 .hcolor_button{width:44px!important;height:44px!important;box-sizing:border-box;border:1px solid #b5a580;}
+#charcreate_v4 .btns {position:sticky!important;bottom:-12px;height:auto!important;display:flex;gap:8px;background:#fff7e8;padding:8px 0;z-index:100;}
+#charcreate_v4 .btns .btn {position:static!important;flex:1;}
+`;
+  if (name === "ChatBox")
+    return `${buttonStyle}
+:host{left:8px!important;top:auto!important;bottom:calc(var(--ro-keyboard-height,0px) + env(safe-area-inset-bottom) + 8px)!important;
+ width:calc(var(--ro-view-width,100vw) - 16px)!important;max-height:44vh!important;z-index:3000!important;}
+#chatbox {width:100%!important;max-width:100%!important;background:#171511ed;}
+#chatbox .content {width:100%!important;box-sizing:border-box;max-height:25vh!important;}
+#chatbox .input {display:block!important;width:100%!important;min-height:44px;}
+#chatbox .input input {font:16px system-ui!important;min-height:44px;box-sizing:border-box;}
+#chatbox .input .wrapper,#chatbox .input .message {width:100%!important;}
+#chatbox .battlemode{display:none!important;}
+`;
+  if (name === "NpcBox")
+    return `${safePanel}${buttonStyle}
+:host {width:calc(var(--ro-view-width,100vw) - 16px)!important;height:auto!important;top:calc(var(--ro-view-top,0px) + 72px)!important;z-index:5000!important;}
+#NpcBox,#NpcBox .border {position:relative!important;width:auto!important;height:auto!important;box-sizing:border-box;}
+#NpcBox .content {width:auto!important;height:auto!important;min-height:100px;max-height:30vh!important;font:16px/1.5 system-ui!important;overflow:auto;}
+#NpcBox .btns {position:relative!important;inset:auto!important;display:flex;justify-content:flex-end;gap:8px;padding-top:8px;}
+#NpcBox .btn {position:static!important;min-width:80px!important;}
+`;
+  if (name === "NpcMenu")
+    return `${safePanel}${buttonStyle}
+:host {width:calc(var(--ro-view-width,100vw) - 16px)!important;height:auto!important;top:calc(var(--ro-view-top,0px) + var(--ro-view-height,100dvh) * .48)!important;z-index:5100!important;}
+#NpcMenu,#NpcMenu .container {position:relative!important;width:auto!important;height:auto!important;box-sizing:border-box;}
+#NpcMenu .middle {max-height:24vh;overflow:auto;}
+#NpcMenu .title,#NpcMenu .content {width:auto!important;height:auto!important;font:16px/1.4 system-ui;}
+#NpcMenu .content div {min-height:44px!important;height:auto!important;padding:10px;box-sizing:border-box;}
+#NpcMenu .btn {position:static!important;min-width:88px!important;margin:6px 8px 4px 0;}
+`;
+  if (/^Inventory/.test(name))
+    return `${safePanel}${buttonStyle}
+:host {width:min(420px,calc(var(--ro-view-width,100vw) - 16px))!important;height:auto!important;z-index:4000!important;}
+#InventoryV3 {height:auto!important;min-height:260px;}
+#InventoryV3 .titlebar{min-height:44px!important;height:auto!important;display:flex;align-items:center;justify-content:space-between;}
+#InventoryV3 .titlebar .close{width:64px!important;min-height:44px!important;}
+#InventoryV3 .titlebar .text{font:16px system-ui!important;width:auto!important;}
+#InventoryV3 .middle{flex-direction:column;}
+#InventoryV3 .tabs{flex-direction:row!important;width:100%!important;background:none!important;}
+#InventoryV3 .tabs .tab{writing-mode:horizontal-tb!important;text-orientation:mixed!important;left:0!important;min-width:44px!important;min-height:44px!important;font:14px system-ui!important;transform:none!important;}
+#InventoryV3 .container{padding:0!important;border:0!important;box-shadow:none!important;}
+#InventoryV3 .content{width:100%!important;grid-template-columns:repeat(auto-fill,minmax(44px,1fr))!important;grid-auto-rows:44px!important;min-height:176px!important;max-height:42vh;overflow:auto!important;margin:0!important;background-image:none!important;background-color:#f4eee1!important;}
+#InventoryV3 .titlebar .clear{display:none;}
+#InventoryV3 .titlebar .base:not(.close),#InventoryV3 .extend{display:none!important;}
+#InventoryV3 .titlebar .right{margin-left:auto;}
+#InventoryV3 .content .item{width:44px!important;height:44px!important;border:1px solid #d0c4a6;box-sizing:border-box;}
+#InventoryV3 .content .item .icon{left:9px!important;top:9px!important;}
+`;
+  if (
+    /^(Equipment|Storage|SkillList|Quest|NpcStore|VendingShop|InputBox|WinPrompt|WinMSG|WinError|WinPopup|ItemInfo|ItemSelection|WinStats|PartyFriends)/.test(
+      name,
+    )
+  )
+    return `${safePanel}${buttonStyle}
+.ui-component-root {min-width:0;}
+.titlebar {min-height:44px!important;height:auto!important;position:sticky!important;top:0;z-index:30;}
+.titlebar .close,.titlebar .base,.titlebar .toggle {min-height:44px!important;min-width:44px!important;background-size:auto!important;}
+.content {max-width:100%!important;overflow:auto!important;overscroll-behavior:contain;}
+.tabs button,.item .btn,.btns button {min-height:44px!important;}
+.container .item {min-width:44px!important;min-height:44px!important;}
+`;
+  return "";
+}

--- a/mods/mobile-ui/mod.json
+++ b/mods/mobile-ui/mod.json
@@ -1,7 +1,7 @@
 {
   "name": "mobile-ui",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "author": "Ragnarok Offline",
-  "description": "Makes the client usable on a phone: real viewport, thumb-sized controls, no page zoom. Does nothing on a desktop.",
+  "description": "Phone layout with compact controls, readable game windows, separate desktop positions and per-browser display settings.",
   "requires": { "app": ">=1.0.6", "era": "any" }
 }

--- a/patches/client/ExtensionBridge.mjs
+++ b/patches/client/ExtensionBridge.mjs
@@ -4,6 +4,7 @@ import Runtime from './ExtensionRuntime.mjs';
 import Session from 'Engine/SessionStorage.js';
 import Camera from 'Renderer/Camera.js';
 import Renderer from 'Renderer/Renderer.js';
+import EntityManager from 'Renderer/EntityManager.js';
 import Altitude from 'Renderer/Map/Altitude.js';
 import PathFinding from 'Utils/PathFinding.js';
 import MapControl from 'Controls/MapControl.js';
@@ -27,7 +28,7 @@ function inputState() {
     // while idle. It is not a declaration that the component is a modal.
     const capturing = Object.values(UIManager.components).some(component =>
         (component.isCapturing || component.mouseMode === 2 ||
-            ['ShortCuts', 'WorldMap', 'SkillTargetSelection', 'CaptchaAnswer', 'CaptchaSelector', 'CaptchaUpload'].includes(component.name)) && visible(component));
+            ['Escape', 'ShortCuts', 'WorldMap', 'SkillTargetSelection', 'CaptchaAnswer', 'CaptchaSelector', 'CaptchaUpload'].includes(component.name)) && visible(component));
     const battle = UIManager.components.ChatBox?.getRoot()?.querySelector('.battlemode');
     return {
         canMove: Boolean(player && Runtime.movement.snapshot().active && !document.hidden && !composing && !editing &&
@@ -61,6 +62,13 @@ function component(name) {
 }
 function action(name, value) {
     if (!Runtime.movement.snapshot().active || Session.FreezeUI) return false;
+    if (name === 'menu') {
+        const menu = component('Escape');
+        if (!menu?.onKeyDown) return false;
+        Runtime.movement.clear('menu');
+        menu.onKeyDown({ key: 'Escape', which: KEYS.ESCAPE });
+        return true;
+    }
     if (name === 'window' && WINDOWS.has(value?.name)) {
         const windowUI = component(value.name);
         if (!windowUI?.onShortCut) return false;
@@ -73,6 +81,28 @@ function action(name, value) {
         if (!shortcuts?.onShortCut) return false;
         shortcuts.onShortCut({ cmd: `EXECUTE${value.index}` });
         return true;
+    }
+    if (name === 'shortcut:assign' && Number.isInteger(value?.slot) && value.slot >= 0 && value.slot < 36 && Number.isInteger(value?.id)) {
+        const shortcuts = component('ShortCut');
+        if (!shortcuts) return false;
+        const row = Math.floor(value.slot / 9);
+        if (value.kind === 'item') {
+            const item = component('Inventory')?.getItemByIndex(value.id);
+            if (!item) return false;
+            shortcuts.removeElement(false, item.ITID, row);
+            shortcuts.addElement(value.slot, false, item.ITID, 0);
+            shortcuts.onChange(value.slot, false, item.ITID, 0);
+            return true;
+        }
+        if (value.kind === 'skill') {
+            const skill = shortcuts.getSkillById(value.id);
+            if (!skill || skill.level < 1) return false;
+            const level = Math.max(1, Math.min(skill.level, skill.selectedLevel || skill.level));
+            shortcuts.removeElement(true, skill.SKID, row, level);
+            shortcuts.addElement(value.slot, true, skill.SKID, level);
+            shortcuts.onChange(value.slot, true, skill.SKID, level);
+            return true;
+        }
     }
     const buttons = { attack: '#attackButton', target: '#toggleAutoTargetButton', interact: '#talktonpcButton', pickup: '#pickupButton' };
     if (Object.hasOwn(buttons, name)) {
@@ -102,10 +132,12 @@ export function init() {
         },
         snapshot() {
             const player = Session.Entity;
+            const target = EntityManager.getFocusEntity();
             return { packetVersion: PACKETVER.value, input: inputState(),
                 player: player ? { id: player.GID, position: Array.from(player.position).slice(0, 2), action: player.action,
                     hp: player.life.hp, maxHp: player.life.hp_max, sp: player.life.sp, maxSp: player.life.sp_max } : null,
-                camera: { direction: Camera.direction } };
+                camera: { direction: Camera.direction },
+                target: target ? { id: target.GID, name: target.display?.name || '', hp: target.life?.hp, maxHp: target.life?.hp_max } : null };
         },
         action,
     });

--- a/patches/client/ExtensionBridge.mjs
+++ b/patches/client/ExtensionBridge.mjs
@@ -55,7 +55,7 @@ function destination(position, vector) {
     return null;
 }
 
-const WINDOWS = new Set(['Inventory', 'Equipment', 'SkillList', 'Quest', 'WorldMap', 'PartyFriends', 'WinStats']);
+const WINDOWS = new Set(['Inventory', 'Equipment', 'SkillList', 'Quest', 'WorldMap', 'PartyFriends', 'WinStats', 'Storage']);
 function component(name) {
     // UIManager resolves version aliases (Inventory -> InventoryV3, etc.).
     try { return UIManager.getComponent(name); } catch { return null; }
@@ -71,9 +71,30 @@ function action(name, value) {
     }
     if (name === 'window' && WINDOWS.has(value?.name)) {
         const windowUI = component(value.name);
+        if (value.open && visible(windowUI)) {
+            Runtime.movement.clear('window');
+            windowUI.focus();
+            return true;
+        }
         if (!windowUI?.onShortCut) return false;
         Runtime.movement.clear('window');
         windowUI.onShortCut({ cmd: 'TOGGLE' });
+        return true;
+    }
+    if (name === 'storage:transfer' && Number.isInteger(value?.index)) {
+        const storage = component('Storage');
+        if (!visible(storage)) return false;
+        const deposit = value.direction === 'deposit';
+        if (!deposit && value.direction !== 'withdraw') return false;
+        const item = (deposit ? component('Inventory') : storage)?.getItemByIndex(value.index);
+        if (!item || (deposit && item.WearState)) return false;
+        const maximum = item.count || 1;
+        const count = value.count === 'all' ? maximum : value.count;
+        if (!Number.isInteger(count) || count < 1 || count > maximum) return false;
+        // These are the same callbacks used after the native drag quantity
+        // dialog; the server still authorizes and acknowledges the transfer.
+        if (deposit) storage.reqAddItem(item.index, count);
+        else storage.reqRemoveItem(item.index, count);
         return true;
     }
     if (name === 'shortcut' && Number.isInteger(value?.index) && value.index >= 0 && value.index < 36) {

--- a/patches/client/LayoutProfile.mjs
+++ b/patches/client/LayoutProfile.mjs
@@ -21,10 +21,12 @@ const touch = navigator.maxTouchPoints > 0 || "ontouchstart" in window;
 export const phoneLayout =
   available && (mode === "on" || (mode === "auto" && small && touch));
 export function geometryKey(key, defaults) {
+  // NpcStore creates nested per-shop geometry lazily from an empty default.
   return phoneLayout &&
-    defaults &&
-    Object.hasOwn(defaults, "x") &&
-    Object.hasOwn(defaults, "y")
+    (key === "NpcStore" ||
+      (defaults &&
+        Object.hasOwn(defaults, "x") &&
+        Object.hasOwn(defaults, "y")))
     ? `ragnarok:phone:${key}`
     : key;
 }

--- a/patches/client/LayoutProfile.mjs
+++ b/patches/client/LayoutProfile.mjs
@@ -1,0 +1,30 @@
+// Chosen before UI modules read geometry preferences. A profile switch reloads
+// the page so the old layout is saved to its own bank, never the other device's.
+import Configs from "Core/Configs.js";
+
+let preference = {};
+try {
+  preference =
+    JSON.parse(
+      localStorage.getItem("ragnarok:plugin:mobile-ui:layout") || "{}",
+    ) || {};
+} catch {
+  /* A fresh browser uses automatic detection. */
+}
+const available = Object.hasOwn(Configs.get("plugins") || {}, "mobile-ui");
+export const mobileModAvailable = available;
+const mode = ["auto", "on", "off"].includes(preference.mode)
+  ? preference.mode
+  : "auto";
+const small = Math.min(window.screen.width, window.screen.height) <= 900;
+const touch = navigator.maxTouchPoints > 0 || "ontouchstart" in window;
+export const phoneLayout =
+  available && (mode === "on" || (mode === "auto" && small && touch));
+export function geometryKey(key, defaults) {
+  return phoneLayout &&
+    defaults &&
+    Object.hasOwn(defaults, "x") &&
+    Object.hasOwn(defaults, "y")
+    ? `ragnarok:phone:${key}`
+    : key;
+}

--- a/patches/client/PointerJoystick.mjs
+++ b/patches/client/PointerJoystick.mjs
@@ -44,5 +44,10 @@ export function attachJoystick(base, thumb, movement) {
     }
     // Suppress the compatibility mouse event that would start camera/map input.
     base.addEventListener('mousedown', event => { event.preventDefault(); event.stopPropagation(); }, { signal });
+    // Pointer capture does not stop the compatibility TouchEvent from reaching
+    // the legacy whole-window camera gesture handler.
+    for (const type of ['touchstart', 'touchmove', 'touchend', 'touchcancel']) {
+        base.addEventListener(type, event => event.stopPropagation(), { signal });
+    }
     return () => { source.dispose(); reset(); controller.abort(); };
 }

--- a/scripts/patch-client-controls.py
+++ b/scripts/patch-client-controls.py
@@ -103,3 +103,30 @@ edit('UI/Components/MobileUI/MobileUI.js', 'MobileUI.onAppend = function onAppen
 edit('UI/Components/MobileUI/MobileUI.js', 'MobileUI.onRemove = function onRemove() {\n',
      'MobileUI.onRemove = function onRemove() {\n\tstopJoystick();\n')
 print('installed client extension API and shared movement hooks')
+
+# Phone windows keep their own geometry. Keep legacy desktop keys unchanged.
+edit('Core/Preferences.js', 'const Storage = {',
+     "import { geometryKey } from 'Plugins/Ragnarok/LayoutProfile.mjs';\n\nconst Storage = {")
+edit('Core/Preferences.js', '\tstatic get(key, def, version) {\n',
+     '\tstatic get(key, def, version) {\n\t\tkey = geometryKey(key, def);\n')
+
+# The old first-touch detector can reveal the native HUD after a player opted
+# out. Use the profile selected before login for app-hosted mobile-ui sessions.
+edit('UI/Components/MobileUI/MobileUI.js', "import { attachJoystick } from 'Plugins/Ragnarok/PointerJoystick.mjs';",
+     "import { attachJoystick } from 'Plugins/Ragnarok/PointerJoystick.mjs';\n"
+     "import { phoneLayout, mobileModAvailable } from 'Plugins/Ragnarok/LayoutProfile.mjs';")
+edit('UI/Components/MobileUI/MobileUI.js', '\tif (Session.isTouchDevice) {\n',
+     '\tif (mobileModAvailable ? phoneLayout : Session.isTouchDevice) {\n')
+edit('UI/Components/MobileUI/MobileUI.js', 'MobileUI.show = function show() {\n',
+     'MobileUI.show = function show() {\n\tif (mobileModAvailable && !phoneLayout) return;\n')
+edit('UI/Background.js', "const _container = document.createElement('div');",
+     "const _container = document.createElement('div');\n_container.className = 'ro-background';")
+edit('UI/Background.js', '\tstatic setImage(filename, callback) {\n',
+     "\tstatic setImage(filename, callback) {\n\t\t_container.dataset.roTiled = String(Array.isArray(filename));\n")
+
+# Phone Stats is opened separately from the menu. Desktop Equipment's extra
+# embedded Stats host would otherwise cover the phone equipment controls.
+edit('UI/Components/WinStats/WinStatsCommon.js', "import DB from 'DB/DBManager.js';",
+     "import { phoneLayout } from 'Plugins/Ragnarok/LayoutProfile.mjs';\nimport DB from 'DB/DBManager.js';")
+edit('UI/Components/WinStats/WinStatsCommon.js', '\tComponent.embed = function embed(anchorHost) {\n',
+     '\tComponent.embed = function embed(anchorHost) {\n\t\tif (phoneLayout) return;\n')

--- a/scripts/patch-client-controls.py
+++ b/scripts/patch-client-controls.py
@@ -149,3 +149,79 @@ edit('UI/Components/NpcStore/NpcStore.js', '&& !Session.isTouchDevice) {',
      '&& !Session.isTouchDevice && !phoneLayout) {')
 edit('UI/Components/InputBox/InputBox.js', '\tthis.isPersistent = !!isPersistent;\n',
      "\tthis.isPersistent = !!isPersistent;\n\tconst entry = this.getRoot().querySelector('input');\n\tif (entry) entry.inputMode = ['number', 'price'].includes(type) ? 'numeric' : '';\n")
+
+# The touch pickup action must wait for the same walk-end callback as map clicks.
+edit('UI/Components/MobileUI/MobileUI.js', """function pickUpItem() {
+	const player = Session.Entity;
+
+	if (!player) {
+		return;
+	}
+
+	const closestItem = EntityManager.getClosestEntity(player, Session.Entity.constructor.TYPE_ITEM);
+
+	if (!closestItem) {
+		return;
+	}
+
+	let dx = Math.abs(player.position[0] - closestItem.position[0]);
+	let dy = Math.abs(player.position[1] - closestItem.position[1]);
+	if (dx < 0) {
+		dx = -dx;
+	}
+	if (dy < 0) {
+		dy = -dy;
+	}
+
+	if ((dx < dy ? dy : dx) > 2) {
+		const dest = [0, 0];
+
+		if (checkFreeCell(Math.round(closestItem.position[0]), Math.round(closestItem.position[1]), 1, dest)) {
+			let pkt;
+			if (PACKETVER.value >= 20180307) {
+				pkt = new PACKET.CZ.REQUEST_MOVE2();
+			} else {
+				pkt = new PACKET.CZ.REQUEST_MOVE();
+			}
+			pkt.dest = dest;
+			Network.sendPacket(pkt);
+		}
+	}
+
+	let pickUpPacket;
+
+	if (PACKETVER.value >= 20180307) {
+		pickUpPacket = new PACKET.CZ.ITEM_PICKUP2();
+	} else {
+		pickUpPacket = new PACKET.CZ.ITEM_PICKUP();
+	}
+
+	pickUpPacket.ITAID = closestItem.GID;
+
+	Network.sendPacket(pickUpPacket);
+}""",
+     """function pickUpItem() {
+	const player = Session.Entity;
+	if (!player) return;
+	const closestItem = EntityManager.getClosestEntity(player, Session.Entity.constructor.TYPE_ITEM);
+	if (!closestItem) return;
+
+	const pickup = PACKETVER.value >= 20180307 ? new PACKET.CZ.ITEM_PICKUP2() : new PACKET.CZ.ITEM_PICKUP();
+	pickup.ITAID = closestItem.GID;
+	Session.moveAction = null;
+	const distance = Math.max(Math.abs(player.position[0] - closestItem.position[0]),
+		Math.abs(player.position[1] - closestItem.position[1]));
+	if (distance > 2) {
+		const dest = [0, 0];
+		if (checkFreeCell(Math.round(closestItem.position[0]), Math.round(closestItem.position[1]), 1, dest)) {
+			// RAGNAROK: use the same deferred action as native map-item clicks.
+			// The server rejects pickup while the approach walk is still pending.
+			Session.moveAction = pickup;
+			const move = PACKETVER.value >= 20180307 ? new PACKET.CZ.REQUEST_MOVE2() : new PACKET.CZ.REQUEST_MOVE();
+			move.dest = dest;
+			Network.sendPacket(move);
+		}
+		return;
+	}
+	Network.sendPacket(pickup);
+}""")

--- a/scripts/patch-client-controls.py
+++ b/scripts/patch-client-controls.py
@@ -130,3 +130,22 @@ edit('UI/Components/WinStats/WinStatsCommon.js', "import DB from 'DB/DBManager.j
      "import { phoneLayout } from 'Plugins/Ragnarok/LayoutProfile.mjs';\nimport DB from 'DB/DBManager.js';")
 edit('UI/Components/WinStats/WinStatsCommon.js', '\tComponent.embed = function embed(anchorHost) {\n',
      '\tComponent.embed = function embed(anchorHost) {\n\t\tif (phoneLayout) return;\n')
+
+# Phone CSS offsets native focus ordering above the HUD, without flattening all
+# panels to the same layer or observing style mutations from a plugin.
+edit('UI/GUIComponent.js', '\t\t\tcomp._host.style.zIndex = value;\n',
+     "\t\t\tcomp._host.style.zIndex = value;\n\t\t\tcomp._host.style.setProperty('--ro-native-z', String(value));\n")
+
+# Native data lookup for validated storage actions. The plugin API returns no
+# mutable inventory/storage objects; the adapter alone uses this method.
+edit('UI/Components/Storage/StorageCommon.js', '\tconst _list = [];\n',
+     '\tconst _list = [];\n\tComponent.getItemByIndex = index => _list.find(item => item.index === index);\n')
+
+# The app phone toolbar intentionally selects a shop item without requiring a
+# preceding map touch to enable the upstream touch-device detector.
+edit('UI/Components/NpcStore/NpcStore.js', "import DB from 'DB/DBManager.js';",
+     "import { phoneLayout } from 'Plugins/Ragnarok/LayoutProfile.mjs';\nimport DB from 'DB/DBManager.js';")
+edit('UI/Components/NpcStore/NpcStore.js', '&& !Session.isTouchDevice) {',
+     '&& !Session.isTouchDevice && !phoneLayout) {')
+edit('UI/Components/InputBox/InputBox.js', '\tthis.isPersistent = !!isPersistent;\n',
+     "\tthis.isPersistent = !!isPersistent;\n\tconst entry = this.getRoot().querySelector('input');\n\tif (entry) entry.inputMode = ['number', 'price'].includes(type) ? 'numeric' : '';\n")

--- a/tests/e2e/controls.spec.cjs
+++ b/tests/e2e/controls.spec.cjs
@@ -1,27 +1,7 @@
 const { test, expect } = require('@playwright/test');
 const fs = require('node:fs');
-const path = require('node:path');
-const { control, processIdentity, sha256 } = require('../../electron/asset-server');
+const { verifyWorld, snapshot } = require('./support.cjs');
 
-async function verifyWorld() {
-    if (!process.env.RO_E2E_WORLD) throw new Error('Set RO_E2E_WORLD to a running disposable test world; see docs/TESTING.md');
-    const world = fs.realpathSync(process.env.RO_E2E_WORLD);
-    const marker = JSON.parse(fs.readFileSync(path.join(world, '.ragnarok-e2e.json'), 'utf8'));
-    expect(marker.disposable).toBe(true);
-    const state = fs.realpathSync(path.join(world, 'state'));
-    const record = JSON.parse(fs.readFileSync(path.join(state, 'asset-owner.json'), 'utf8'));
-    const identity = record.identity;
-    expect(identity.stateRoot).toBe(state);
-    expect(identity.httpPort).toBe(3338);
-    const binary = path.join(world, 'runtime/bin', process.platform === 'win32' ? 'robrowser-remoteclient.exe' : 'robrowser-remoteclient');
-    expect(identity.executableDigest).toBe(sha256(fs.readFileSync(binary)));
-    expect(await processIdentity(identity.pid, path.join(world, 'runtime/bin', process.platform === 'win32' ? 'ragnarok-stack.exe' : 'ragnarok-stack'))).toEqual(record.osIdentity);
-    const secret = fs.readFileSync(path.join(state, 'asset-control.secret'), 'utf8').trim();
-    await control(identity, secret, 'status');
-    return { world, identity };
-}
-
-const snapshot = page => page.evaluate(() => window.roClientDiagnostics.snapshot());
 async function login(page) {
     await page.goto('/', { waitUntil: 'domcontentloaded' });
     await page.locator('#user').fill(process.env.RO_E2E_ACCOUNT || 'ragnarok');

--- a/tests/e2e/mobile-actions.spec.cjs
+++ b/tests/e2e/mobile-actions.spec.cjs
@@ -1,0 +1,278 @@
+const { test, expect, devices } = require("@playwright/test");
+const fs = require("node:fs");
+const { verifyWorld, snapshot } = require("./support.cjs");
+const {
+  login,
+  command,
+  inventory,
+  closeInventory,
+  inventoryCounts,
+} = require("./phone.cjs");
+
+test.use({
+  ...devices["Pixel 5"],
+  viewport: { width: 390, height: 844 },
+  screen: { width: 390, height: 844 },
+  deviceScaleFactor: 1,
+  actionTimeout: 10000,
+});
+const messages = async (page) =>
+  (await page.locator("#ChatBox .content").allTextContents()).join("\n");
+const occurrences = (text, pattern) => (text.match(pattern) || []).length;
+
+test("live phone: item healing, shortcut use, one-tap distant pickup and combat", async ({
+  page,
+  context,
+  browser,
+}, testInfo) => {
+  const { identity } = await verifyWorld();
+  const errors = [],
+    consoleErrors = [],
+    failedResponses = [],
+    sockets = [],
+    evidence = {};
+  const redact = (value) => {
+    const password = process.env.RO_E2E_PASSWORD || "ragnarok";
+    return value.split(password).join("[redacted]").slice(0, 1000);
+  };
+  page.on("console", (message) => {
+    if (message.type() === "error") consoleErrors.push(redact(message.text()));
+  });
+  page.on("response", (response) => {
+    if (response.status() >= 400)
+      failedResponses.push({
+        status: response.status(),
+        path: new URL(response.url()).pathname,
+      });
+  });
+  page.on("websocket", (socket) => {
+    const path = new URL(socket.url()).pathname;
+    sockets.push({ event: "open", path });
+    socket.on("close", () => sockets.push({ event: "close", path }));
+  });
+  page.on("pageerror", (error) => errors.push(error.message));
+  await login(page);
+  await context.tracing.start({ screenshots: true, snapshots: true });
+  let cdp;
+  try {
+    await command(page, "@warp prontera 150 190");
+    await command(page, "@cleanmap"); // Remove only old floor loot in this verified disposable town.
+    await command(page, "@heal");
+    const maxHp = (await snapshot(page)).player.maxHp;
+    await inventory(page);
+    const before = await inventoryCounts(page);
+    await closeInventory(page);
+    await command(page, "@item 501 5");
+    await inventory(page);
+    let index;
+    await expect
+      .poll(async () => {
+        const after = await inventoryCounts(page);
+        const matching = Object.keys(after).filter(
+          (key) => after[key] === (before[key] || 0) + 5,
+        );
+        if (matching.length === 1) index = matching[0];
+        return matching.length;
+      })
+      .toBe(1);
+    const initial = (await inventoryCounts(page))[index];
+    const count = async () => (await inventoryCounts(page))[index] || 0;
+    await closeInventory(page);
+    await command(page, "@heal -25");
+    await expect
+      .poll(async () => (await snapshot(page)).player.hp)
+      .toBeLessThan(maxHp - 10);
+    const hurt = (await snapshot(page)).player.hp;
+    await inventory(page);
+    await page
+      .locator(`#InventoryV3 .content .item[data-index="${index}"]`)
+      .tap();
+    await page.getByRole("button", { name: "Use / equip", exact: true }).tap();
+    await expect.poll(count).toBe(initial - 1);
+    await expect
+      .poll(async () => (await snapshot(page)).player.hp)
+      .toBeGreaterThan(hurt);
+    const healed = (await snapshot(page)).player.hp;
+    await page.getByRole("button", { name: "Set F2", exact: true }).tap();
+    await expect(
+      page.getByRole("button", { name: /Use.*F2.*Red Potion/ }),
+    ).toBeVisible();
+    await page.screenshot({
+      path: testInfo.outputPath("item-use-and-shortcut.png"),
+    });
+    await closeInventory(page);
+    await command(page, "@heal -25");
+    await expect
+      .poll(async () => (await snapshot(page)).player.hp)
+      .toBeLessThan(maxHp - 10);
+    const hurtAgain = (await snapshot(page)).player.hp;
+    await page.getByRole("button", { name: /Use.*F2.*Red Potion/ }).tap();
+    await expect.poll(count).toBe(initial - 2);
+    await expect
+      .poll(async () => (await snapshot(page)).player.hp)
+      .toBeGreaterThan(hurtAgain);
+    evidence.items = {
+      initial,
+      hurt,
+      healed,
+      hurtAgain,
+      shortcutHp: (await snapshot(page)).player.hp,
+      afterUse: await count(),
+    };
+
+    // Seed a real floor stack, then use actual joystick touch to leave pickup
+    // range. One tap must both approach and collect, via native walk-end.
+    const droppedAt = (await snapshot(page)).player.position;
+    await command(page, "@dropall 0");
+    await expect.poll(count).toBe(0);
+    cdp = await context.newCDPSession(page);
+    const base = await page.locator("#joystickBase").boundingBox();
+    const start = {
+      id: 1,
+      x: base.x + base.width / 2,
+      y: base.y + base.height / 2,
+      radiusX: 4,
+      radiusY: 4,
+      force: 1,
+    };
+    try {
+      await cdp.send("Input.dispatchTouchEvent", {
+        type: "touchStart",
+        touchPoints: [start],
+      });
+      await cdp.send("Input.dispatchTouchEvent", {
+        type: "touchMove",
+        touchPoints: [{ ...start, y: start.y + 35 }],
+      });
+      await expect
+        .poll(async () =>
+          Math.max(
+            ...(await snapshot(page)).player.position.map((v, i) =>
+              Math.abs(v - droppedAt[i]),
+            ),
+          ),
+        )
+        .toBeGreaterThanOrEqual(6);
+    } finally {
+      await cdp.send("Input.dispatchTouchEvent", {
+        type: "touchEnd",
+        touchPoints: [],
+      });
+    }
+    await page.waitForTimeout(1100); // Let the already accepted short destination finish.
+    const away = await snapshot(page);
+    await page.getByRole("button", { name: "Pick up", exact: true }).tap();
+    // A deliberate new joystick direction must cancel the pending pickup,
+    // just as native click-to-move cancels an earlier queued action.
+    try {
+      await cdp.send("Input.dispatchTouchEvent", {
+        type: "touchStart",
+        touchPoints: [start],
+      });
+      await cdp.send("Input.dispatchTouchEvent", {
+        type: "touchMove",
+        touchPoints: [{ ...start, x: start.x + 35 }],
+      });
+      await expect
+        .poll(async () => (await snapshot(page)).movement.requests)
+        .toBeGreaterThan(away.movement.requests);
+    } finally {
+      await cdp.send("Input.dispatchTouchEvent", {
+        type: "touchEnd",
+        touchPoints: [],
+      });
+    }
+    await page.waitForTimeout(1800);
+    expect(await count()).toBe(0);
+    const cancelled = await snapshot(page);
+    await page.getByRole("button", { name: "Pick up", exact: true }).tap();
+    await expect
+      .poll(async () => {
+        const rows = await inventoryCounts(page);
+        const returned = Object.keys(rows).filter(
+          (key) => rows[key] === initial - 2,
+        );
+        if (returned.length === 1) index = returned[0];
+        return returned.length;
+      })
+      .toBe(1);
+    const collected = await snapshot(page);
+    expect(collected.serverMovement.acknowledgements).toBeGreaterThan(
+      away.serverMovement.acknowledgements,
+    );
+    evidence.pickup = {
+      droppedAt,
+      away,
+      cancelled,
+      collected,
+      restoredCount: await count(),
+    };
+    await page.screenshot({ path: testInfo.outputPath("distant-pickup.png") });
+
+    const oldMessages = await messages(page);
+    await command(page, "@monster 1002 1");
+    await expect.poll(() => messages(page)).toContain("All monsters summoned!");
+    await page.getByRole("button", { name: "Attack", exact: true }).tap();
+    await expect
+      .poll(async () => (await snapshot(page)).target?.name)
+      .toBe("Poring");
+    const target = (await snapshot(page)).target;
+    await page.screenshot({ path: testInfo.outputPath("poring-target.png") });
+    // These native battle messages are generated by received server action
+    // and experience packets. A delivered click or unknown monster HP=-1
+    // cannot, on its own, prove that an attack or kill happened.
+    await expect
+      .poll(
+        async () => occurrences(await messages(page), /\[Poring\] receives/g),
+        { timeout: 30000 },
+      )
+      .toBeGreaterThan(occurrences(oldMessages, /\[Poring\] receives/g));
+    await expect
+      .poll(async () => occurrences(await messages(page), /Base exp points/g), {
+        timeout: 30000,
+      })
+      .toBeGreaterThan(occurrences(oldMessages, /Base exp points/g));
+    await expect.poll(async () => (await snapshot(page)).target).toBe(null);
+    evidence.combat = {
+      target,
+      after: await snapshot(page),
+      messages: await messages(page),
+    };
+    await page.screenshot({ path: testInfo.outputPath("after-combat.png") });
+    await command(page, "@delitem 501 3");
+    await expect.poll(count).toBe(initial - 5);
+    await command(page, "@heal");
+    await command(page, "@warp prontera 150 180");
+    expect(errors).toEqual([]);
+  } finally {
+    await cdp
+      ?.send("Input.dispatchTouchEvent", {
+        type: "touchCancel",
+        touchPoints: [],
+      })
+      .catch(() => {});
+    await page
+      .screenshot({ path: testInfo.outputPath("final-state.png") })
+      .catch(() => {});
+    fs.writeFileSync(
+      testInfo.outputPath("report.json"),
+      JSON.stringify(
+        {
+          identity,
+          browser: browser.version(),
+          viewport: page.viewportSize(),
+          evidence,
+          errors,
+          consoleErrors,
+          failedResponses,
+          sockets,
+        },
+        null,
+        2,
+      ),
+    );
+    await context.tracing.stop({
+      path: testInfo.outputPath("actions-trace.zip"),
+    });
+  }
+});

--- a/tests/e2e/mobile-commerce.spec.cjs
+++ b/tests/e2e/mobile-commerce.spec.cjs
@@ -1,0 +1,359 @@
+const { test, expect, devices } = require("@playwright/test");
+const fs = require("node:fs");
+const { verifyWorld, snapshot } = require("./support.cjs");
+
+test.use({ ...devices["Pixel 5"], deviceScaleFactor: 1, actionTimeout: 10000 });
+
+async function login(page) {
+  await page.goto("/");
+  await page
+    .getByLabel("Account", { exact: true })
+    .fill(process.env.RO_E2E_ACCOUNT || "ragnarok");
+  await page
+    .getByLabel("Password", { exact: true })
+    .fill(process.env.RO_E2E_PASSWORD || "ragnarok");
+  await page.getByRole("button", { name: "Log in", exact: true }).tap();
+  await page
+    .getByRole("button", { name: "Character slot 1", exact: true })
+    .tap();
+  await page.getByRole("button", { name: "Play / create", exact: true }).tap();
+  await expect
+    .poll(async () => (await snapshot(page)).input.canMove)
+    .toBe(true);
+}
+async function menu(page, name) {
+  await page.getByRole("button", { name: "Menu", exact: true }).tap();
+  await page.getByRole("button", { name, exact: true }).tap();
+}
+async function command(page, value) {
+  await menu(page, "Chat");
+  await page.getByLabel("Chat message", { exact: true }).fill(value);
+  await page.keyboard.press("Enter");
+  const close = page.getByRole("button", { name: "Close chat", exact: true });
+  if (value.startsWith("@warp ")) {
+    // Map transitions rebuild ChatBox and hide the phone chat. Wait for that
+    // lifecycle change before touching controls on the destination map.
+    await expect(close).toBeHidden();
+    await expect
+      .poll(async () => (await snapshot(page)).input.canMove)
+      .toBe(true);
+  } else await close.tap();
+}
+async function inventory(page) {
+  await menu(page, "Inventory");
+  await page
+    .locator("#InventoryV3 .tabs .tab")
+    .filter({ hasText: /^Use$/ })
+    .tap();
+}
+const closeInventory = (page) =>
+  page
+    .locator("#InventoryV3")
+    .getByRole("button", { name: "Close", exact: true })
+    .tap();
+const items = (page) =>
+  page
+    .locator("#InventoryV3 .content .item")
+    .evaluateAll((elements) =>
+      Object.fromEntries(
+        elements.map((item) => [
+          item.dataset.index,
+          Number(item.querySelector(".count").textContent),
+        ]),
+      ),
+    );
+const zeny = async (page) =>
+  Number(
+    (await page.locator(".zeny_value").first().textContent()).replace(
+      /[^0-9]/g,
+      "",
+    ),
+  );
+const storedCount = async (page) => {
+  const potion = page
+    .locator("#Storage .content .item")
+    .filter({ hasText: "Red Potion" });
+  return (await potion.count())
+    ? Number(await potion.locator(".count").textContent())
+    : 0;
+};
+
+for (const [name, viewport] of [
+  ["portrait", { width: 390, height: 844 }],
+  ["landscape", { width: 800, height: 360 }],
+]) {
+  test.describe(name, () => {
+    test.use({ viewport, screen: viewport });
+    test("live phone: storage conservation, quantity rejection and NPC buy/sell", async ({
+      page,
+      context,
+    }, testInfo) => {
+      const { identity } = await verifyWorld();
+      const errors = [],
+        evidence = {};
+      page.on("pageerror", (error) => errors.push(error.message));
+      await login(page);
+      await context.tracing.start({ screenshots: true, snapshots: true });
+      try {
+        // The marker/ownership check above is required before these real
+        // GM fixture commands. Never assign player state or mock packets.
+        await inventory(page);
+        const before = await items(page);
+        await closeInventory(page);
+        await command(page, "@item 501 10");
+        await inventory(page);
+        let potionIndex;
+        await expect
+          .poll(async () => {
+            const after = await items(page);
+            const changed = Object.keys(after).filter(
+              (index) => after[index] === (before[index] || 0) + 10,
+            );
+            if (changed.length === 1) potionIndex = changed[0];
+            return changed.length;
+          })
+          .toBe(1);
+        const count = async () => (await items(page))[potionIndex] || 0;
+        const initial = await count();
+        await closeInventory(page);
+        await command(page, "@storage");
+        await expect(
+          page.getByRole("button", { name: "Open inventory", exact: true }),
+        ).toBeVisible();
+        const stored = await storedCount(page);
+        await page
+          .getByRole("button", { name: "Open inventory", exact: true })
+          .tap();
+        const potion = page.locator(
+          `#InventoryV3 .content .item[data-index="${potionIndex}"]`,
+        );
+        await potion.tap();
+        await page
+          .getByLabel("Deposit quantity", { exact: true })
+          .fill(String(initial + 1));
+        await page.getByRole("button", { name: "Deposit", exact: true }).tap();
+        await expect(
+          page.locator("#InventoryV3 .ro-storage-controls output"),
+        ).toContainText("Choose an available quantity");
+        expect(await count()).toBe(initial);
+        expect(await storedCount(page)).toBe(stored);
+        await page.getByLabel("Deposit quantity", { exact: true }).fill("2");
+        await page.getByRole("button", { name: "Deposit", exact: true }).tap();
+        await expect.poll(count).toBe(initial - 2);
+        await expect.poll(() => storedCount(page)).toBe(stored + 2);
+        await page.screenshot({
+          path: testInfo.outputPath("inventory-deposit.png"),
+        });
+        await page
+          .getByRole("button", { name: "Back to storage", exact: true })
+          .tap();
+        await page
+          .locator("#Storage .content .item")
+          .filter({ hasText: "Red Potion" })
+          .tap();
+        await page.getByLabel("Withdraw quantity", { exact: true }).fill("2");
+        await page.getByRole("button", { name: "Withdraw", exact: true }).tap();
+        await expect.poll(() => storedCount(page)).toBe(stored);
+        await expect.poll(count).toBe(initial);
+        await page.screenshot({
+          path: testInfo.outputPath("storage-withdraw.png"),
+        });
+        await page
+          .getByRole("button", { name: "Open inventory", exact: true })
+          .tap();
+        await potion.tap();
+        await page
+          .getByRole("button", { name: "Deposit all", exact: true })
+          .tap();
+        await expect.poll(count).toBe(0);
+        await expect.poll(() => storedCount(page)).toBe(stored + initial);
+        await page
+          .getByRole("button", { name: "Back to storage", exact: true })
+          .tap();
+        await page
+          .locator("#Storage .content .item")
+          .filter({ hasText: "Red Potion" })
+          .tap();
+        await page
+          .getByRole("button", { name: "Withdraw all", exact: true })
+          .tap();
+        await expect.poll(() => storedCount(page)).toBe(0);
+        // The server may reuse a different inventory slot after a whole stack
+        // was removed. Identify the returned stack through its acknowledged count.
+        await expect
+          .poll(async () => {
+            const rows = await items(page);
+            const matching = Object.keys(rows).filter(
+              (index) => rows[index] === initial + stored,
+            );
+            if (matching.length === 1) potionIndex = matching[0];
+            return matching.length;
+          })
+          .toBe(1);
+        if (stored > 0) {
+          await page
+            .getByRole("button", { name: "Open inventory", exact: true })
+            .tap();
+          await page
+            .locator(`#InventoryV3 .content .item[data-index="${potionIndex}"]`)
+            .tap();
+          await page
+            .getByLabel("Deposit quantity", { exact: true })
+            .fill(String(stored));
+          await page
+            .getByRole("button", { name: "Deposit", exact: true })
+            .tap();
+          await expect.poll(count).toBe(initial);
+          await expect.poll(() => storedCount(page)).toBe(stored);
+          await page
+            .getByRole("button", { name: "Back to storage", exact: true })
+            .tap();
+        }
+        await page
+          .getByRole("button", { name: "Close storage", exact: true })
+          .tap();
+        await expect(
+          page.getByLabel("Deposit quantity", { exact: true }),
+        ).toBeHidden();
+        await closeInventory(page);
+        evidence.storage = {
+          initial,
+          stored,
+          deposited: 2,
+          withdrawn: 2,
+          wholeStackDeposit: initial,
+          wholeStackWithdraw: initial + stored,
+          restoredStorage: stored,
+          final: initial,
+        };
+
+        await expect(page.locator("#NpcStore")).toHaveCount(0);
+        const originalZeny = await zeny(page);
+        await command(page, "@zeny 10000");
+        await expect.poll(() => zeny(page)).toBe(originalZeny + 10000);
+        await command(page, "@warp prt_in 126 74");
+        await expect
+          .poll(async () => (await snapshot(page)).map)
+          .toBe("prt_in.gat");
+        await expect
+          .poll(async () =>
+            Math.round((await snapshot(page)).player.position[1]),
+          )
+          .toBe(74);
+        // This is the pinned renewal tool dealer at prt_in (126,76).
+        await page.getByRole("button", { name: "Talk", exact: true }).tap();
+        await page.getByRole("button", { name: "Buy", exact: true }).tap();
+        const store = page.locator("#NpcStore");
+        const shopPotion = store
+          .locator(".InputWindow .item")
+          .filter({ hasText: "Red Potion" });
+        await shopPotion.tap();
+        const price = Number(
+          (await shopPotion.locator(".price").textContent()).replace(
+            /[^0-9]/g,
+            "",
+          ),
+        );
+        const beforeBuy = await zeny(page);
+        await page
+          .getByRole("button", { name: "Add selected", exact: true })
+          .tap();
+        await expect(page.getByLabel("Value", { exact: true })).toHaveAttribute(
+          "inputmode",
+          "numeric",
+        );
+        expect((await snapshot(page)).input.canMove).toBe(false);
+        await page.screenshot({
+          path: testInfo.outputPath("shop-quantity.png"),
+        });
+        await page.getByLabel("Value", { exact: true }).fill("2");
+        await page
+          .locator("#InputBox")
+          .getByRole("button", { name: "OK", exact: true })
+          .tap();
+        await expect(store.locator(".OutputWindow .item")).toContainText(
+          "Red Potion",
+        );
+        await page.screenshot({ path: testInfo.outputPath("shop-cart.png") });
+        await page.getByRole("button", { name: "Buy", exact: true }).tap();
+        await expect(store).toHaveCount(0);
+        await expect.poll(() => zeny(page)).toBe(beforeBuy - price * 2);
+        await inventory(page);
+        await expect.poll(count).toBe(initial + 2);
+        await closeInventory(page);
+
+        await page.getByRole("button", { name: "Talk", exact: true }).tap();
+        await page.getByRole("button", { name: "Sell", exact: true }).tap();
+        const sellPotion = store
+          .locator(".InputWindow .item")
+          .filter({ hasText: "Red Potion" });
+        await sellPotion.tap();
+        const sellPrice = Number(
+          (await sellPotion.locator(".price").textContent()).replace(
+            /[^0-9]/g,
+            "",
+          ),
+        );
+        const beforeSell = await zeny(page);
+        await page
+          .getByRole("button", { name: "Add selected", exact: true })
+          .tap();
+        await page.getByLabel("Value", { exact: true }).fill("1");
+        await page
+          .locator("#InputBox")
+          .getByRole("button", { name: "OK", exact: true })
+          .tap();
+        await page.getByRole("button", { name: "Sell", exact: true }).tap();
+        await expect(store).toHaveCount(0);
+        await expect.poll(() => zeny(page)).toBe(beforeSell + sellPrice);
+        await inventory(page);
+        await expect.poll(count).toBe(initial + 1);
+        await page.screenshot({
+          path: testInfo.outputPath("inventory-after-buy-sell.png"),
+        });
+        evidence.shop = {
+          price,
+          beforeBuy,
+          purchased: 2,
+          sellPrice,
+          sold: 1,
+          finalCount: await count(),
+          finalZeny: await zeny(page),
+        };
+        const preferences = await page.evaluate(() => ({
+          desktop: localStorage.getItem("NpcStore"),
+          phone: localStorage.getItem("ragnarok:phone:NpcStore"),
+        }));
+        expect(preferences.desktop).toBe(null);
+        expect(preferences.phone).not.toBe(null);
+        evidence.shop.preferences = preferences;
+        await closeInventory(page);
+        // Successful runs restore the fixture's item and money changes so
+        // repeating the suite cannot eventually overload the character.
+        await command(page, "@delitem 501 11");
+        await inventory(page);
+        await expect.poll(count).toBe(initial - 10);
+        await closeInventory(page);
+        await command(page, `@zeny ${originalZeny - (await zeny(page))}`);
+        await expect.poll(() => zeny(page)).toBe(originalZeny);
+        evidence.restored = { items: initial - 10, zeny: originalZeny, stored };
+        await command(page, "@warp prontera 150 180");
+        await expect
+          .poll(async () => (await snapshot(page)).map)
+          .toBe("prontera.gat");
+        expect(errors).toEqual([]);
+      } finally {
+        await page
+          .screenshot({ path: testInfo.outputPath("final-state.png") })
+          .catch(() => {});
+        fs.writeFileSync(
+          testInfo.outputPath("report.json"),
+          JSON.stringify({ identity, evidence, errors }, null, 2),
+        );
+        await context.tracing.stop({
+          path: testInfo.outputPath("commerce-trace.zip"),
+        });
+      }
+    });
+  });
+}

--- a/tests/e2e/mobile-commerce.spec.cjs
+++ b/tests/e2e/mobile-commerce.spec.cjs
@@ -4,64 +4,15 @@ const { verifyWorld, snapshot } = require("./support.cjs");
 
 test.use({ ...devices["Pixel 5"], deviceScaleFactor: 1, actionTimeout: 10000 });
 
-async function login(page) {
-  await page.goto("/");
-  await page
-    .getByLabel("Account", { exact: true })
-    .fill(process.env.RO_E2E_ACCOUNT || "ragnarok");
-  await page
-    .getByLabel("Password", { exact: true })
-    .fill(process.env.RO_E2E_PASSWORD || "ragnarok");
-  await page.getByRole("button", { name: "Log in", exact: true }).tap();
-  await page
-    .getByRole("button", { name: "Character slot 1", exact: true })
-    .tap();
-  await page.getByRole("button", { name: "Play / create", exact: true }).tap();
-  await expect
-    .poll(async () => (await snapshot(page)).input.canMove)
-    .toBe(true);
-}
-async function menu(page, name) {
-  await page.getByRole("button", { name: "Menu", exact: true }).tap();
-  await page.getByRole("button", { name, exact: true }).tap();
-}
-async function command(page, value) {
-  await menu(page, "Chat");
-  await page.getByLabel("Chat message", { exact: true }).fill(value);
-  await page.keyboard.press("Enter");
-  const close = page.getByRole("button", { name: "Close chat", exact: true });
-  if (value.startsWith("@warp ")) {
-    // Map transitions rebuild ChatBox and hide the phone chat. Wait for that
-    // lifecycle change before touching controls on the destination map.
-    await expect(close).toBeHidden();
-    await expect
-      .poll(async () => (await snapshot(page)).input.canMove)
-      .toBe(true);
-  } else await close.tap();
-}
-async function inventory(page) {
-  await menu(page, "Inventory");
-  await page
-    .locator("#InventoryV3 .tabs .tab")
-    .filter({ hasText: /^Use$/ })
-    .tap();
-}
-const closeInventory = (page) =>
-  page
-    .locator("#InventoryV3")
-    .getByRole("button", { name: "Close", exact: true })
-    .tap();
-const items = (page) =>
-  page
-    .locator("#InventoryV3 .content .item")
-    .evaluateAll((elements) =>
-      Object.fromEntries(
-        elements.map((item) => [
-          item.dataset.index,
-          Number(item.querySelector(".count").textContent),
-        ]),
-      ),
-    );
+const {
+  login,
+  menu,
+  command,
+  inventory,
+  closeInventory,
+  inventoryCounts: items,
+} = require("./phone.cjs");
+
 const zeny = async (page) =>
   Number(
     (await page.locator(".zeny_value").first().textContent()).replace(

--- a/tests/e2e/mobile-layout.spec.cjs
+++ b/tests/e2e/mobile-layout.spec.cjs
@@ -1,0 +1,144 @@
+const { test, expect, devices } = require("@playwright/test");
+const fs = require("node:fs");
+const { verifyWorld, snapshot } = require("./support.cjs");
+
+const profiles = [
+  { name: "desktop", width: 1440, height: 900 },
+  { name: "phone390", width: 390, height: 844, touch: true },
+  { name: "phone360", width: 360, height: 800, touch: true },
+  { name: "landscape844", width: 844, height: 390, touch: true },
+  { name: "landscape800", width: 800, height: 360, touch: true },
+  { name: "tablet", width: 768, height: 1024, touch: true },
+];
+for (const profile of profiles)
+  test(`live layout: ${profile.name}`, async ({ browser }, testInfo) => {
+    const { identity } = await verifyWorld();
+    const context = await browser.newContext({
+      ...(profile.touch ? devices["Pixel 5"] : {}),
+      viewport: { width: profile.width, height: profile.height },
+      screen: { width: profile.width, height: profile.height },
+      deviceScaleFactor: 1,
+    });
+    const page = await context.newPage();
+    page.setDefaultTimeout(15000);
+    const report = {
+      profile,
+      browser: browser.version(),
+      identity,
+      errors: [],
+      consoleErrors: [],
+      responses: [],
+      sockets: [],
+      screens: [],
+    };
+    page.on("pageerror", (error) => report.errors.push(error.message));
+    page.on("console", (message) => {
+      if (message.type() === "error")
+        report.consoleErrors.push(message.text().slice(0, 700));
+    });
+    page.on("response", (response) => {
+      if (response.status() >= 400)
+        report.responses.push({
+          status: response.status(),
+          path: new URL(response.url()).pathname,
+        });
+    });
+    page.on("websocket", (socket) => {
+      const pathname = new URL(socket.url()).pathname;
+      report.sockets.push({ event: "open", path: pathname });
+      socket.on("close", () =>
+        report.sockets.push({ event: "close", path: pathname }),
+      );
+    });
+    const press = (locator) =>
+      profile.touch ? locator.tap() : locator.click();
+    const capture = async (name) => {
+      await page.waitForTimeout(600);
+      await page.screenshot({ path: testInfo.outputPath(`${name}.png`) });
+      report.screens.push(name);
+    };
+    const fit = async (locator) => {
+      const box = await locator.boundingBox();
+      expect(box).toBeTruthy();
+      expect(box.x).toBeGreaterThanOrEqual(-1);
+      expect(box.y).toBeGreaterThanOrEqual(-1);
+      expect(box.x + box.width).toBeLessThanOrEqual(profile.width + 1);
+      expect(box.y + box.height).toBeLessThanOrEqual(profile.height + 1);
+    };
+    try {
+      await page.goto("http://127.0.0.1:3338/");
+      await page.locator("#user").waitFor();
+      await capture("login");
+      if (profile.touch) await fit(page.locator("body > [id^=WinLogin]"));
+      await page
+        .locator("#user")
+        .fill(process.env.RO_E2E_ACCOUNT || "ragnarok");
+      await page
+        .locator("#pass")
+        .fill(process.env.RO_E2E_PASSWORD || "ragnarok");
+      await press(page.locator(".connect"));
+      await page.locator("#slot0").waitFor();
+      await capture("characters");
+      // Inspect creation without populating additional slots on every run.
+      // The disposable fixture keeps slot 3 empty; this is not a user save.
+      if (profile.touch) {
+        await page
+          .getByRole("button", { name: "Character slot 3", exact: true })
+          .tap();
+        await page
+          .getByRole("button", { name: "Play / create", exact: true })
+          .tap();
+        await page.getByLabel("Character name", { exact: true }).waitFor();
+        await capture("creation");
+        await fit(page.locator("body > #CharCreatev4"));
+        const create = page.getByRole("button", {
+          name: "Create",
+          exact: true,
+        });
+        await create.scrollIntoViewIfNeeded();
+        await fit(create);
+        const size = await create.boundingBox();
+        expect(size.height).toBeGreaterThanOrEqual(44);
+        await page.getByRole("button", { name: "Cancel", exact: true }).tap();
+        await page
+          .getByRole("button", { name: "Character slot 1", exact: true })
+          .tap();
+        await page
+          .getByRole("button", { name: "Play / create", exact: true })
+          .tap();
+      } else await page.locator("#slot0").dblclick();
+      await expect.poll(async () => (await snapshot(page)).map).toBeTruthy();
+      await context.tracing.start({ screenshots: true, snapshots: true });
+      await capture("map");
+      report.state = await snapshot(page);
+      if (profile.touch) {
+        for (const name of ["Attack", "Talk", "Pick up", "Menu"]) {
+          const button = page.getByRole("button", { name, exact: true });
+          await fit(button);
+          const box = await button.boundingBox();
+          expect(box.height).toBeGreaterThanOrEqual(44);
+          expect(box.width).toBeGreaterThanOrEqual(44);
+        }
+        await page.getByRole("button", { name: "Menu", exact: true }).tap();
+        await page
+          .getByRole("button", { name: "Inventory", exact: true })
+          .tap();
+        await capture("inventory");
+        await fit(page.locator("body > #InventoryV3"));
+        await page.locator("#InventoryV3 .close").tap();
+      } else
+        await expect(
+          page.getByRole("button", { name: "Attack", exact: true }),
+        ).not.toBeVisible();
+      await context.tracing.stop({
+        path: testInfo.outputPath("layout-trace.zip"),
+      });
+      expect(report.errors).toEqual([]);
+    } finally {
+      fs.writeFileSync(
+        testInfo.outputPath("report.json"),
+        JSON.stringify(report, null, 2),
+      );
+      await context.close();
+    }
+  });

--- a/tests/e2e/mobile-preferences.spec.cjs
+++ b/tests/e2e/mobile-preferences.spec.cjs
@@ -1,0 +1,102 @@
+const { test, expect, devices } = require("@playwright/test");
+const { verifyWorld, snapshot } = require("./support.cjs");
+test.use({
+  ...devices["Pixel 5"],
+  viewport: { width: 390, height: 844 },
+  screen: { width: 390, height: 844 },
+  deviceScaleFactor: 1,
+});
+
+async function login(page, phone) {
+  await page.locator("#user").fill(process.env.RO_E2E_ACCOUNT || "ragnarok");
+  await page.locator("#pass").fill(process.env.RO_E2E_PASSWORD || "ragnarok");
+  await page.locator(".connect").tap();
+  if (phone) {
+    await page
+      .getByRole("button", { name: "Character slot 1", exact: true })
+      .tap();
+    await page
+      .getByRole("button", { name: "Play / create", exact: true })
+      .tap();
+  } else await page.locator("#slot0").dblclick();
+  await expect
+    .poll(async () => (await snapshot(page)).input.canMove)
+    .toBe(true);
+}
+
+test("live phone: size and mode persistence, separate geometry, opt-out survives touch", async ({
+  page,
+}, testInfo) => {
+  await verifyWorld();
+  page.setDefaultTimeout(15000);
+  const desktopGeometry = JSON.stringify({
+    _version: 1,
+    x: 205,
+    y: 137,
+    show: false,
+  });
+  await page.addInitScript((value) => {
+    if (localStorage.getItem("InventoryV3") === null)
+      localStorage.setItem("InventoryV3", value);
+  }, desktopGeometry);
+  await page.goto("/");
+  await login(page, true);
+  await page.getByRole("button", { name: "Menu", exact: true }).tap();
+  await page.getByRole("button", { name: "Display", exact: true }).tap();
+  const dialog = page.getByRole("dialog", { name: "Display settings" });
+  await expect(dialog).toBeVisible();
+  expect((await snapshot(page)).input.canMove).toBe(false);
+  const size = dialog.getByLabel("Control size");
+  await size.focus();
+  await size.press("End");
+  await dialog.getByRole("button", { name: "Done", exact: true }).tap();
+  const attack = await page
+    .getByRole("button", { name: "Attack", exact: true })
+    .boundingBox();
+  const shortcuts = await page
+    .locator("#ragnarok-mobile .skills")
+    .boundingBox();
+  expect(attack.height).toBeGreaterThanOrEqual(120);
+  expect(shortcuts.y + shortcuts.height).toBeLessThan(attack.y);
+  await page.screenshot({ path: testInfo.outputPath("large-controls.png") });
+  await page.getByRole("button", { name: "Menu", exact: true }).tap();
+  await page.getByRole("button", { name: "Display", exact: true }).tap();
+  await dialog.getByLabel("Phone layout").selectOption("off");
+  await dialog
+    .getByRole("button", { name: "Save and reload", exact: true })
+    .tap();
+  await page.locator("#user").waitFor();
+  expect(await page.evaluate(() => localStorage.getItem("InventoryV3"))).toBe(
+    desktopGeometry,
+  );
+  const phoneGeometry = await page.evaluate(() =>
+    localStorage.getItem("ragnarok:phone:InventoryV3"),
+  );
+  expect(phoneGeometry).not.toBeNull();
+  await login(page, false);
+  await expect(
+    page.getByRole("button", { name: "Attack", exact: true }),
+  ).not.toBeVisible();
+  // A real map touch invokes the legacy first-touch detector; Off still wins.
+  await page.touchscreen.tap(195, 400);
+  await expect(page.locator("#joystickBase")).not.toBeVisible();
+  await page.getByRole("button", { name: "Display", exact: true }).tap();
+  await expect(dialog.getByLabel("Phone layout")).toHaveValue("off");
+  await expect(dialog.getByLabel("Control size")).toHaveValue("1.25");
+  await dialog.getByLabel("Phone layout").selectOption("on");
+  await dialog
+    .getByRole("button", { name: "Save and reload", exact: true })
+    .tap();
+  await page.getByLabel("Account", { exact: true }).waitFor();
+  expect(
+    await page.evaluate(() =>
+      localStorage.getItem("ragnarok:phone:InventoryV3"),
+    ),
+  ).toBe(phoneGeometry);
+  await login(page, true);
+  await expect(
+    page.getByRole("button", { name: "Attack", exact: true }),
+  ).toBeVisible();
+  expect((await snapshot(page)).movement.registeredSources).toBe(2);
+  await page.screenshot({ path: testInfo.outputPath("phone-restored.png") });
+});

--- a/tests/e2e/mobile.spec.cjs
+++ b/tests/e2e/mobile.spec.cjs
@@ -1,0 +1,186 @@
+const { test, expect, devices } = require("@playwright/test");
+const fs = require("node:fs");
+const { verifyWorld, snapshot } = require("./support.cjs");
+
+test.use({
+  ...devices["Pixel 5"],
+  viewport: { width: 390, height: 844 },
+  screen: { width: 390, height: 844 },
+  deviceScaleFactor: 1,
+});
+
+async function login(page) {
+  await page.goto("/");
+  await page
+    .getByLabel("Account", { exact: true })
+    .fill(process.env.RO_E2E_ACCOUNT || "ragnarok");
+  await page
+    .getByLabel("Password", { exact: true })
+    .fill(process.env.RO_E2E_PASSWORD || "ragnarok");
+  await page.getByRole("button", { name: "Log in", exact: true }).tap();
+  await page
+    .getByRole("button", { name: "Character slot 1", exact: true })
+    .tap();
+  await page.getByRole("button", { name: "Play / create", exact: true }).tap();
+  await expect
+    .poll(async () => (await snapshot(page)).input.canMove)
+    .toBe(true);
+}
+async function command(page, text) {
+  await page.getByRole("button", { name: "Menu", exact: true }).tap();
+  await page.getByRole("button", { name: "Chat", exact: true }).tap();
+  await page.getByLabel("Chat message", { exact: true }).fill(text);
+  await page.keyboard.press("Enter");
+}
+
+test("live phone: two independent thumbs, both release orders, cancellation and native action delivery", async ({
+  page,
+  context,
+}, testInfo) => {
+  const { identity } = await verifyWorld();
+  const errors = [],
+    samples = [];
+  page.on("pageerror", (error) => errors.push(error.message));
+  await login(page);
+  // Real GM command in a marker- and identity-verified disposable world only.
+  // An open town path makes server movement assertions repeatable.
+  await command(page, "@warp prontera 150 180");
+  await expect
+    .poll(async () => (await snapshot(page)).map)
+    .toBe("prontera.gat");
+  await expect
+    .poll(async () => Math.round((await snapshot(page)).player.position[1]))
+    .toBe(180);
+  const closeChat = page.getByRole("button", {
+    name: "Close chat",
+    exact: true,
+  });
+  if (await closeChat.isVisible()) await closeChat.tap();
+  await expect
+    .poll(async () => (await snapshot(page)).input.canMove)
+    .toBe(true);
+  await context.tracing.start({ screenshots: true, snapshots: true });
+  await page.evaluate(() => {
+    window.touchEvidence = [];
+    for (const type of ["pointerdown", "pointerup", "pointercancel", "click"]) {
+      document.addEventListener(
+        type,
+        (event) =>
+          window.touchEvidence.push({
+            type,
+            id: event.pointerId,
+            target: event.composedPath()[0]?.id,
+            trusted: event.isTrusted,
+          }),
+        true,
+      );
+    }
+  });
+  const cdp = await context.newCDPSession(page);
+  const touch = (type, touchPoints) =>
+    cdp.send("Input.dispatchTouchEvent", { type, touchPoints });
+  const base = await page.locator("#joystickBase").boundingBox();
+  const attack = await page
+    .getByRole("button", { name: "Attack", exact: true })
+    .boundingBox();
+  const center = {
+    id: 1,
+    x: base.x + base.width / 2,
+    y: base.y + base.height / 2,
+    radiusX: 4,
+    radiusY: 4,
+    force: 1,
+  };
+  const second = {
+    id: 2,
+    x: attack.x + attack.width / 2,
+    y: attack.y + attack.height / 2,
+    radiusX: 4,
+    radiusY: 4,
+    force: 1,
+  };
+  const first = { ...center, y: center.y + 35 };
+  const record = async (name) => {
+    const state = await snapshot(page);
+    samples.push({ name, state });
+    return state;
+  };
+  const initial = await record("initial");
+  const attackCount = () =>
+    page.evaluate(
+      () =>
+        window.touchEvidence.filter(
+          (event) => event.type === "click" && event.target === "attackButton",
+        ).length,
+    );
+  try {
+    await touch("touchStart", [center]);
+    await touch("touchMove", [first]);
+    await expect
+      .poll(async () => (await snapshot(page)).serverMovement.acknowledgements)
+      .toBeGreaterThan(initial.serverMovement.acknowledgements);
+    await touch("touchStart", [first, second]);
+    await touch("touchEnd", [second]); // This Chromium ends the specified pointer, preserving the other.
+    await expect.poll(attackCount).toBe(1);
+    const attackReleased = await record("attack-released");
+    expect(attackReleased.movement.source).toBe("engine:touch:joystick");
+    expect(attackReleased.camera.direction).toBe(initial.camera.direction);
+    await page.waitForTimeout(250);
+    expect((await snapshot(page)).movement.requests).toBeGreaterThan(
+      attackReleased.movement.requests,
+    );
+    await touch("touchEnd", []);
+    const released = await record("joystick-released");
+    await page.waitForTimeout(700);
+    expect((await snapshot(page)).movement.requests).toBe(
+      released.movement.requests,
+    );
+    expect((await snapshot(page)).movement.source).toBe(null);
+
+    // Release the joystick first. The held action thumb cannot resume it.
+    await touch("touchStart", [center]);
+    await touch("touchMove", [first]);
+    await touch("touchStart", [first, second]);
+    await touch("touchEnd", [first]);
+    const firstReleased = await record("joystick-released-first");
+    expect(firstReleased.movement.source).toBe(null);
+    await touch("touchEnd", []);
+    await expect.poll(attackCount).toBe(2);
+    await page.waitForTimeout(300);
+    expect((await snapshot(page)).movement.requests).toBe(
+      firstReleased.movement.requests,
+    );
+
+    await touch("touchStart", [center]);
+    await touch("touchMove", [first]);
+    await touch("touchCancel", []);
+    const cancelled = await record("cancelled");
+    expect(cancelled.movement.source).toBe(null);
+    await page.waitForTimeout(300);
+    expect((await snapshot(page)).movement.requests).toBe(
+      cancelled.movement.requests,
+    );
+    expect((await snapshot(page)).camera.direction).toBe(
+      initial.camera.direction,
+    );
+    // A single primary tap must not invoke both pointer and compatibility paths.
+    await page.getByRole("button", { name: "Attack", exact: true }).tap();
+    expect(await attackCount()).toBe(3);
+    const events = await page.evaluate(() => window.touchEvidence);
+    expect(
+      events.filter((event) => event.type === "pointerdown" && event.trusted)
+        .length,
+    ).toBeGreaterThanOrEqual(6);
+    expect(errors).toEqual([]);
+    await page.screenshot({ path: testInfo.outputPath("two-thumbs-map.png") });
+    fs.writeFileSync(
+      testInfo.outputPath("report.json"),
+      JSON.stringify({ identity, samples, events, errors }, null, 2),
+    );
+  } finally {
+    await touch("touchCancel", []).catch(() => {});
+    await context.tracing.stop({
+      path: testInfo.outputPath("two-thumbs-trace.zip"),
+    });
+  }
+});

--- a/tests/e2e/phone.cjs
+++ b/tests/e2e/phone.cjs
@@ -1,0 +1,70 @@
+const { expect } = require("@playwright/test");
+const { snapshot } = require("./support.cjs");
+
+async function login(page) {
+  await page.goto("/");
+  await page
+    .getByLabel("Account", { exact: true })
+    .fill(process.env.RO_E2E_ACCOUNT || "ragnarok");
+  await page
+    .getByLabel("Password", { exact: true })
+    .fill(process.env.RO_E2E_PASSWORD || "ragnarok");
+  await page.getByRole("button", { name: "Log in", exact: true }).tap();
+  await page
+    .getByRole("button", { name: "Character slot 1", exact: true })
+    .tap();
+  await page.getByRole("button", { name: "Play / create", exact: true }).tap();
+  await expect
+    .poll(async () => (await snapshot(page)).input.canMove)
+    .toBe(true);
+}
+async function menu(page, name) {
+  await page.getByRole("button", { name: "Menu", exact: true }).tap();
+  await page.getByRole("button", { name, exact: true }).tap();
+}
+async function command(page, value) {
+  await menu(page, "Chat");
+  await page.getByLabel("Chat message", { exact: true }).fill(value);
+  await page.keyboard.press("Enter");
+  const close = page.getByRole("button", { name: "Close chat", exact: true });
+  if (value.startsWith("@warp ")) {
+    // Map transitions rebuild ChatBox and hide the phone chat. Wait for that
+    // lifecycle change before touching controls on the destination map.
+    await expect(close).toBeHidden();
+    await expect
+      .poll(async () => (await snapshot(page)).input.canMove)
+      .toBe(true);
+  } else await close.tap();
+}
+async function inventory(page) {
+  await menu(page, "Inventory");
+  await page
+    .locator("#InventoryV3 .tabs .tab")
+    .filter({ hasText: /^Use$/ })
+    .tap();
+}
+const closeInventory = (page) =>
+  page
+    .locator("#InventoryV3")
+    .getByRole("button", { name: "Close", exact: true })
+    .tap();
+const inventoryCounts = (page) =>
+  page
+    .locator("#InventoryV3 .content .item")
+    .evaluateAll((elements) =>
+      Object.fromEntries(
+        elements.map((item) => [
+          item.dataset.index,
+          Number(item.querySelector(".count").textContent),
+        ]),
+      ),
+    );
+
+module.exports = {
+  login,
+  menu,
+  command,
+  inventory,
+  closeInventory,
+  inventoryCounts,
+};

--- a/tests/e2e/support.cjs
+++ b/tests/e2e/support.cjs
@@ -1,0 +1,54 @@
+const { expect } = require("@playwright/test");
+const fs = require("node:fs");
+const path = require("node:path");
+const {
+  control,
+  processIdentity,
+  sha256,
+} = require("../../electron/asset-server");
+
+async function verifyWorld() {
+  if (!process.env.RO_E2E_WORLD)
+    throw new Error(
+      "Set RO_E2E_WORLD to a running disposable test world; see docs/TESTING.md",
+    );
+  const world = fs.realpathSync(process.env.RO_E2E_WORLD);
+  const marker = JSON.parse(
+    fs.readFileSync(path.join(world, ".ragnarok-e2e.json"), "utf8"),
+  );
+  expect(marker.disposable).toBe(true);
+  const state = fs.realpathSync(path.join(world, "state"));
+  const record = JSON.parse(
+    fs.readFileSync(path.join(state, "asset-owner.json"), "utf8"),
+  );
+  const identity = record.identity;
+  expect(identity.stateRoot).toBe(state);
+  expect(identity.httpPort).toBe(3338);
+  const binary = path.join(
+    world,
+    "runtime/bin",
+    process.platform === "win32"
+      ? "robrowser-remoteclient.exe"
+      : "robrowser-remoteclient",
+  );
+  expect(identity.executableDigest).toBe(sha256(fs.readFileSync(binary)));
+  expect(
+    await processIdentity(
+      identity.pid,
+      path.join(
+        world,
+        "runtime/bin",
+        process.platform === "win32" ? "ragnarok-stack.exe" : "ragnarok-stack",
+      ),
+    ),
+  ).toEqual(record.osIdentity);
+  const secret = fs
+    .readFileSync(path.join(state, "asset-control.secret"), "utf8")
+    .trim();
+  await control(identity, secret, "status");
+  return { world, identity };
+}
+
+const snapshot = (page) =>
+  page.evaluate(() => window.roClientDiagnostics.snapshot());
+module.exports = { verifyWorld, snapshot };


### PR DESCRIPTION
Phone players currently get overlapping desktop windows, inaccessible drag/double-click actions, and lost second-thumb attacks. This adds component-specific phone layouts and explicit tap controls while retaining roBrowser's native movement, inventory, shop and storage handlers.

Stacked on #55; relates to #6. This remains a **draft**, with gameplay and device coverage still outstanding. No merge requested.

- Auto/On/Off and control-size preferences, separate phone/desktop geometry, viewport and keyboard offsets, compact HP/SP/target HUD, native joystick, Attack/Talk/Pick up, F1–F4 and a game menu.
- Touch login and character selection/creation; item/equipment/skill selection and action toolbars; native shortcut assignment and persisted icons. Equipment, skills and quests have their own layouts; Stats opens separately.
- Shops offer native Buy/Sell, tap selection, quantity entry and cart controls. Storage offers validated quantity/whole-stack transfers and explicit focus between inventory and storage. The phone UI preserves native panel focus order, sizes the buy/sell chooser and quantity popup, and stops compatibility mouse presses from reaching NPCs beneath panels. Nested shop geometry uses the phone preference bank. Distant pickup uses the existing deferred native action after walking; a new joystick/keyboard movement cancels it.
- Scoped styles, labels, listeners and cleanup through client API 1. The first-touch detector respects Off; second-thumb releases invoke native actions exactly once without taking over the camera.
- Development-only Playwright suites verify the disposable world's private process identity and run actual rAthena/RemoteClient/roBrowser gameplay. No mocked map or direct player-state assignment.

Validation: 29 Node tests pass, including real Rust lifecycle/asset integrations. Fresh pinned roBrowser source patches twice with identical results and builds Online/worker/HTML. All **12 live Playwright tests pass together (4.7 minutes)**: desktop movement, six viewport profiles, phone preferences, two thumbs, portrait/landscape commerce, and item/shortcut healing, distant pickup/cancellation and Poring combat. Item/commerce tests assert server-confirmed inventory/HP/Zeny changes; combat checks native damage and experience messages from received server packets. A delivered click or unknown monster HP is not treated as combat proof. Successful fixture runs restore added potion counts and Zeny; combat experience and F2's potion assignment persist in the disposable world. Screenshots/traces are local under `artifacts/issue-6/`; reproduction and limits are in `docs/TESTING.md`. All four CI jobs passed on prior head81f64dc (run34110066785); CI for the pickup follow-up is pending.

Still required for #6: learned skill use/targeting and further combat cases; player vending and remaining NPC/quest flows; keyboard/orientation/background/death/IME cases; Firefox and packaged Electron; physical Android Chrome and iPhone Safari. Existing selected-asset Lua/HTTP diagnostics are recorded, not treated as a clean console. Only the disposable save was changed. This PR does not enable internet exposure; #4's era-specific GM/admin password Settings action, bootstrap protection and sharing safeguards remain separate.

Latest head `5f766ff`: all four CI jobs passed in [run 34112766524](https://github.com/Flux159/ragnarokoffline.app/actions/runs/34112766524).

Current stack validation: all client/Linux/macOS/Windows checks pass at `7c94138` ([CI](https://github.com/Flux159/ragnarokoffline.app/actions/runs/34134801571)). This head includes the bounded, authenticated Windows readiness retry from #53; the feature changes remain isolated from their parent PR. Nothing has been advanced to main or released.
