### PR TITLE
Prepare private database credential bootstrap for safer hosting

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -1,7 +1,7 @@
 name: images
 
 # Builds the two container images the app ships with, and publishes them as a
-# rolling release asset.
+# rolling release asset on main. Manual runs produce review artifacts only.
 #
 # These cannot be built in the app workflow. Two reasons, either sufficient:
 #
@@ -33,6 +33,7 @@ on:
     paths:
       - 'containers/**'
       - '.github/workflows/images.yml'
+      - 'tests/integration/mariadb-secrets.py'
       # The packetver lives here and is a build arg for the rAthena image, so a
       # bump has to rebuild. It over-triggers on unrelated bootstrap edits;
       # a stale image is the worse failure.
@@ -80,6 +81,9 @@ jobs:
       - name: Build the database image
         run: docker build -t ragnarokmac/mariadb:11.4 containers/mariadb
 
+      - name: Validate database secret bootstrap against the image
+        run: python3 tests/integration/mariadb-secrets.py
+
       # rAthena's source is the build context, so our Dockerfile is copied into
       # the checkout — the same thing bootstrap.sh does locally.
       - name: Build rAthena
@@ -119,12 +123,23 @@ jobs:
           tar czf rathena-sql.tar.gz -C sql .
           ls -lh rathena-sql.tar.gz
 
+      - name: Upload reviewable image artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: container-images-${{ matrix.arch }}
+          path: |
+            images-${{ matrix.arch }}.tar.gz
+            rathena-sql.tar.gz
+          retention-days: 7
+          if-no-files-found: error
+
       # A rolling tag, not a version. These track the Dockerfiles, which change
       # on their own schedule, and the app build fetches them by this tag
       # explicitly — so cutting an app release never has to carry a fresh copy
       # of two container images with it. Marked prerelease so it does not
       # present itself as a version of the app on the releases page.
       - name: Publish
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: softprops/action-gh-release@v2
         with:
           tag_name: images

