### PR TITLE
Add owner-only account creation policy to Settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,15 @@ doesn't matter if you pick `_M` or `_F`, you are still able to create male and
 female characters after logging in. After your first account creation, you can 
 login as `myname`  without the suffix. Both the name and the password need at least four characters.
 
+To approve accounts yourself, choose **Settings → Accounts → New account creation →
+Owner only, through Settings**, then **Apply account creation policy and restart**.
+This disables `_M` / `_F` signup while existing accounts keep working. Create
+ordinary accounts with **Create friend account** in the same panel. The account
+creation policy applies to both eras and survives Repair and era changes; accounts
+and passwords themselves remain separate for each era. Local/LAN installs retain
+login signup until you change this setting. Internet sharing is still under
+development and requires additional access and credential safeguards.
+
 Ordinary accounts have almost no `@` commands — rAthena keeps `@autoloot` and
 `@showexp` for GMs. Settings → Mods → **player-commands** gives player characters some common commands.
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -333,3 +333,16 @@ are never part of the application payload.
 To also test a real host stopping when it becomes a joiner, run the stopped-world
 era harness above with `RO_E2E_JOIN_AT_END=1`. It verifies that all local game and
 engine ports close, and that applying Settings in Join mode keeps them closed.
+
+
+### Owner account creation policy
+
+`tests/e2e/registration-settings.cjs` owns a stopped disposable world, using the
+same `RO_E2E_WORLD` / `RO_E2E_CLIENT_JSON` inputs as the era Settings fixture. It
+checks actual game signup when enabled, rejected `_M` and `_F` signup with owner
+policy, group-0 account creation through Settings, existing GM characters in both
+eras, and policy persistence through Repair and renewal → pre-renewal → renewal.
+It saves Settings/game screenshots and a credential-free JSON report under the
+world's `account-tests/registration-*` directory. Test accounts stay in that
+disposable database; the fixture restores the original local settings and stops
+its server before exiting. Do not run it against a player save.