--- a/containers/mariadb/README.md
+++ b/containers/mariadb/README.md
@@ -1,0 +1,54 @@
+# Database bootstrap credentials
+
+The image accepts `MARIADB_ROOT_PASSWORD_FILE` and `MARIADB_PASSWORD_FILE`.
+Mount a private directory read-only and set each variable to its container file
+path. Files must contain the exact password: 1–256 printable ASCII bytes, without
+a newline. Leading/trailing spaces, quotes and backslashes are preserved. Do not
+set both a password value and its file variable. Files, container configuration
+and host staging directories must be accessible only to the owner; passwords do
+not belong in the asset root, logs or command arguments.
+
+Legacy `MARIADB_ROOT_PASSWORD` / `MARIADB_PASSWORD` callers remain supported, with
+`ragnarok` used only when the variable is absent. An explicitly empty password is
+an error. These legacy values remain visible in container creation metadata, so
+new managed credentials must use files. The entrypoint clears inherited password
+variables before starting database processes. Application user/database names
+accept only ASCII letters, digits and underscores; the application user cannot
+be `root`.
+
+These inputs initialize **new volumes only**. Replacing a password file does not
+rotate an existing account. Supervisor-driven rotation, private CLI option files,
+credential recovery and per-era migration are separate work; this image change
+alone does not make internet hosting safe or change existing app credentials.
+
+The private initialization server listens only on its Unix socket. Password SQL
+uses a private stdin stream with error output suppressed; quoting uses explicit
+`NO_BACKSLASH_ESCAPES` plus doubled quotes. The entrypoint stops its exact child
+with SIGTERM and waits for clean shutdown instead of passing the root password to
+`mariadb-admin`. See MariaDB's [shutdown documentation](https://mariadb.com/docs/server/reference/sql-statements/administrative-sql-statements/shutdown)
+and [string literal documentation](https://mariadb.com/docs/server/reference/sql-structure/sql-language-structure/string-literals).
+
+A new volume gets `.ragnarok-initializing` before schema creation. Only successful
+credential initialization and clean shutdown remove it. A failed or interrupted
+first boot leaves the next start blocked before any network listener opens.
+Preserve that volume and its logs for recovery; do not delete the marker to bypass
+the check. Restore a verified backup, or explicitly discard a confirmed unused
+new volume and initialize a replacement. Legacy volumes without this marker
+continue to open normally; their credential policy must be audited separately.
+
+## Validation
+
+With a real Docker daemon (the test never publishes host ports):
+
+```sh
+docker build -t ragnarokmac/mariadb:11.4 containers/mariadb
+python3 tests/integration/mariadb-secrets.py
+```
+
+The test creates UUID-named disposable volumes, authenticates real root/application
+connections with punctuation-bearing secrets, rejects the known default, checks
+process/log/metadata exposure, verifies clean restart and retained rows/passwords,
+and exercises invalid inputs and interrupted initialization. It removes only its
+own containers/volumes. Both native architectures run it in `images.yml` before
+bundling. Manual workflow runs upload seven-day artifacts and **do not publish**
+the rolling `images` release. Publishing remains limited to a matching main push.

--- a/containers/mariadb/entrypoint.sh
+++ b/containers/mariadb/entrypoint.sh
@@ -36,7 +36,8 @@ if [ ! -d "$DATADIR/mysql" ]; then
         value=$1
         secret_file=$2
         supplied=$3
-        if [ -n "$secret_file" ]; then
+        if [ "$4" = x ]; then
+            [ -n "$secret_file" ] || fail 'Database password file path cannot be empty.'
             [ "$supplied" = no ] || fail 'Supply a password value or a password file, not both.'
             [ -f "$secret_file" ] && [ -r "$secret_file" ] || fail 'Cannot read database password file.'
             count=$(wc -c < "$secret_file")
@@ -54,8 +55,8 @@ if [ ! -d "$DATADIR/mysql" ]; then
     app_supplied=no
     [ "${MARIADB_ROOT_PASSWORD+x}" != x ] || root_supplied=yes
     [ "${MARIADB_PASSWORD+x}" != x ] || app_supplied=yes
-    root_password=$(read_password "${MARIADB_ROOT_PASSWORD-ragnarok}" "${MARIADB_ROOT_PASSWORD_FILE-}" "$root_supplied")
-    app_password=$(read_password "${MARIADB_PASSWORD-ragnarok}" "${MARIADB_PASSWORD_FILE-}" "$app_supplied")
+    root_password=$(read_password "${MARIADB_ROOT_PASSWORD-ragnarok}" "${MARIADB_ROOT_PASSWORD_FILE-}" "$root_supplied" "${MARIADB_ROOT_PASSWORD_FILE+x}")
+    app_password=$(read_password "${MARIADB_PASSWORD-ragnarok}" "${MARIADB_PASSWORD_FILE-}" "$app_supplied" "${MARIADB_PASSWORD_FILE+x}")
     database=${MARIADB_DATABASE-ragnarok}
     username=${MARIADB_USER-ragnarok}
     case "$database" in ''|*[!a-zA-Z0-9_]*) fail 'Database name must contain letters, digits or underscores.' ;; esac

--- a/containers/mariadb/entrypoint.sh
+++ b/containers/mariadb/entrypoint.sh
@@ -1,65 +1,120 @@
 #!/bin/sh
-# Initialise on first boot, then hand over to the server.
-#
-# The same environment variables as the official image, so callers do not have
-# to care which one they are talking to.
-set -e
+# Initialise on first boot, then hand over to the server. Passwords may be
+# supplied as MARIADB_{ROOT_PASSWORD,PASSWORD}_FILE; files contain the exact
+# printable ASCII password without a newline. Existing databases are untouched.
+set -eu
+umask 077
 
 DATADIR=/var/lib/mysql
 SOCK=/run/mysqld/init.sock
+PENDING="$DATADIR/.ragnarok-initializing"
+init_pid=
+fail() { echo "$1" >&2; exit 1; }
+cleanup() {
+    if [ -n "$init_pid" ]; then
+        kill -TERM "$init_pid" 2>/dev/null || true
+        wait "$init_pid" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+trap 'exit 1' HUP INT TERM
 
-# The image creates this and hands it to mysql, but the ownership does not
-# always survive into the running container — nebula-slim's image loader drops
-# uid/gid, so the directory arrives root-owned and mariadbd, which runs as
-# mysql, cannot create its socket in it ("Bind on unix socket: Permission
-# denied"). We are still root here, so just assert it every boot; the official
-# image does the same thing for the same reason.
+# The image loader can drop uid/gid. Only this socket directory belongs to
+# mysql; secret files and the initialisation marker remain owned by root.
 mkdir -p /run/mysqld
 chown mysql:mysql /run/mysqld
+chmod 755 /run/mysqld
+
+# Never start a half-initialised database on the network after an interrupted
+# first boot. In particular, DATADIR/mysql alone does not prove root was secured.
+[ ! -e "$PENDING" ] || fail 'Database initialisation was interrupted. Preserve this volume and recover or restore it before starting; no network listener was opened.'
 
 if [ ! -d "$DATADIR/mysql" ]; then
-    echo "initialising a new database in $DATADIR"
+    # Do not use eval or export the resolved values. This function's stdout is
+    # captured by the shell; values never become a command argument or log line.
+    read_password() {
+        value=$1
+        secret_file=$2
+        supplied=$3
+        if [ -n "$secret_file" ]; then
+            [ "$supplied" = no ] || fail 'Supply a password value or a password file, not both.'
+            [ -f "$secret_file" ] && [ -r "$secret_file" ] || fail 'Cannot read database password file.'
+            count=$(wc -c < "$secret_file")
+            [ "$count" -ge 1 ] && [ "$count" -le 256 ] || fail 'Database password must contain 1–256 printable ASCII bytes without a newline.'
+            invalid=$(LC_ALL=C tr -d '\040-\176' < "$secret_file" | wc -c)
+            [ "$invalid" -eq 0 ] || fail 'Database password must contain 1–256 printable ASCII bytes without a newline.'
+            value=$(cat "$secret_file")
+        fi
+        [ "${#value}" -ge 1 ] && [ "${#value}" -le 256 ] || fail 'Database password must contain 1–256 printable ASCII bytes without a newline.'
+        invalid=$(printf '%s' "$value" | LC_ALL=C tr -d '\040-\176' | wc -c)
+        [ "$invalid" -eq 0 ] || fail 'Database password must contain 1–256 printable ASCII bytes without a newline.'
+        printf '%s' "$value"
+    }
+    root_supplied=no
+    app_supplied=no
+    [ "${MARIADB_ROOT_PASSWORD+x}" != x ] || root_supplied=yes
+    [ "${MARIADB_PASSWORD+x}" != x ] || app_supplied=yes
+    root_password=$(read_password "${MARIADB_ROOT_PASSWORD-ragnarok}" "${MARIADB_ROOT_PASSWORD_FILE-}" "$root_supplied")
+    app_password=$(read_password "${MARIADB_PASSWORD-ragnarok}" "${MARIADB_PASSWORD_FILE-}" "$app_supplied")
+    database=${MARIADB_DATABASE-ragnarok}
+    username=${MARIADB_USER-ragnarok}
+    case "$database" in ''|*[!a-zA-Z0-9_]*) fail 'Database name must contain letters, digits or underscores.' ;; esac
+    case "$username" in ''|*[!a-zA-Z0-9_]*) fail 'Database user must contain letters, digits or underscores.' ;; esac
+    [ "${#database}" -le 64 ] && [ "${#username}" -le 80 ] || fail 'Database name or user is too long.'
+    [ "$username" != root ] || fail 'The application database user cannot be root.'
+
+    # Legacy value-based callers still work, but their exported secrets must
+    # not be inherited by any database process. File-based callers avoid also
+    # storing these values in the container's creation configuration.
+    unset MARIADB_ROOT_PASSWORD MARIADB_PASSWORD MARIADB_ROOT_PASSWORD_FILE MARIADB_PASSWORD_FILE
+    # Explicit SQL mode makes backslashes literal. A quote is represented by
+    # two quotes; shell expansion does not evaluate the password as shell code.
+    root_sql=$(printf '%s' "$root_password" | sed "s/'/''/g")
+    app_sql=$(printf '%s' "$app_password" | sed "s/'/''/g")
+    unset root_password app_password
+
+    echo 'initialising a new database'
     chown -R mysql:mysql "$DATADIR"