--- a/electron/main.js
+++ b/electron/main.js
@@ -786,6 +786,7 @@ async function linkClientOwned(paths) {
 }
 
 const SETTINGS_DEFAULTS = {
+	open_registration: true,
 	base_exp_rate: 100,
 	job_exp_rate: 100,
 	quest_exp_rate: 100,
@@ -817,11 +818,7 @@ const SETTINGS_DEFAULTS = {
 };
 
 function getSettings() {
-	try {
-		return { ...SETTINGS_DEFAULTS, ...JSON.parse(fs.readFileSync(path.join(stateDir(), 'settings.json'), 'utf8')) };
-	} catch {
-		return { ...SETTINGS_DEFAULTS };
-	}
+	return require('./settings-store').read(path.join(stateDir(), 'settings.json'), SETTINGS_DEFAULTS);
 }
 
 // rAthena has no zeny multiplier: whether monsters drop zeny at all is a
@@ -927,7 +924,7 @@ async function saveSettings(settings) {
 	// settings written there would be silently lost.
 	const state = stateDir();
 	fs.mkdirSync(path.join(state, 'conf'), { recursive: true });
-	fs.writeFileSync(path.join(state, 'settings.json'), JSON.stringify(settings, null, 2));
+	settings = require('./settings-store').write(path.join(state, 'settings.json'), settings, SETTINGS_DEFAULTS);
 	writeSettingsFiles(settings);
 
 	// A marker rather than a value: stack.sh regenerates the Kafra scripts from

--- a/electron/settings-store.js
+++ b/electron/settings-store.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const crypto = require('node:crypto');
+const LIMIT = 1024 * 1024;
+const ERROR = 'Cannot read account creation policy. Repair settings.json before starting the server; registration was not enabled.';
+
+function validate(settings) {
+  if (!settings || typeof settings !== 'object' || Array.isArray(settings) ||
+      (Object.hasOwn(settings, 'open_registration') && typeof settings.open_registration !== 'boolean')) {
+    throw new Error(ERROR);
+  }
+  return settings;
+}
+
+function read(file, defaults) {
+  let body;
+  try {
+    if (fs.statSync(file).size > LIMIT) throw new Error(ERROR);
+    body = fs.readFileSync(file, 'utf8');
+  } catch (error) {
+    if (error.code === 'ENOENT') return { ...defaults };
+    throw new Error(ERROR);
+  }
+  try { return { ...defaults, ...validate(JSON.parse(body)) }; }
+  catch { throw new Error(ERROR); }
+}
+
+function write(file, update, defaults) {
+  validate(update);
+  const settings = validate({ ...read(file, defaults), ...update });
+  const body = JSON.stringify(settings, null, 2) + '\n';
+  if (Buffer.byteLength(body) > LIMIT) throw new Error(ERROR);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  const temporary = file + '.' + crypto.randomBytes(12).toString('hex') + '.tmp';
+  let fd;
+  try {
+    fd = fs.openSync(temporary, 'wx', 0o600);
+    fs.writeFileSync(fd, body);
+    fs.fsyncSync(fd);
+    fs.closeSync(fd);
+    fd = undefined;
+    fs.renameSync(temporary, file);
+  } finally {
+    if (fd !== undefined) fs.closeSync(fd);
+    fs.rmSync(temporary, { force: true });
+  }
+  return settings;
+}
+
+module.exports = { read, write };

--- a/src/settings.html
+++ b/src/settings.html
@@ -702,8 +702,9 @@ $('registration-save').onclick = async () => {
   button.disabled = true;
   status.textContent = 'Saving account creation policy and restarting…';
   try {
-    const settings = await invoke('get_settings');
-    settings.open_registration = $('open-registration').value === 'open';
+    // Merge this one preference inside the serialized owner operation, so a
+    // concurrent era change cannot be overwritten by an older UI snapshot.
+    const settings = { open_registration: $('open-registration').value === 'open' };
     await invoke('save_settings', { settings });
     const mode = await invoke('get_mode');
     status.textContent = mode.mode === 'join'

--- a/src/settings.html
+++ b/src/settings.html
@@ -175,6 +175,14 @@
     <p class="note">Manage accounts on your own running server. Renewal and pre-renewal
       have separate accounts and passwords. Changes disconnect current players and restart
       game services; account IDs, privileges and characters are preserved.</p>
+    <label><span>New account creation</span><select id="open-registration">
+      <option value="open">Anyone at the game login screen</option>
+      <option value="owner">Owner only, through Settings</option>
+    </select></label>
+    <p class="note">Owner only disables _M / _F signup. Existing accounts keep working.
+      This policy applies to both eras. Apply and restart to change it.</p>
+    <button id="registration-save" class="ghost">Apply account creation policy and restart</button>
+    <p class="note" id="registration-status" role="status" aria-live="polite"></p>
     <div class="row"><span id="accounts-era">Choose Refresh to load the current era</span>
       <button id="accounts-refresh" class="ghost">Refresh accounts</button></div>
     <p class="note" id="accounts-status" role="status" aria-live="polite"></p>
@@ -688,12 +696,34 @@ $('mods-apply').onclick = () => withButton('mods-apply', 'Applying…', 'Apply',
   return 'Mods applied. Restart the app for client-side changes.';
 });
 
+$('registration-save').onclick = async () => {
+  const button = $('registration-save');
+  const status = $('registration-status');
+  button.disabled = true;
+  status.textContent = 'Saving account creation policy and restarting…';
+  try {
+    const settings = await invoke('get_settings');
+    settings.open_registration = $('open-registration').value === 'open';
+    await invoke('save_settings', { settings });
+    const mode = await invoke('get_mode');
+    status.textContent = mode.mode === 'join'
+      ? 'Saved for your own server. It will apply when you next host.'
+      : settings.open_registration ? 'Game login signup is enabled.'
+        : 'Only the owner can create accounts through Settings. Existing accounts can still log in.';
+  } catch (error) {
+    status.textContent = `Could not apply account creation policy: ${String(error)}. Start the server to retry.`;
+  } finally {
+    button.disabled = false;
+  }
+};
+
 $('save').onclick = async () => {
   const settings = await invoke('get_settings');
   for (const k of RATES) settings[k] = rateOf(k);
   settings.max_aspd = Number($('max_aspd').value) || 190;
   settings.max_parameter = Number($('max_parameter').value) || 99;
   settings.free_kafra_warp = $('free_kafra_warp').checked;
+  settings.open_registration = $('open-registration').value === 'open';
   settings.prerenewal = eraIsPre;
   settings.zeny_from_mobs = $('zeny_from_mobs').checked;
   $('save').disabled = true;
@@ -726,6 +756,7 @@ invoke('get_settings').then(s => {
   $('max_aspd').value = s.max_aspd ?? 190;
   $('max_parameter').value = s.max_parameter ?? 99;
   $('free_kafra_warp').checked = !!s.free_kafra_warp;
+  $('open-registration').value = s.open_registration === false ? 'owner' : 'open';
   setEra(!!s.prerenewal);
   $('zeny_from_mobs').checked = !!s.zeny_from_mobs;
   $('population_enable').checked = !!s.population_enable;

--- a/stack/src/cmds.rs
+++ b/stack/src/cmds.rs
@@ -1474,6 +1474,8 @@ fn run_server(cfg: &Config, dk: &Docker, name: &str, port: u16, binary: &str, la
 }
 
 pub fn up(cfg: &Config, dk: &Docker, lan: bool, ram_mib: Option<u32>) -> Result<(), String> {
+    // Validate before touching the engine or replacing any running service.
+    let open_registration = crate::registration::enabled(&cfg.state)?;
     let conf = cfg.state.join("conf");
     for d in ["conf", "sql", "backups"] {
         fs::create_dir_all(cfg.state.join(d)).map_err(|e| format!("creating {d}: {e}"))?;
@@ -1605,10 +1607,6 @@ pub fn up(cfg: &Config, dk: &Docker, lan: bool, ram_mib: Option<u32>) -> Result<
         "login_server_ip: ragnarok-db\n", "ipban_db_ip: ragnarok-db\n",
         "char_server_ip: ragnarok-db\n", "map_server_ip: ragnarok-db\n",
         "web_server_ip: ragnarok-db\n", "log_db_ip: ragnarok-db\n"))?;
-    // rAthena ships new_account: no, so roBrowser's simplified registration has
-    // nothing to talk to. This is a single-player server on loopback.
-    write_conf(&conf, "login_conf.txt",
-        "new_account: yes\nacc_name_min_length: 4\npassword_min_length: 4\n")?;
     // The address char and map hand the client to reconnect to. This is the
     // one that actually decides whether a LAN player can play: everything can
     // be bound wide and reachable, and the client will still be told to go to
@@ -1668,6 +1666,9 @@ pub fn up(cfg: &Config, dk: &Docker, lan: bool, ram_mib: Option<u32>) -> Result<
     // on a map that a removed mod used to provide cannot be selected at all.
     rescue_stranded_characters(cfg, dk, &mods.maps);
     write_mod_conf_files(cfg, &mods)?;
+    // Owner account policy is final, after mod assembly, and regenerated for
+    // startup, Repair and each era. Mods cannot reopen suffix registration.
+    write_conf(&conf, "login_conf.txt", &crate::registration::login_config(open_registration))?;
 
     // A mod's allowlisted settings go after ours, because rAthena's config
     // reader takes the last assignment of a key: start_point in particular is
@@ -1833,6 +1834,7 @@ pub fn restore(cfg: &Config, dk: &Docker, src: &str) -> Result<(), String> {
 /// container-level can be cleaned because the daemon is not answering.
 /// Player data is untouched — characters live in the ragnarokmac-db volume.
 pub fn repair(cfg: &Config, dk: &Docker, lan: bool, ram_mib: Option<u32>) -> Result<(), String> {
+    crate::registration::enabled(&cfg.state)?;
     phase(cfg, "Repairing…");
     // Break the lock rather than wait: the usual reason to reach for repair is
     // a previous run that died holding one.

--- a/stack/src/main.rs
+++ b/stack/src/main.rs
@@ -19,6 +19,7 @@ mod json;
 mod mapcache;
 mod mods;
 mod process_identity;
+mod registration;
 mod operation_lock;
 
 use config::Config;

--- a/stack/src/registration.rs
+++ b/stack/src/registration.rs
@@ -1,0 +1,73 @@
+//! Persisted login registration policy, read on every startup/repair/era switch.
+//! Missing legacy settings retain local/LAN behavior; malformed settings never
+//! silently reopen registration. Internet-mode enforcement builds on this policy.
+use crate::json::{self, Value};
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
+
+const LIMIT: u64 = 1024 * 1024;
+const ERROR: &str = "Cannot read account creation policy. Repair settings.json before starting the server; registration was not enabled.";
+
+fn parse(body: &str) -> Result<bool, String> {
+    let settings = json::parse(body).map_err(|_| ERROR)?;
+    if !settings.is_object() {
+        return Err(ERROR.into());
+    }
+    match settings.get("open_registration") {
+        None => Ok(true),
+        Some(Value::Bool(value)) => Ok(*value),
+        _ => Err(ERROR.into()),
+    }
+}
+
+pub fn enabled(state: &Path) -> Result<bool, String> {
+    let file = match File::open(state.join("settings.json")) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(true),
+        Err(_) => return Err(ERROR.into()),
+    };
+    let mut body = String::new();
+    file.take(LIMIT + 1)
+        .read_to_string(&mut body)
+        .map_err(|_| ERROR)?;
+    if body.len() as u64 > LIMIT {
+        return Err(ERROR.into());
+    }
+    parse(&body)
+}
+
+pub fn login_config(enabled: bool) -> String {
+    format!(
+        "new_account: {}\nacc_name_min_length: 4\npassword_min_length: 4\n",
+        if enabled { "yes" } else { "no" }
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn explicit_owner_policy_is_preserved_alongside_other_settings() {
+        assert!(!parse(r#"{"open_registration":false,"prerenewal":true}"#).unwrap());
+        assert!(parse(r#"{"open_registration":true}"#).unwrap());
+        assert!(parse(r#"{"prerenewal":false}"#).unwrap());
+        assert!(login_config(false).starts_with("new_account: no\n"));
+    }
+
+    #[test]
+    fn corrupt_policy_never_becomes_open_registration() {
+        for value in [
+            "",
+            "{",
+            "null",
+            "[]",
+            r#"{"open_registration":"false"}"#,
+            r#"{"open_registration":null}"#,
+            r#"{"open_registration":0}"#,
+        ] {
+            assert!(parse(value).is_err());
+        }
+    }
+}

--- a/tests/e2e/join-settings.cjs
+++ b/tests/e2e/join-settings.cjs
@@ -45,6 +45,11 @@ async function main() {
       expect(await invoke('assets_ready')).toBe(true);
       const settings = await invoke('get_settings');
       expect(await invoke('save_settings', { settings })).toContain('Joining starts no local server');
+      await invoke('save_settings', { settings: { prerenewal: true, max_aspd: 197 } });
+      await owner.locator('#open-registration').selectOption('owner');
+      await owner.locator('#registration-save').click();
+      await expect(owner.locator('#registration-status')).toHaveText('Saved for your own server. It will apply when you next host.');
+      expect(await invoke('get_settings')).toMatchObject({ open_registration: false, prerenewal: true, max_aspd: 197 });
       await invoke('launch_game');
       await expect(boot.locator('h1')).toHaveText('Host authentication fixture');
       expect(boot.url()).toBe(origin + '/api.html?app=ONLINE#invite=' + invite);

--- a/tests/e2e/registration-settings.cjs
+++ b/tests/e2e/registration-settings.cjs
@@ -1,0 +1,189 @@
+// Opt-in real Settings/roBrowser registration policy. Owns one stopped disposable
+// world for the duration; never reads or writes a player's save.
+const fs = require('node:fs');
+const path = require('node:path');
+const net = require('node:net');
+const crypto = require('node:crypto');
+const { _electron, chromium, devices, expect: defaultExpect } = require('@playwright/test');
+const expect = defaultExpect.configure({ timeout: 90000 });
+const generatedSecrets = [];
+function freshPassword() { const value = crypto.randomBytes(8).toString('hex'); generatedSecrets.push(value); return value; }
+const { verifyWorld, snapshot } = require('./support.cjs');
+const work = path.resolve(__dirname, '../..');
+if (!process.env.RO_E2E_WORLD || !process.env.RO_E2E_CLIENT_JSON)
+  throw Error('Set RO_E2E_WORLD and RO_E2E_CLIENT_JSON; stop the disposable world first');
+const world = fs.realpathSync(process.env.RO_E2E_WORLD);
+if (JSON.parse(fs.readFileSync(path.join(world, '.ragnarok-e2e.json'))).disposable !== true)
+  throw Error('Not a disposable world');
+const clientPath = path.join(world, 'client.json');
+if (fs.existsSync(clientPath)) throw Error('Fixture requires no existing client.json');
+const selected = JSON.parse(fs.readFileSync(process.env.RO_E2E_CLIENT_JSON));
+const state = path.join(world, 'state');
+const settingsPath = path.join(state, 'settings.json');
+const settings = fs.existsSync(settingsPath) ? fs.readFileSync(settingsPath) : null;
+if (fs.existsSync(path.join(state, 'prerenewal'))) throw Error('Start with renewal selected');
+const credentials = Object.fromEntries(['renewal', 'prerenewal'].map(era => [era,
+  JSON.parse(fs.readFileSync(path.join(world, era === 'renewal'
+    ? 'account-test-credentials.json' : 'prerenewal-account-test-credentials.json'))),
+]));
+const out = path.join(world, 'account-tests', 'registration-' + Date.now());
+fs.mkdirSync(out, { recursive: true });
+const report = { checks: [], screens: [], pageErrors: [] };
+const env = { ...process.env, RAGNAROK_OFFLINE_HOME: world,
+  RAGNAROKMAC_ROOT: path.join(world, 'runtime'), RAGNAROKMAC_STATE: state,
+  NEBULA_HOME: path.join(world, 'nebula') };
+async function freePorts() {
+  for (const port of [3338, 6900, 6121, 5121, 7462]) {
+    await new Promise((resolve, reject) => {
+      const socket = net.connect(port, '127.0.0.1');
+      socket.once('connect', () => { socket.destroy(); reject(Error(`Port ${port} is occupied; stop the other host first`)); });
+      socket.once('error', e => e.code === 'ECONNREFUSED' ? resolve() : reject(e));
+      socket.setTimeout(1000, () => { socket.destroy(); reject(Error(`Port ${port} did not refuse connections`)); });
+    });
+  }
+}
+async function main() {
+  await freePorts();
+  const app = await _electron.launch({ executablePath: require('electron'),
+    args: [path.join(work, 'electron/main.js'), '--user-data-dir=' + path.join(world, 'registration-electron-profile')],
+    env, cwd: work, timeout: 45000 });
+  let owner, browser;
+  const invoke = (name, args) => owner.evaluate(({ name, args }) => window.__ELECTRON__.core.invoke(name, args), { name, args });
+  try {
+    owner = await app.firstWindow();
+    await expect(owner.locator('body')).toContainText('Waiting for your client', { timeout: 30000 });
+    await invoke('set_client_paths', { paths: { ...selected, mode: 'host', lan: false, vm_ram_mib: 4096 } });
+    await invoke('start_stack');
+    await verifyWorld();
+    await invoke('open_settings');
+    await expect.poll(() => app.windows().some(p => p.url().endsWith('settings.html'))).toBe(true);
+    const page = app.windows().find(p => p.url().endsWith('settings.html'));
+    page.setDefaultTimeout(240000);
+    browser = await chromium.launch({ headless: true });
+    report.browser = browser.version();
+    const context = await browser.newContext({ ...devices['Pixel 5'] });
+    const game = await context.newPage();
+    game.setDefaultTimeout(90000);
+    game.on('pageerror', error => report.pageErrors.push(error.message));
+    async function signupAttempt(username, password, allowed) {
+      const isolated = await browser.newContext({ ...devices['Pixel 5'] });
+      try {
+        const attempt = await isolated.newPage();
+        attempt.setDefaultTimeout(45000);
+        await attempt.goto('http://127.0.0.1:3338/');
+        await attempt.getByLabel('Account', { exact: true }).fill(username);
+        await attempt.getByLabel('Password', { exact: true }).fill(password);
+        await attempt.getByRole('button', { name: 'Log in', exact: true }).tap();
+        if (allowed) await expect(attempt.getByRole('button', { name: 'Character slot 1', exact: true })).toBeVisible();
+        else await expect(attempt.locator('.text').filter({ hasText: /Incorrect User ID or Password/ })).toBeVisible();
+      } finally { await isolated.close(); }
+    }
+    // Verify the opt-out reverses cleanly while this is a local test host.
+    await page.locator('#open-registration').selectOption('open');
+    await page.locator('#registration-save').click();
+    await expect(page.locator('#registration-status')).toHaveText('Game login signup is enabled.', { timeout: 240000 });
+    const openUser = 'astraopen' + crypto.randomBytes(4).toString('hex');
+    await signupAttempt(openUser + '_M', freshPassword(), true);
+    const openAccounts = await invoke('accounts', { action: 'list', era: 'renewal' });
+    expect(openAccounts.accounts.find(a => a.username === openUser)).toMatchObject({ group: 0, state: 0 });
+    report.openSignupWorks = true;
+    console.log('Native login signup enabled and verified');
+    await page.locator('#open-registration').selectOption('owner');
+    await page.locator('#registration-save').click();
+    await expect(page.locator('#registration-status')).toContainText('Only the owner can create accounts', { timeout: 240000 });
+    console.log('Owner-only policy applied through Settings');
+    await page.locator('#accounts-panel').screenshot({ path: path.join(out, 'owner-policy.png') });
+    for (const era of ['renewal', 'prerenewal', 'renewal']) {
+      if (report.checks.length) {
+        await game.goto('about:blank');
+        await page.locator(era === 'renewal' ? '#era-re' : '#era-pre').click();
+        const label = era === 'renewal' ? 'renewal' : 'pre-renewal';
+        await expect(page.locator('#era-status')).toContainText(`Switched to ${label} in`, { timeout: 240000 });
+      }
+      await verifyWorld();
+      expect(fs.readFileSync(path.join(state, 'conf/login_conf.txt'), 'utf8')).toMatch(/^new_account: no$/m);
+      expect((await invoke('get_settings')).open_registration).toBe(false);
+      for (const suffix of ['_M', '_F']) {
+        await signupAttempt('astradeny' + crypto.randomBytes(4).toString('hex') + suffix,
+          freshPassword(), false);
+      }
+      if (era === 'prerenewal') {
+        await invoke('stack_repair');
+        await verifyWorld();
+        expect(fs.readFileSync(path.join(state, 'conf/login_conf.txt'), 'utf8')).toMatch(/^new_account: no$/m);
+        await signupAttempt('astrarepair' + crypto.randomBytes(3).toString('hex') + '_F',
+          freshPassword(), false);
+        report.repairRetainsOwnerPolicy = true;
+      }
+      const friend = 'astraowner' + crypto.randomBytes(4).toString('hex');
+      const friendPassword = freshPassword();
+      await page.locator('#account-username').fill(friend);
+      await page.locator('#account-password').fill(friendPassword);
+      await page.locator('#account-confirmation').fill(friendPassword);
+      await page.locator('#accounts-refresh').click();
+      await expect(page.locator('#accounts-era')).toHaveText(era === 'renewal' ? 'Renewal accounts' : 'Pre-renewal accounts');
+      // Refresh intentionally clears password fields; enter only after it finishes.
+      await page.locator('#account-username').fill(friend);
+      await page.locator('#account-password').fill(friendPassword);
+      await page.locator('#account-confirmation').fill(friendPassword);
+      await page.locator('#account-create').click();
+      await expect(page.locator('#accounts-status')).toContainText('Account updated in ' + era);
+      await signupAttempt(friend, friendPassword, true);
+      report.approvedAccounts = [...(report.approvedAccounts || []), { era, username: friend }];
+      await page.getByRole('button', { name: 'Refresh accounts', exact: true }).click();
+      await expect(page.locator('#accounts-era')).toHaveText(era === 'renewal' ? 'Renewal accounts' : 'Pre-renewal accounts');
+      const accounts = await invoke('accounts', { action: 'list', era });
+      const gm = accounts.accounts.find(a => a.id === '2000000');
+      expect(gm).toMatchObject({ username: 'ragnarok', group: 99, state: 0, defaultPassword: false });
+      const config = await (await context.request.get('http://127.0.0.1:3338/Config.local.js')).text();
+      expect(config).toContain(`renewal: ${era === 'renewal'},`);
+      const prefix = String(report.checks.length) + '-' + era;
+      await page.locator('#accounts-panel').screenshot({ path: path.join(out, prefix + '-accounts.png') });
+      await game.goto('http://127.0.0.1:3338/');
+      await game.getByLabel('Account', { exact: true }).fill(credentials[era].account);
+      await game.getByLabel('Password', { exact: true }).fill(credentials[era].password);
+      await game.getByRole('button', { name: 'Log in', exact: true }).tap();
+      await game.getByRole('button', { name: 'Character slot 1', exact: true }).tap();
+      await game.getByRole('button', { name: 'Play / create', exact: true }).tap();
+      if (era === 'prerenewal') {
+        await expect.poll(async () => await game.getByLabel('Character name', { exact: true }).isVisible()
+          || !!(await snapshot(game))?.input?.canMove).toBe(true);
+        if (await game.getByLabel('Character name', { exact: true }).isVisible()) {
+          await game.getByLabel('Character name', { exact: true }).fill('AstraEra');
+          await game.getByRole('button', { name: 'Create', exact: true }).tap();
+          await game.getByRole('button', { name: 'Character slot 1', exact: true }).tap();
+          await game.getByRole('button', { name: 'Play / create', exact: true }).tap();
+        }
+      }
+      await expect.poll(async () => (await snapshot(game)).input.canMove, { timeout: 90000 }).toBe(true);
+      expect(await game.evaluate(() => window.ROConfigLocal.servers[0].renewal)).toBe(era === 'renewal');
+      const current = await snapshot(game);
+      report.checks.push({ era, configMatches: true, gm, player: current.player, map: current.map });
+      await game.screenshot({ path: path.join(out, prefix + '-map.png') });
+      report.screens.push(prefix + '-accounts.png', prefix + '-map.png');
+      console.log('Owner registration policy and existing game login passed:', era);
+    }
+    expect(report.pageErrors).toEqual([]);
+    console.log('Registration Settings/game checks passed. Evidence:', out);
+  } finally {
+    if (browser) await browser.close();
+    // Use the owning shell to stop its assets before restoring selection files.
+    // If teardown fails, retain the files so a later launch sees the true state.
+    let stopped = false;
+    try { if (owner) { await invoke('assets_stop'); await invoke('stack_down'); stopped = true; } }
+    finally {
+      await app.evaluate(({ app }) => app.exit(0)).catch(() => {});
+      if (stopped) {
+        fs.rmSync(clientPath);
+        if (settings) fs.writeFileSync(settingsPath, settings); else fs.rmSync(settingsPath, { force: true });
+        fs.rmSync(path.join(state, 'prerenewal'), { force: true });
+      }
+      fs.writeFileSync(path.join(out, 'report.json'), JSON.stringify(report, null, 2));
+    }
+  }
+}
+main().catch(error => {
+  let message = String(error.message);
+  for (const password of [...Object.values(credentials).map(c => c.password), ...generatedSecrets]) message = message.split(password).join('[redacted]');
+  console.error(message); process.exitCode = 1;
+});

--- a/tests/e2e/registration-settings.cjs
+++ b/tests/e2e/registration-settings.cjs
@@ -136,7 +136,7 @@ async function main() {
       await page.locator('#account-password').fill(friendPassword);
       await page.locator('#account-confirmation').fill(friendPassword);
       await page.locator('#account-create').click();
-      await expect(page.locator('#accounts-status')).toContainText('Account updated in ' + era);
+      await expect(page.locator('#accounts-status')).toContainText('Account updated in ' + (era === 'prerenewal' ? 'pre-renewal' : era));
       await signupAttempt(friend, friendPassword, true);
       report.approvedAccounts = [...(report.approvedAccounts || []), { era, username: friend }];
       await page.getByRole('button', { name: 'Refresh accounts', exact: true }).click();

--- a/tests/e2e/registration-settings.cjs
+++ b/tests/e2e/registration-settings.cjs
@@ -75,7 +75,16 @@ async function main() {
         await attempt.getByLabel('Password', { exact: true }).fill(password);
         await attempt.getByRole('button', { name: 'Log in', exact: true }).tap();
         if (allowed) await expect(attempt.getByRole('button', { name: 'Character slot 1', exact: true })).toBeVisible();
-        else await expect(attempt.locator('.text').filter({ hasText: /Incorrect User ID or Password/ })).toBeVisible();
+        else {
+          // REFUSE_LOGIN code 0 is an unregistered ID; code 1 is a wrong
+          // password for an existing account. Assert the actual pinned message.
+          await expect(attempt.locator('.text').filter({ hasText: /Unregistered ID/ })).toBeVisible();
+          const era = (await invoke('get_settings')).prerenewal ? 'prerenewal' : 'renewal';
+          const accounts = await invoke('accounts', { action: 'list', era });
+          expect(accounts.accounts.some(a => [username, username.replace(/_[MF]$/, '')].includes(a.username))).toBe(false);
+          report.rejectedSignupCount = (report.rejectedSignupCount || 0) + 1;
+          if (report.rejectedSignupCount === 1) await attempt.screenshot({ path: path.join(out, 'signup-denied.png') });
+        }
       } finally { await isolated.close(); }
     }
     // Verify the opt-out reverses cleanly while this is a local test host.

--- a/tests/settings-store.test.cjs
+++ b/tests/settings-store.test.cjs
@@ -1,0 +1,43 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const store = require('../electron/settings-store');
+const defaults = { open_registration: true, prerenewal: false };
+function fixture(t) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ro-registration-'));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  return path.join(dir, 'settings.json');
+}
+
+test('legacy settings retain local signup; owner policy survives partial updates and era changes', t => {
+  const file = fixture(t);
+  assert.deepEqual(store.read(file, defaults), defaults);
+  fs.writeFileSync(file, '{"max_aspd":190}');
+  assert.equal(store.read(file, defaults).open_registration, true);
+  store.write(file, { open_registration: false }, defaults);
+  store.write(file, { prerenewal: true }, defaults);
+  assert.deepEqual(store.read(file, defaults), { open_registration: false, prerenewal: true, max_aspd: 190 });
+  assert.deepEqual(fs.readdirSync(path.dirname(file)), ['settings.json']);
+});
+
+test('malformed saved policy fails closed and is never overwritten with defaults', t => {
+  const file = fixture(t);
+  for (const body of ['{', 'null', '[]', '{"open_registration":"false"}', '{"open_registration":null}', ' '.repeat(1024 * 1024 + 1)]) {
+    fs.writeFileSync(file, body);
+    assert.throws(() => store.read(file, defaults), /Cannot read account creation policy/);
+    assert.throws(() => store.write(file, { prerenewal: true }, defaults), /Cannot read account creation policy/);
+    assert.equal(fs.readFileSync(file, 'utf8'), body);
+  }
+});
+
+test('invalid updates cannot erase or reopen owner policy', t => {
+  const file = fixture(t);
+  store.write(file, { open_registration: false }, defaults);
+  const previous = fs.readFileSync(file, 'utf8');
+  for (const update of [null, [], { open_registration: undefined }, { open_registration: 'true' }, { open_registration: 1 }]) {
+    assert.throws(() => store.write(file, update, defaults));
+    assert.equal(fs.readFileSync(file, 'utf8'), previous);
+  }
+});

--- a/tests/settings-store.test.cjs
+++ b/tests/settings-store.test.cjs
@@ -41,3 +41,24 @@ test('invalid updates cannot erase or reopen owner policy', t => {
     assert.equal(fs.readFileSync(file, 'utf8'), previous);
   }
 });
+
+test('the real supervisor rejects corrupt policy before startup or Repair reaches the engine', { skip: !process.env.STACK_BIN }, t => {
+  const { spawnSync } = require('node:child_process');
+  const file = fixture(t);
+  const root = path.dirname(file);
+  const fake = path.join(root, 'must-not-execute' + (process.platform === 'win32' ? '.exe' : ''));
+  fs.writeFileSync(fake, 'This is deliberately not an executable.', { mode: 0o700 });
+  fs.writeFileSync(file, '{"open_registration":"false"}');
+  for (const verb of ['up', 'repair']) {
+    const result = spawnSync(process.env.STACK_BIN, [verb], {
+      encoding: 'utf8', timeout: 5000,
+      env: { ...process.env, RAGNAROK_OFFLINE_ROOT: root, RAGNAROKMAC_STATE: root,
+        NEBULA_HOME: path.join(root, 'never-started'), NEBULA_BIN: fake, RAGNAROKMAC_DOCKER: fake },
+    });
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /Cannot read account creation policy/);
+    assert.equal(fs.existsSync(path.join(root, 'never-started')), false);
+    assert.equal(fs.existsSync(path.join(root, 'phase')), false);
+    assert.equal(fs.readFileSync(file, 'utf8'), '{"open_registration":"false"}');
+  }
+});


### PR DESCRIPTION
Hosts can now choose **Settings → Accounts → New account creation → Owner only, through Settings** and apply it with a server restart. This disables rAthena's `_M` / `_F` signup while retaining existing logins and the owner-side group-0 account creation added in #57. The setting applies to both eras; their accounts/passwords remain separate.

The supervisor reads the policy before engine work on startup and Repair, writes the effective login configuration after mod assembly, and preserves it on era changes. Settings writes now preserve omitted preferences and replace the file atomically. Malformed, oversized or wrongly typed saved settings fail closed instead of falling back to open signup. Missing legacy preferences retain current local/LAN behavior.

Stacked on #59 for issue #4. This is the local/LAN policy control that internet modes will require; invite/session protection, service credential rotation and connector readiness enforcement remain separate work. No public endpoint is enabled.

Validation at `26c1038f4a298bd4e9ecf564e38cf13cbcf2d9a1`: all four app jobs passed in [Test run 34128017121](https://github.com/Flux159/ragnarokoffline.app/actions/runs/34128017121). Locally, 54 Rust tests and all 44 Node tests passed with no skips, including real-supervisor rejection of corrupt policy before startup/Repair reaches the VM. Settings inline script, Electron syntax and diff checks passed.

Real Electron/roBrowser validation passed in a disposable world with Chromium 153.0.8010.12: open signup, seven rejected `_M`/`_F` attempts with no corresponding DB account, three owner-approved accounts that log in, policy retained through Repair, and existing GM characters through renewal → pre-renewal → renewal. Zero page errors; Settings, rejected-signup and both-era gameplay screenshots were inspected. A separate HTTP/HTTPS Join fixture verified the final UI preserves other preferences and starts no local VM. The owning test shell stopped its world and restored original local settings; all fixed game/engine ports are free. Screenshots/report are retained locally under `artifacts/issue-6/world/account-tests/registration-1788787983300` and `registration-join-final`.

No merge or release is requested. Full internet-hosting acceptance remains open.

Current stack validation: all client/Linux/macOS/Windows checks pass at `ab8aae2` ([CI](https://github.com/Flux159/ragnarokoffline.app/actions/runs/34134801228)). This head includes the bounded, authenticated Windows readiness retry from #53; the feature changes remain isolated from their parent PR. Nothing has been advanced to main or released.