+    : > "$PENDING"
     mariadb-install-db --user=mysql --datadir="$DATADIR" --skip-test-db >/dev/null
-
-    # Bring the server up on a private socket only: nothing can reach it over
-    # the network until the schema is in and the passwords are set.
-    mariadbd --user=mysql --datadir="$DATADIR" --skip-networking \
-             --socket="$SOCK" &
+    mariadbd --user=mysql --datadir="$DATADIR" --skip-networking --socket="$SOCK" &
     init_pid=$!
-
     tries=60
     until mariadb-admin --socket="$SOCK" ping >/dev/null 2>&1; do
         tries=$((tries - 1))
-        [ $tries -le 0 ] && { echo "database failed to start for initialisation" >&2; exit 1; }
+        [ "$tries" -gt 0 ] || fail 'Database failed to start for initialisation.'
+        kill -0 "$init_pid" 2>/dev/null || fail 'Database stopped during initialisation.'
         sleep 1
     done
 
-    mariadb --socket="$SOCK" <<SQL
-CREATE DATABASE IF NOT EXISTS \`${MARIADB_DATABASE:-ragnarok}\`;
-CREATE USER IF NOT EXISTS '${MARIADB_USER:-ragnarok}'@'%' IDENTIFIED BY '${MARIADB_PASSWORD:-ragnarok}';
-GRANT ALL PRIVILEGES ON \`${MARIADB_DATABASE:-ragnarok}\`.* TO '${MARIADB_USER:-ragnarok}'@'%';
-FLUSH PRIVILEGES;
+    # SQL errors can echo credentials. Emit a bounded explanation instead.
+    mariadb --socket="$SOCK" 2>/dev/null <<SQL || fail 'Database account initialisation failed.'
+SET SESSION sql_mode='NO_BACKSLASH_ESCAPES';
+CREATE DATABASE IF NOT EXISTS \`$database\`;
+CREATE USER IF NOT EXISTS '$username'@'%' IDENTIFIED BY '$app_sql';
+GRANT ALL PRIVILEGES ON \`$database\`.* TO '$username'@'%';
 SQL
-
-    # Imported in filename order, like the official image, so 01- comes first.
-    # Still as passwordless root: the account is locked down afterwards, or
-    # these would all fail with access denied.
+    unset app_sql
     for f in /docker-entrypoint-initdb.d/*.sql; do
         [ -f "$f" ] || continue
         echo "importing $(basename "$f")"
-        mariadb --socket="$SOCK" "${MARIADB_DATABASE:-ragnarok}" < "$f"
+        mariadb --socket="$SOCK" "$database" < "$f" 2>/dev/null || fail 'Database schema import failed.'
     done
-
-    # Last, so everything above could still connect.
-    mariadb --socket="$SOCK" <<SQL
-ALTER USER 'root'@'localhost' IDENTIFIED BY '${MARIADB_ROOT_PASSWORD:-ragnarok}';
-FLUSH PRIVILEGES;
+    mariadb --socket="$SOCK" 2>/dev/null <<SQL || fail 'Database root credential initialisation failed.'
+SET SESSION sql_mode='NO_BACKSLASH_ESCAPES';
+ALTER USER 'root'@'localhost' IDENTIFIED BY '$root_sql';
 SQL
+    unset root_sql
 
-    mariadb-admin --socket="$SOCK" --user=root --password="${MARIADB_ROOT_PASSWORD:-ragnarok}" shutdown
-    wait "$init_pid" 2>/dev/null || true
-    echo "initialisation complete"
+    # SIGTERM is MariaDB's graceful shutdown. This is our exact child, so no
+    # password-bearing mariadb-admin argument or broad process search is needed.
+    kill -TERM "$init_pid"
+    wait "$init_pid"
+    init_pid=
+    rm "$PENDING"
+    echo 'initialisation complete'
 fi
 
+unset MARIADB_ROOT_PASSWORD MARIADB_PASSWORD MARIADB_ROOT_PASSWORD_FILE MARIADB_PASSWORD_FILE
+trap - EXIT HUP INT TERM
 exec mariadbd --user=mysql --datadir="$DATADIR" --bind-address=0.0.0.0

--- a/tests/integration/mariadb-secrets.py
+++ b/tests/integration/mariadb-secrets.py
@@ -57,6 +57,8 @@ def start(label, directory, env, volume=None, init_dir=None):
         docker('volume', 'create', volume)
         volumes.append(volume)
     containers.append(name)
+    # Test-only ptrace capability permits reading our mysqld /proc environment
+    # after its uid drop. Production containers do not receive this capability.
     args = ['run', '-d', '--name', name, '--network', 'none', '--cap-add', 'SYS_PTRACE', '-v', volume + ':/var/lib/mysql',
             '-v', str(directory) + ':/run/test-secrets:ro']
     if init_dir is not None:
@@ -100,7 +102,7 @@ def check_no_secret_output(name, passwords):
     output = docker('logs', name)
     captured = output.stdout + output.stderr
     inspected = docker('inspect', name).stdout
-    processes = docker('top', name, '-eo', 'args').stdout
+    processes = docker('top', name, '-eo', 'pid,args').stdout
     environment = docker('exec', name, 'sh', '-c', 'cat /proc/1/environ').stdout
     # Include unique suffixes so SQL/option-file escaping cannot hide leakage.
     passwords = passwords + [password[-33:-1] for password in passwords]

--- a/tests/integration/mariadb-secrets.py
+++ b/tests/integration/mariadb-secrets.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Disposable real-image tests. No host ports or existing volumes are used.
+
+Build containers/mariadb as ragnarokmac/mariadb:11.4, then run this script.
+All subprocess output is captured; failures deliberately omit SQL/credentials.
+"""
+import os
+from pathlib import Path
+import secrets
+import subprocess
+import tempfile
+import time
+
+IMAGE = os.environ.get('RO_TEST_DB_IMAGE', 'ragnarokmac/mariadb:11.4')
+PREFIX = 'ro-db-secret-test-' + secrets.token_hex(6)
+containers = []
+volumes = []
+
+
+def docker(*args, data=None, check=True):
+    result = subprocess.run(['docker', *args], input=data, text=True,
+                            stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=120)
+    if check and result.returncode:
+        raise RuntimeError('Docker test operation failed (output suppressed).')
+    return result
+
+
+def assert_safe(condition, reason):
+    if not condition:
+        raise RuntimeError(reason)
+
+
+def option_file(path, user, password):
+    # MariaDB option-file escaping is separate from SQL literal escaping.
+    escaped = password.replace('\\', '\\\\').replace('"', '\\"')
+    path.write_text('[client]\nuser=' + user + '\npassword="' + escaped + '"\n')
+    path.chmod(0o600)
+
+
+def sql(name, filename, query, success=True, tcp=False):
+    args = ['exec', '-i', name, 'mariadb',
+            '--defaults-extra-file=/run/test-secrets/' + filename]
+    if tcp:
+        args += ['--protocol=TCP', '-h127.0.0.1']
+    result = docker(*args, '--batch', '--skip-column-names', data=query, check=False)
+    if success:
+        assert_safe(result.returncode == 0, 'Expected database credentials were rejected.')
+    else:
+        assert_safe(result.returncode != 0, 'Unexpected database credentials were accepted.')
+    return result.stdout.strip()
+
+
+def start(label, directory, env, volume=None, init_dir=None):
+    name = PREFIX + '-' + label
+    if volume is None:
+        volume = name
+        docker('volume', 'create', volume)
+        volumes.append(volume)
+    containers.append(name)
+    args = ['run', '-d', '--name', name, '--network', 'none', '-v', volume + ':/var/lib/mysql',
+            '-v', str(directory) + ':/run/test-secrets:ro']
+    if init_dir is not None:
+        args += ['-v', str(init_dir) + ':/docker-entrypoint-initdb.d:ro']
+    for key, value in env.items():
+        args += ['-e', key + '=' + value]
+    docker(*args, IMAGE)
+    return name, volume
+
+
+def wait_ready(name):
+    until = time.monotonic() + 90
+    while time.monotonic() < until:
+        # Use TCP so the private, half-initialised socket cannot pass readiness.
+        result = docker('exec', '-i', name, 'mariadb',
+                        '--defaults-extra-file=/run/test-secrets/root.cnf',
+                        '--protocol=TCP', '-h127.0.0.1', '--batch', '--skip-column-names',
+                        data='SELECT 1;', check=False)
+        if result.returncode == 0 and result.stdout.strip() == '1':
+            return
+        if docker('inspect', '-f', '{{.State.Running}}', name).stdout.strip() != 'true':
+            raise RuntimeError('Database exited before readiness (logs suppressed).')
+        time.sleep(0.5)
+    raise RuntimeError('Database readiness timed out (logs suppressed).')
+
+
+def wait_failed(name):
+    until = time.monotonic() + 90
+    while time.monotonic() < until:
+        result = docker('inspect', '-f', '{{.State.Running}} {{.State.ExitCode}}', name)
+        running, code = result.stdout.strip().split()
+        if running == 'false':
+            assert_safe(code != '0', 'Invalid bootstrap unexpectedly succeeded.')
+            return
+        time.sleep(0.5)
+    raise RuntimeError('Invalid bootstrap did not fail closed.')
+
+
+def check_no_secret_output(name, passwords):
+    # Only inspect processes belonging to our UUID-named disposable container.
+    output = docker('logs', name)
+    captured = output.stdout + output.stderr
+    inspected = docker('inspect', name).stdout
+    processes = docker('top', name, '-eo', 'args').stdout
+    environment = docker('exec', name, 'sh', '-c', 'cat /proc/1/environ').stdout
+    for password in passwords:
+        assert_safe(password not in captured + inspected + processes + environment,
+                    'A credential appeared in container metadata, logs or process state.')
+    assert_safe('MARIADB_ROOT_PASSWORD=' not in environment and 'MARIADB_PASSWORD=' not in environment,
+                'Password environment variables reached the database process.')
+
+
+def main():
+    with tempfile.TemporaryDirectory(prefix=PREFIX) as temp:
+        directory = Path(temp)
+        # SQL metacharacters, backslashes, quotes, shell syntax and edge spaces
+        # must survive unchanged without running SQL or shell instructions.
+        root = " Root'\\\";$(false)#" + secrets.token_hex(16) + ' '
+        app = " App'\\\";-- " + secrets.token_hex(16) + ' '
+        for file, value in [('root.secret', root), ('app.secret', app),
+                            ('changed.secret', secrets.token_hex(24)), ('empty.secret', ''),
+                            ('newline.secret', 'password\n'), ('nul.secret', 'pass\0word')]:
+            (directory / file).write_text(value)
+            (directory / file).chmod(0o600)
+        option_file(directory / 'root.cnf', 'root', root)
+        option_file(directory / 'app.cnf', 'ro_app', app)
+        option_file(directory / 'wrong.cnf', 'root', 'ragnarok')
+        env = {'MARIADB_ROOT_PASSWORD_FILE': '/run/test-secrets/root.secret',
+               'MARIADB_PASSWORD_FILE': '/run/test-secrets/app.secret',
+               'MARIADB_DATABASE': 'ro_test', 'MARIADB_USER': 'ro_app'}
+        name, volume = start('fresh', directory, env)
+        wait_ready(name)
+        sql(name, 'wrong.cnf', 'SELECT 1;', success=False, tcp=True)
+        sql(name, 'app.cnf', 'CREATE TABLE ro_test.retained (id INT PRIMARY KEY); INSERT INTO ro_test.retained VALUES (42);', tcp=True)
+        assert_safe(sql(name, 'root.cnf', 'SELECT COUNT(*) FROM mysql.user WHERE User=\'ro_app\';') == '1',
+                    'Application database account was not created exactly once.')
+        check_no_secret_output(name, [root, app])
+        docker('stop', '-t', '30', name)
+        assert_safe(docker('inspect', '-f', '{{.State.ExitCode}}', name).stdout.strip() == '0',
+                    'Database did not shut down cleanly.')
+        docker('rm', name)
+        name, _ = start('existing', directory,
+                        {**env, 'MARIADB_ROOT_PASSWORD_FILE': '/run/test-secrets/changed.secret',
+                         'MARIADB_PASSWORD_FILE': '/run/test-secrets/changed.secret'}, volume)
+        wait_ready(name)
+        assert_safe(sql(name, 'app.cnf', 'SELECT id FROM ro_test.retained;', tcp=True) == '42',
+                    'Restart modified existing data or credentials.')
+        check_no_secret_output(name, [root, app])
+        print('PASS: private-file initialization, exact password authentication, clean restart and retained data')
+
+        # Legacy unset defaults still work; explicit empty values do not select
+        # the known fallback. Test non-secret default only through env/argv.
+        legacy = directory / 'legacy'
+        legacy.mkdir(mode=0o700)
+        option_file(legacy / 'root.cnf', 'root', 'ragnarok')
+        name, _ = start('legacy', legacy, {})
+        wait_ready(name)
+        assert_safe(sql(name, 'root.cnf', "SELECT COUNT(*) FROM mysql.user WHERE User='ragnarok';") == '1',
+                    'Legacy default initialization failed.')
+        print('PASS: backward-compatible local bootstrap')
+
+        for label, invalid in [
+            ('both', {**env, 'MARIADB_ROOT_PASSWORD': 'unused-test-value'}),
+            ('empty', {**env, 'MARIADB_PASSWORD_FILE': '/run/test-secrets/empty.secret'}),
+            ('newline', {**env, 'MARIADB_PASSWORD_FILE': '/run/test-secrets/newline.secret'}),
+            ('nul', {**env, 'MARIADB_PASSWORD_FILE': '/run/test-secrets/nul.secret'}),
+            ('missing', {**env, 'MARIADB_PASSWORD_FILE': '/run/test-secrets/absent.secret'}),
+            ('identifier', {**env, 'MARIADB_DATABASE': 'invalid`; DROP DATABASE mysql;--'}),
+            ('empty-value', {'MARIADB_PASSWORD': ''}),
+        ]:
+            name, _ = start(label, directory, invalid)
+            wait_failed(name)
+        print('PASS: conflicting, empty, malformed, missing and unsafe bootstrap inputs rejected')
+
+        bad_schema = directory / 'bad-schema'
+        bad_schema.mkdir(mode=0o700)
+        (bad_schema / '01-fail.sql').write_text('THIS IS NOT SQL;')
+        name, volume = start('interrupted', directory, env, init_dir=bad_schema)
+        wait_failed(name)
+        docker('rm', name)
+        name, _ = start('retry', directory, env, volume)
+        wait_failed(name)
+        logs = docker('logs', name)
+        assert_safe('initialisation was interrupted' in logs.stderr + logs.stdout,
+                    'Incomplete database did not retain its fail-closed marker.')
+        print('PASS: failed schema import cannot expose a half-initialized database on restart')
+
+
+try:
+    main()
+except Exception as error:
+    # Never print subprocess input/output or an exception with command arguments.
+    print('FAIL: ' + (str(error) if isinstance(error, RuntimeError) else type(error).__name__))
+    raise SystemExit(1)
+finally:
+    for name in containers:
+        docker('stop', '-t', '30', name, check=False)
+        docker('rm', '-f', name, check=False)
+    for volume in volumes:
+        docker('volume', 'rm', volume, check=False)

--- a/tests/integration/mariadb-secrets.py
+++ b/tests/integration/mariadb-secrets.py
@@ -21,7 +21,7 @@ def docker(*args, data=None, check=True):
     result = subprocess.run(['docker', *args], input=data, text=True,
                             stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=120)
     if check and result.returncode:
-        raise RuntimeError('Docker test operation failed (output suppressed).')
+        raise RuntimeError('Docker test operation failed: ' + args[0] + ' (output suppressed).')
     return result
 
 
@@ -57,7 +57,7 @@ def start(label, directory, env, volume=None, init_dir=None):
         docker('volume', 'create', volume)
         volumes.append(volume)
     containers.append(name)
-    args = ['run', '-d', '--name', name, '--network', 'none', '-v', volume + ':/var/lib/mysql',
+    args = ['run', '-d', '--name', name, '--network', 'none', '--cap-add', 'SYS_PTRACE', '-v', volume + ':/var/lib/mysql',
             '-v', str(directory) + ':/run/test-secrets:ro']
     if init_dir is not None:
         args += ['-v', str(init_dir) + ':/docker-entrypoint-initdb.d:ro']
@@ -102,6 +102,8 @@ def check_no_secret_output(name, passwords):
     inspected = docker('inspect', name).stdout
     processes = docker('top', name, '-eo', 'args').stdout
     environment = docker('exec', name, 'sh', '-c', 'cat /proc/1/environ').stdout
+    # Include unique suffixes so SQL/option-file escaping cannot hide leakage.
+    passwords = passwords + [password[-33:-1] for password in passwords]
     for password in passwords:
         assert_safe(password not in captured + inspected + processes + environment,
                     'A credential appeared in container metadata, logs or process state.')
@@ -166,6 +168,7 @@ def main():
             ('missing', {**env, 'MARIADB_PASSWORD_FILE': '/run/test-secrets/absent.secret'}),
             ('identifier', {**env, 'MARIADB_DATABASE': 'invalid`; DROP DATABASE mysql;--'}),
             ('empty-value', {'MARIADB_PASSWORD': ''}),
+            ('empty-file-path', {**env, 'MARIADB_PASSWORD_FILE': ''}),
         ]:
             name, _ = start(label, directory, invalid)
             wait_failed(name)


### PR DESCRIPTION
Issue #4 requires replacing shared database credentials before internet publication. The existing image passes the root password in a shutdown command argument. This change adds private password-file inputs for new volumes, removes that argument, preserves punctuation and spaces through SQL authentication, and leaves existing database credentials/data unchanged.

Initialization stays on a private Unix socket until credential setup succeeds. An interrupted first boot leaves a marker that blocks subsequent network startup, preventing an incompletely secured database from appearing ready. Password-bearing SQL errors are suppressed; resolved credentials are cleared from child environments. Legacy local defaults remain supported when password variables are absent.

Stacked on #58. This is the image prerequisite for service-secret rotation; the supervisor still uses its existing credentials. It does not enable internet hosting, rotate existing accounts, or close #4.

Final validation at `aea3cbfe4a042ec49209503566963e835f7e338a`: native x64 and arm64 database/image jobs passed in [images run 34126319221](https://github.com/Flux159/ragnarokoffline.app/actions/runs/34126319221), including all real MariaDB credential tests. Both full image bundles are attached as seven-day workflow artifacts; Publish was skipped. All four app checks passed in [Test run 34126324441](https://github.com/Flux159/ragnarokoffline.app/actions/runs/34126324441). The same MariaDB integration suite passed locally on arm64; shellcheck passed too. Initial CI attempts exposed a test-only Docker process-list format error, fixed before this final run.

Current stack validation: all client/Linux/macOS/Windows checks pass at `17fcdc8` ([CI](https://github.com/Flux159/ragnarokoffline.app/actions/runs/34134801270)). This head includes the bounded, authenticated Windows readiness retry from #53; the feature changes remain isolated from their parent PR. Nothing has been advanced to main or released.
