### PR TITLE
Manage private era-specific database and interserver credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ and passwords themselves remain separate for each era. Local/LAN installs retain
 login signup until you change this setting. Internet sharing is still under
 development and requires additional access and credential safeguards.
 
+For internal server passwords, **Settings → Accounts → Secure internal server
+credentials** saves a backup and replaces the selected era’s shared service
+credentials. Game logins and characters are preserved. See
+[managed internal credentials](docs/SERVICE_CREDENTIALS.md) for persistence and
+recovery; internet access still requires additional safeguards.
+
 Ordinary accounts have almost no `@` commands — rAthena keeps `@autoloot` and
 `@showexp` for GMs. Settings → Mods → **player-commands** gives player characters some common commands.
 

--- a/containers/mariadb/Dockerfile
+++ b/containers/mariadb/Dockerfile
@@ -6,6 +6,7 @@
 # floating: MariaDB cannot open a data directory written by a newer major
 # version, so an unannounced upgrade would leave existing characters unreadable.
 FROM alpine:3.23
+LABEL app.ragnarokoffline.private-db-files="v1"
 
 # One layer on purpose. A later `rm` only hides files from the filesystem view —
 # they stay in the layer that added them, and both layers ship. The install and

--- a/docs/SERVICE_CREDENTIALS.md
+++ b/docs/SERVICE_CREDENTIALS.md
@@ -1,0 +1,56 @@
+# Managed internal credentials
+
+Settings → Accounts → **Secure internal server credentials** replaces this era’s
+shared database root/application passwords and `s1/p1` interserver password with
+independent system-generated values. It saves a backup first, disconnects players
+while their data is saved, and restarts the server. It preserves game accounts,
+passwords, IDs, groups and characters. Run it for each era you intend to host.
+Internet mode will require these credentials; this action alone does not enable
+or authorize internet access.
+
+The equivalent trusted-owner command is `ragnarok-stack secure-services`, with the
+same optional `--lan` and `--ram` flags as `up`. The database must already be running
+in the selected era. The runtime image must advertise
+`app.ragnarokoffline.private-db-files=v1`; an older image is rejected before a
+migration journal or password change. Custom SQL/interserver accounts are refused
+before the first migration rather than silently replacing an unsupported setup.
+
+## Persistence and recovery
+
+Each era’s immutable journal lives under
+`state/private/service-credentials/{renewal,prerenewal}/credentials.json`, outside
+the served asset root. Database secrets are 256-bit hex values; the interserver
+secret has 138 random bits in 23 base64url characters, fitting the pinned protocol’s
+24-byte field including its terminator. Generation uses `/dev/urandom` on Unix and
+[BCryptGenRandom](https://learn.microsoft.com/en-us/windows/win32/api/bcrypt/nf-bcrypt-bcryptgenrandom)
+with the system provider on Windows. No crate dependencies are added.
+
+The journal and derived files are written privately, synced and published before
+SQL changes. Only verified new database logins and the exact interserver row
+produce a `ready` marker. A pending migration can retry with its journal or the
+known legacy root password; completed migrations never fall back to that password.
+Repeated preparation/startup uses the same credentials. It does not regenerate
+secrets because an account or file is missing.
+
+Keep this private state with the VM save disk. Losing or corrupting the journal
+can make an already-secured database inaccessible. Preserve the journal, disk and
+pre-migration SQL backup when recovering; do not delete the marker or substitute
+known defaults. Restoring a SQL backup into an accessible managed database keeps
+its current SQL credentials and reapplies its current interserver secret. Restore
+stops game writers first, retains a pre-restore backup, and leaves the game stopped
+until the owner restarts it. A failed SQL import may be partial and is reported as
+such. SQL backup era metadata/portable restore and scheduled retention remain part
+of the broader backup work.
+
+Host protection uses owner-only Unix ancestors/files and explicit protected
+owner-plus-SYSTEM Windows DACLs. Unsupported filesystems, symlinks/reparse points,
+and secret-file hard links fail closed. Game config is readable by `USER rathena`
+inside the container while its host ancestor stays private. Windows copies are
+staged beneath private app state. SQL clients receive a private option-file path,
+and SQL is carried through bounded stdin; generated passwords are never command
+arguments. The database receives `_FILE` paths, not password environment values.
+
+The image bootstrap, supervisor migration, generated config, backup/restore and
+owner account operations must be deployed together. This work does not provide
+invite/session authentication, mandatory internet signup policy, a tunnel provider
+or a public registration portal; those requirements remain separate gates.

--- a/docs/SERVICE_CREDENTIALS.md
+++ b/docs/SERVICE_CREDENTIALS.md
@@ -14,6 +14,8 @@ in the selected era. The runtime image must advertise
 `app.ragnarokoffline.private-db-files=v1`; an older image is rejected before a
 migration journal or password change. Custom SQL/interserver accounts are refused
 before the first migration rather than silently replacing an unsupported setup.
+Startup reloads a changed bundled image archive even when its image tags already
+exist in the VM cache; a successful load is recorded only after both images exist.
 
 ## Persistence and recovery
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -346,3 +346,24 @@ It saves Settings/game screenshots and a credential-free JSON report under the
 world's `account-tests/registration-*` directory. Test accounts stay in that
 disposable database; the fixture restores the original local settings and stops
 its server before exiting. Do not run it against a player save.
+
+### Internal service credentials
+
+`tests/e2e/service-credentials-settings.cjs` uses those same stopped-world inputs
+and existing per-era GM fixture credentials. Use the bundled image advertising
+`private-db-files=v1`. The test secures renewal and pre-renewal, switches back,
+and verifies existing native character login, unchanged player identities and
+passwords, independent durable service credentials, and rejected legacy SQL root
+authentication. It also exercises managed backup/restore with a legacy interserver
+row, recovery from interrupted password changes, and ordinary account creation,
+password changes, disabling and enabling through the owner IPC.
+
+Recovery deliberately changes the disposable SQL root password back to its known
+legacy value after stopping game writers and removing the pending journal's ready
+marker. Never use this fixture on a player save or publicly reachable host. The
+test restores ordinary Settings and stops its server, but retains managed service
+journals, private backups and test accounts for subsequent acceptance work. Keep
+that private state with the disposable VM disk. Reports and Settings/game
+screenshots are under `account-tests/service-credentials-<timestamp>/`; they do
+not contain passwords. Native packaged migration on Windows/Linux and full
+internet-hosting safeguards remain separate acceptance requirements.

--- a/electron/main.js
+++ b/electron/main.js
@@ -1639,9 +1639,11 @@ const handlers = {
 		return 'Diagnostics copied. Paste them into the issue that just opened.';
 	},
 	stack_repair: () => runStack(['repair']),
-	secure_services: () => {
+	secure_services: async () => {
 		if (getClientPaths().mode !== 'host') throw new Error('Switch to your own server before securing its internal credentials.');
-		return runStack(['secure-services']);
+		const output = await runStack(['secure-services']);
+		return output.match(/^Internal service credentials secured for (?:renewal|prerenewal)\..*$/m)?.[0]
+			|| 'Internal service credentials secured. Player accounts and characters were preserved.';
 	},
 	db_backup: ({ path: p }) => runStack(['backup', p]),
 	db_restore: ({ path: p }) => runStack(['restore', p]),

--- a/electron/main.js
+++ b/electron/main.js
@@ -417,7 +417,7 @@ function migrateDataRoot() {
 // rather than at each call site because there are seven of them and a missed
 // one is a setting that silently does nothing.
 function withEngineFlags(args) {
-	if (args[0] !== 'up' && args[0] !== 'repair') return args;
+	if (!['up', 'repair', 'secure-services'].includes(args[0])) return args;
 	const client = getClientPaths();
 	const out = [...args];
 	if (client.lan && !out.includes('--lan')) out.push('--lan');
@@ -1639,6 +1639,10 @@ const handlers = {
 		return 'Diagnostics copied. Paste them into the issue that just opened.';
 	},
 	stack_repair: () => runStack(['repair']),
+	secure_services: () => {
+		if (getClientPaths().mode !== 'host') throw new Error('Switch to your own server before securing its internal credentials.');
+		return runStack(['secure-services']);
+	},
 	db_backup: ({ path: p }) => runStack(['backup', p]),
 	db_restore: ({ path: p }) => runStack(['restore', p]),
 
@@ -1921,7 +1925,7 @@ const GAME_PAGE_HANDLERS = new Set([]);
 // Includes settings writes before their supervisor call: an era marker must
 // not change halfway through an account operation. Read-only status stays live.
 const SERVER_OPERATIONS = new Set(['accounts', 'save_settings', 'set_mode', 'set_client_paths', 'start_stack',
-	'stack_up', 'stack_down', 'stack_repair', 'db_backup', 'db_restore']);
+	'stack_up', 'stack_down', 'stack_repair', 'secure_services', 'db_backup', 'db_restore']);
 let serverOperationQueue = Promise.resolve();
 function queueServerOperation(operation) {
 	if (tearingDown) return Promise.reject(new Error('The app is quitting; wait until the next launch.'));

--- a/src/settings.html
+++ b/src/settings.html
@@ -202,6 +202,12 @@
     <p class="note">Create an ordinary player account with the password entered above.
       Use 4–23 letters, numbers, underscores or hyphens, without an _M or _F suffix.</p>
     <button id="account-create" class="ghost" disabled>Create friend account</button>
+    <hr />
+    <p class="note">Replace this era’s shared internal server passwords with unique credentials.
+      This saves a backup and disconnects players while the server restarts. Game account
+      passwords and characters are preserved. Keep the app’s private state with your save.</p>
+    <button id="secure-services" class="ghost">Secure internal server credentials</button>
+    <p class="note" id="services-status" role="status" aria-live="polite"></p>
   </div>
 
   <h2>Save data</h2>
@@ -211,7 +217,7 @@
       <button id="backup" class="ghost">Back up…</button>
       <button id="restore" class="ghost">Restore…</button>
     </div>
-    <div class="note" id="db-note">Everything you have played is inside that disk image; it is not a folder you can open.</div>
+    <div class="note" id="db-note">Backups briefly disconnect players so their latest data can be saved consistently. Restore keeps the game stopped until you restart it and preserves a backup of the current database.</div>
   </div>
 
   <h2>Mods</h2>
@@ -695,6 +701,15 @@ $('mods-apply').onclick = () => withButton('mods-apply', 'Applying…', 'Apply',
   await refreshMods();
   return 'Mods applied. Restart the app for client-side changes.';
 });
+
+$('secure-services').onclick = async () => {
+  const button = $('secure-services');
+  button.disabled = true;
+  $('services-status').textContent = 'Backing up and securing this era’s internal credentials…';
+  try { $('services-status').textContent = (await invoke('secure_services')).trim(); }
+  catch (error) { $('services-status').textContent = String(error); }
+  finally { button.disabled = false; }
+};
 
 $('registration-save').onclick = async () => {
   const button = $('registration-save');

--- a/stack/src/accounts.rs
+++ b/stack/src/accounts.rs
@@ -89,7 +89,7 @@ fn verify_password_format(cfg: &Config) -> Result<(), String> {
     Ok(())
 }
 
-fn verify_era(cfg: &Config, dk: &Docker, era: &str) -> Result<(), String> {
+pub(crate) fn verify_era(cfg: &Config, dk: &Docker, era: &str) -> Result<(), String> {
     let volume = match era {
         "renewal" => "ragnarokmac-db",
         "prerenewal" => "ragnarokmac-db-prere",
@@ -166,7 +166,7 @@ fn list(dk: &Docker, era: &str) -> Result<String, String> {
 /// Stop all game sessions before writing: rAthena can save an in-memory login
 /// record and overwrite a concurrent password change. Restart only the services
 /// that were running. The database and all account/character IDs stay intact.
-fn with_servers_stopped<T>(
+pub(crate) fn with_servers_stopped<T>(
     dk: &Docker,
     operation: impl FnOnce() -> Result<T, String>,
 ) -> Result<T, String> {

--- a/stack/src/cmds.rs
+++ b/stack/src/cmds.rs
@@ -3,7 +3,7 @@
 use crate::config::{data_root, home, lan_ip, Config, DB_CONTAINER, NET, SERVERS};
 use crate::docker::{older_than, Docker, Mount};
 use std::fs;
-use std::io::Write;
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::thread::sleep;
@@ -1169,37 +1169,38 @@ fn engine_failure_help(reason: &str) -> String {
 /// guards is unforgiving: with no images, `run` falls through to pulling
 /// `ragnarokmac/mariadb` from a registry that has never heard of it, and the
 /// error is about a network we should never have touched.
-fn ensure_images(cfg: &Config, dk: &Docker) -> Result<(), String> {
-    if dk.image_exists(&cfg.image) && dk.image_exists(&cfg.db_image) {
-        return Ok(());
+// Cache identity, not a security signature. Release provenance/checksums
+// authenticate the packaged archive; this detects changed bytes under fixed tags.
+fn image_bundle_fingerprint(mut reader: impl Read) -> Result<String, String> {
+    let mut hash = 0xcbf2_9ce4_8422_2325u64;
+    let mut block = [0u8; 64 * 1024];
+    loop {
+        let count = reader.read(&mut block).map_err(|_| "Cannot read the server image bundle")?;
+        if count == 0 { break; }
+        for byte in &block[..count] { hash ^= *byte as u64; hash = hash.wrapping_mul(0x0000_0100_0000_01b3); }
     }
+    Ok(format!("{hash:016x}"))
+}
+
+fn ensure_images(cfg: &Config, dk: &Docker) -> Result<(), String> {
+    let present = dk.image_exists(&cfg.image) && dk.image_exists(&cfg.db_image);
     let bundle = cfg.root.join("dist/images.tar.gz");
     if !bundle.exists() {
+        if present { return Ok(()); }
         return Err(format!("no server images, and no bundle at {}", bundle.display()));
     }
-    // Only announce it when there is one to do: a phase that says "first run
-    // only" on every run trains people to ignore it.
-    phase(cfg, "Loading the server images… (first run only)");
-    // `docker load` reads gzip directly, so this needs no external gunzip —
-    // which is the whole point of not shelling out here.
-    let f = fs::File::open(&bundle).map_err(|e| format!("opening the image bundle: {e}"))?;
-    let st = Command::new(&cfg.docker)
-        .arg("load")
-        .env("NEBULA_HOME", &cfg.nebula_home)
-        .stdin(Stdio::from(f))
-        .stdout(Stdio::null())
-        .stderr(Stdio::piped())
-        .status()
-        .map_err(|e| format!("running docker load: {e}"))?;
-    if !st.success() {
-        return Err("could not load the bundled server images".into());
-    }
-    // Verify rather than trust the exit status: a partial load leaves the
-    // caller to run an image that is not there.
+    let fingerprint = image_bundle_fingerprint(fs::File::open(&bundle).map_err(|_| "Cannot open the server image bundle")?)?;
+    let identity = format!("v1:{fingerprint}:{}:{}\n", cfg.image, cfg.db_image);
+    let marker = cfg.state.join("image-bundle.id");
+    if present && fs::read_to_string(&marker).ok().as_deref() == Some(identity.as_str()) { return Ok(()); }
+    phase(cfg, "Loading the bundled server images…");
+    // Always use Docker's owned-engine transport, including Windows' loopback
+    // proxy. Existing fixed image tags are replaced when bundled bytes change.
+    dk.load_bundle(&bundle)?;
     if !dk.image_exists(&cfg.image) || !dk.image_exists(&cfg.db_image) {
         return Err(format!("image load did not produce {} and {}", cfg.image, cfg.db_image));
     }
-    Ok(())
+    fs::write(marker, identity).map_err(|_| "Cannot record the loaded server image bundle".to_string())
 }
 
 /// The Kafra teleport prices are hardcoded in the NPC script with no config
@@ -2029,6 +2030,14 @@ fn human(bytes: u64) -> String {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn changed_image_bytes_invalidate_the_same_tag_cache() {
+        let first = super::image_bundle_fingerprint(&b"same-size-old"[..]).unwrap();
+        let second = super::image_bundle_fingerprint(&b"same-size-new"[..]).unwrap();
+        assert_ne!(first, second);
+        assert_eq!(first, super::image_bundle_fingerprint(&b"same-size-old"[..]).unwrap());
+    }
+
     use super::*;
 
     /// The one contract this file has with another program's prose.

--- a/stack/src/cmds.rs
+++ b/stack/src/cmds.rs
@@ -1473,9 +1473,123 @@ fn run_server(cfg: &Config, dk: &Docker, name: &str, port: u16, binary: &str, la
         .map_err(|e| format!("starting {name}: {e}"))
 }
 
+fn stop_game_services(dk: &Docker) -> Result<(), String> {
+    for service in ["ragnarok-map", "ragnarok-char", "ragnarok-login"] {
+        if dk.is_running(service) && (dk.output(["stop", "-t", "30", service]).is_err() || dk.is_running(service)) {
+            return Err(format!("Could not stop {service} cleanly; database credentials were not changed."));
+        }
+    }
+    Ok(())
+}
+
+fn require_private_database_image(cfg: &Config, dk: &Docker) -> Result<(), String> {
+    let body = dk.output(["image", "inspect", &cfg.db_image]).map_err(|_| "Cannot inspect the database image")?;
+    let parsed = crate::json::parse(&body).map_err(|_| "Cannot inspect the database image")?;
+    let config = match &parsed { crate::json::Value::Array(images) => images.first(), _ => Some(&parsed) }
+        .and_then(|image| image.get("Config")).and_then(|config| config.get("Labels"));
+    if config.and_then(|labels| labels.str("app.ragnarokoffline.private-db-files")) != Some("v1") {
+        return Err("Service credential protection needs an updated bundled database image with private-db-files v1. Update the runtime images before continuing.".into());
+    }
+    Ok(())
+}
+
+fn protect_game_config(cfg: &Config) -> Result<(), String> {
+    crate::private_fs::directory(&cfg.state)?;
+    let conf = cfg.state.join("conf");
+    crate::private_fs::directory(&conf)?;
+    for entry in fs::read_dir(&conf).map_err(|_| "Cannot protect game configuration")? {
+        let entry = entry.map_err(|_| "Cannot protect game configuration")?;
+        // Reject links before writing any secret: a config alias into the
+        // asset root could otherwise expose its bytes through HTTP.
+        crate::private_fs::protect(&entry.path(), false)?;
+    }
+    Ok(())
+}
+
+fn finish_game_config(cfg: &Config) -> Result<(), String> {
+    let conf = cfg.state.join("conf");
+    for entry in fs::read_dir(&conf).map_err(|_| "Cannot protect generated game configuration")? {
+        let entry = entry.map_err(|_| "Cannot protect generated game configuration")?;
+        crate::private_fs::protect(&entry.path(), false)?;
+        #[cfg(unix)] {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(entry.path(), fs::Permissions::from_mode(0o644)).map_err(|_| "Cannot prepare container game configuration")?;
+        }
+    }
+    #[cfg(unix)] {
+        use std::os::unix::fs::PermissionsExt;
+        // The host's state ancestor stays 0700, but this mount root must be
+        // traversable by USER rathena inside the VM. Windows copies preserve
+        // its private host DACL independently of the guest file mode.
+        fs::set_permissions(&conf, fs::Permissions::from_mode(0o755)).map_err(|_| "Cannot prepare container game configuration")?;
+    }
+    Ok(())
+}
+
+fn audit_service_accounts(dk: &Docker, legacy: bool) -> Result<(), String> {
+    let services = dk.root_sql("SELECT COUNT(*) FROM login WHERE sex='S' AND state=0; SELECT COUNT(*) FROM login WHERE account_id=1 AND BINARY userid='s1' AND sex='S' AND state=0;", legacy)?;
+    if services.lines().collect::<Vec<_>>() != ["1", "1"] {
+        return Err("This database has custom or disabled interserver accounts. Migrate those accounts explicitly before enabling managed service credentials; player accounts were not changed.".into());
+    }
+    let users = dk.root_sql("SELECT COUNT(*) FROM mysql.user WHERE User='root' AND Host='localhost'; SELECT COUNT(*) FROM mysql.user WHERE User='ragnarok' AND Host='%'; SELECT COUNT(*) FROM mysql.user WHERE (User='root' AND Host<>'localhost') OR (User='ragnarok' AND Host<>'%');", legacy)?;
+    if users.lines().collect::<Vec<_>>() != ["1", "1", "0"] {
+        return Err("This database has custom SQL service accounts. Migrate them explicitly before enabling managed credentials; player accounts were not changed.".into());
+    }
+    Ok(())
+}
+
+fn migrate_service_credentials(dk: &Docker, credentials: &crate::service_credentials::Credentials) -> Result<(), String> {
+    // Pending journals may be retried after any individual ALTER succeeds.
+    // Ready journals never fall back to the published legacy root password.
+    let mut legacy = false;
+    let mut connected = false;
+    for _ in 0..90 {
+        if dk.root_sql("SELECT 1 FROM login LIMIT 1;", false).is_ok() { connected = true; break; }
+        if !credentials.ready && dk.root_sql("SELECT 1 FROM login LIMIT 1;", true).is_ok() { legacy = true; connected = true; break; }
+        sleep(Duration::from_secs(2));
+    }
+    if !connected { return Err("Cannot authenticate the era's database using its credential journal. Preserve the journal and database; restore a matching backup to recover.".into()); }
+    audit_service_accounts(dk, legacy)?;
+    // All inserted values are generated/validated ASCII tokens, never player
+    // input. DDL commits individually, which is why the journal precedes this.
+    dk.root_sql(&format!("ALTER USER 'ragnarok'@'%' IDENTIFIED BY '{}'; UPDATE login SET user_pass='{}' WHERE account_id=1 AND BINARY userid='s1' AND sex='S'; ALTER USER 'root'@'localhost' IDENTIFIED BY '{}';", credentials.database, credentials.interserver, credentials.root), legacy)?;
+    if dk.root_sql("SELECT 1;", false)?.trim() != "1" || dk.private_sql("SELECT 1;")?.trim() != "1" {
+        return Err("New service credentials did not verify. Keep the journal and retry startup; no game service was started.".into());
+    }
+    let verified = dk.private_sql(&format!("SELECT COUNT(*) FROM login WHERE account_id=1 AND BINARY userid='s1' AND sex='S' AND state=0 AND BINARY user_pass='{}';", credentials.interserver))?;
+    if verified.trim() != "1" { return Err("Interserver credentials did not verify; game services remain stopped.".into()); }
+    credentials.mark_ready()
+}
+
+pub fn secure_services(cfg: &Config, dk: &Docker, lan: bool, ram_mib: Option<u32>) -> Result<(), String> {
+    crate::registration::enabled(&cfg.state)?;
+    dk.require_private_sql()?;
+    crate::accounts::verify_era(cfg, dk, crate::service_credentials::era(cfg))?;
+    ensure_images(cfg, dk)?;
+    require_private_database_image(cfg, dk)?;
+    if crate::service_credentials::load(&cfg.state, crate::service_credentials::era(cfg))?.is_none() {
+        audit_service_accounts(dk, true)?;
+        // The backup must complete before publishing a migration journal. It
+        // includes all player data; secure its host directory before writing.
+        crate::private_fs::directory(&cfg.state)?;
+        let backups = cfg.state.join("backups"); crate::private_fs::directory(&backups)?;
+        stop_game_services(dk)?;
+        let destination = backups.join(format!("before-service-credentials-{}-{}.sql", crate::service_credentials::era(cfg), crate::private_fs::random_hex(8)?));
+        if let Err(error) = backup(cfg, dk, &destination.to_string_lossy()) {
+            return Err(format!("Service credentials were not changed: {error}. Start the server to reconnect."));
+        }
+        crate::private_fs::protect(&destination, false)?;
+    }
+    crate::service_credentials::prepare(cfg)?;
+    up(cfg, dk, lan, ram_mib)?;
+    println!("Internal service credentials secured for {}. Player accounts and characters were preserved.", crate::service_credentials::era(cfg));
+    Ok(())
+}
+
 pub fn up(cfg: &Config, dk: &Docker, lan: bool, ram_mib: Option<u32>) -> Result<(), String> {
     // Validate before touching the engine or replacing any running service.
     let open_registration = crate::registration::enabled(&cfg.state)?;
+    let credentials = crate::service_credentials::load(&cfg.state, crate::service_credentials::era(cfg))?;
     let conf = cfg.state.join("conf");
     for d in ["conf", "sql", "backups"] {
         fs::create_dir_all(cfg.state.join(d)).map_err(|e| format!("creating {d}: {e}"))?;
@@ -1487,6 +1601,17 @@ pub fn up(cfg: &Config, dk: &Docker, lan: bool, ram_mib: Option<u32>) -> Result<
     let _lock = Lock::acquire(cfg)?;
     phase(cfg, "Starting the virtual machine…");
     ensure_engine(cfg, dk, lan, ram_mib)?;
+    if let Some(credentials) = &credentials {
+        credentials.write_files()?;
+        protect_game_config(cfg)?;
+        // Recreate the database with the private bind/copy, including after a
+        // failed migration or a runtime update. Flush players first.
+        stop_game_services(dk)?;
+        if dk.is_running(DB_CONTAINER) && (dk.output(["stop", "-t", "30", DB_CONTAINER]).is_err() || dk.is_running(DB_CONTAINER)) {
+            return Err("Could not stop the database cleanly; credentials were not changed".into());
+        }
+        dk.remove_container(DB_CONTAINER);
+    }
 
     // A failed single-file bind leaves a directory behind at the source path.
     // Clear anything in conf/ that is not a regular file so a stale one cannot
@@ -1519,6 +1644,7 @@ pub fn up(cfg: &Config, dk: &Docker, lan: bool, ram_mib: Option<u32>) -> Result<
     }
 
     ensure_images(cfg, dk)?;
+    if credentials.is_some() { require_private_database_image(cfg, dk)?; }
     dk.quiet(["network", "create", NET]);
 
     // The era decides which volume holds the characters, and a running database
@@ -1547,7 +1673,7 @@ pub fn up(cfg: &Config, dk: &Docker, lan: bool, ram_mib: Option<u32>) -> Result<
 
     if !dk.is_running(DB_CONTAINER) {
         dk.remove_container(DB_CONTAINER);
-        let mounts = vec![
+        let mut mounts = vec![
             Mount::Bind {
                 host: cfg.state.join("sql"),
                 container: "/docker-entrypoint-initdb.d".into(),
@@ -1563,13 +1689,13 @@ pub fn up(cfg: &Config, dk: &Docker, lan: bool, ram_mib: Option<u32>) -> Result<
             },
             Mount::Volume { name: want_volume.clone(), container: "/var/lib/mysql".into() },
         ];
-        let opts: Vec<String> = [
-            "--network", NET,
-            "-e", "MARIADB_ROOT_PASSWORD=ragnarok",
-            "-e", "MARIADB_DATABASE=ragnarok",
-            "-e", "MARIADB_USER=ragnarok",
-            "-e", "MARIADB_PASSWORD=ragnarok",
-        ].iter().map(|s| s.to_string()).collect();
+        let mut opts: Vec<String> = ["--network", NET, "-e", "MARIADB_DATABASE=ragnarok", "-e", "MARIADB_USER=ragnarok"].iter().map(|s| s.to_string()).collect();
+        if let Some(credentials) = &credentials {
+            mounts.push(Mount::Bind { host: credentials.directory.clone(), container: crate::service_credentials::CONTAINER_DIR.into(), ro: true });
+            opts.extend(["-e", "MARIADB_ROOT_PASSWORD_FILE=/run/ragnarok-private/root.secret", "-e", "MARIADB_PASSWORD_FILE=/run/ragnarok-private/database.secret"].iter().map(|s| s.to_string()));
+        } else {
+            opts.extend(["-e", "MARIADB_ROOT_PASSWORD=ragnarok", "-e", "MARIADB_PASSWORD=ragnarok"].iter().map(|s| s.to_string()));
+        }
         dk.run_container(DB_CONTAINER, &cfg.db_image, &[], &mounts, &opts)
             .map_err(|e| format!("starting the database: {e}"))?;
     }
@@ -1577,6 +1703,7 @@ pub fn up(cfg: &Config, dk: &Docker, lan: bool, ram_mib: Option<u32>) -> Result<
     // that is not running.
     let _ = fs::write(&volume_marker, &want_volume);
     phase(cfg, "Starting the database…");
+    if let Some(credentials) = &credentials { migrate_service_credentials(dk, credentials)?; }
     wait_for_db(dk)?;
 
     // Only sql/03-account.sql seeds the GM, during first database creation.
@@ -1607,6 +1734,11 @@ pub fn up(cfg: &Config, dk: &Docker, lan: bool, ram_mib: Option<u32>) -> Result<
         "login_server_ip: ragnarok-db\n", "ipban_db_ip: ragnarok-db\n",
         "char_server_ip: ragnarok-db\n", "map_server_ip: ragnarok-db\n",
         "web_server_ip: ragnarok-db\n", "log_db_ip: ragnarok-db\n"))?;
+    if let Some(credentials) = &credentials {
+        let file = conf.join("inter_conf.txt");
+        let existing = fs::read_to_string(&file).map_err(|_| "Cannot read generated SQL configuration")?;
+        write_conf(&conf, "inter_conf.txt", &format!("{existing}{}", credentials.inter_config()))?;
+    }
     // The address char and map hand the client to reconnect to. This is the
     // one that actually decides whether a LAN player can play: everything can
     // be bound wide and reachable, and the client will still be told to go to
@@ -1676,7 +1808,8 @@ pub fn up(cfg: &Config, dk: &Docker, lan: bool, ram_mib: Option<u32>) -> Result<
     // filling it, so the last line is the whole answer rather than an addition.
     write_conf(&conf, "char_conf.txt",
         &format!("login_ip: ragnarok-login\nchar_ip: {advertise}\npincode_enabled: no\n\
-                  {start_point}\n{}", conf_lines(&mods, "char_conf.txt")))?;
+                  {start_point}\n{}{}", conf_lines(&mods, "char_conf.txt"),
+                  credentials.as_ref().map(|c| format!("userid: s1\npasswd: {}\n", c.interserver)).unwrap_or_default()))?;
 
     let product = if cfg!(target_os = "macos") { "RagnarokMac" }
         else if cfg!(windows) { "RagnarokWindows" }
@@ -1685,8 +1818,9 @@ pub fn up(cfg: &Config, dk: &Docker, lan: bool, ram_mib: Option<u32>) -> Result<
     write_conf(&conf, "motd.txt",
         &format!("Welcome to {product} Offline! Please report any bugs on Github\n"))?;
     write_conf(&conf, "map_conf.txt",
-        &format!("char_ip: ragnarok-char\nmap_ip: {advertise}\nmotd_txt: conf/import/motd.txt\n{}{}{}",
-                 conf_lines(&mods, "map_conf.txt"), mods.map_lines, mods.npc_lines))?;
+        &format!("char_ip: ragnarok-char\nmap_ip: {advertise}\nmotd_txt: conf/import/motd.txt\n{}{}{}{}",
+                 conf_lines(&mods, "map_conf.txt"), mods.map_lines, mods.npc_lines,
+                 credentials.as_ref().map(|c| format!("userid: s1\npasswd: {}\n", c.interserver)).unwrap_or_default()))?;
 
     let endpoint = format!(
         "{{\"host\":\"{advertise}\",\"login\":6900,\"char\":6121,\"map\":5121}}\n");
@@ -1699,6 +1833,7 @@ pub fn up(cfg: &Config, dk: &Docker, lan: bool, ram_mib: Option<u32>) -> Result<
         let _ = fs::write(web.join("endpoint.json"), &endpoint);
     }
 
+    if credentials.is_some() { finish_game_config(cfg)?; }
     prepare_kafra_scripts(cfg, dk);
     phase(cfg, "Starting the login, character and map servers…");
     // login and web are era-independent -- neither src/login nor src/web
@@ -1726,12 +1861,13 @@ pub fn up(cfg: &Config, dk: &Docker, lan: bool, ram_mib: Option<u32>) -> Result<
 
 pub fn down(cfg: &Config, dk: &Docker) -> Result<(), String> {
     let _lock = Lock::acquire(cfg)?;
-    // Game servers hold no state, so killing them is fine. The database does:
-    // stop it gracefully so InnoDB closes cleanly rather than recovering.
+    stop_game_services(dk)?;
     for c in SERVERS {
         dk.remove_container(c);
     }
-    dk.quiet(["stop", "-t", "10", DB_CONTAINER]);
+    if dk.is_running(DB_CONTAINER) && (dk.output(["stop", "-t", "30", DB_CONTAINER]).is_err() || dk.is_running(DB_CONTAINER)) {
+        return Err("Could not stop the database cleanly; the VM was left running to protect the save.".into());
+    }
     dk.remove_container(DB_CONTAINER);
 
     // And the microVM itself, last -- after the database has closed cleanly,
@@ -1770,16 +1906,22 @@ pub fn status(dk: &Docker) {
 }
 
 pub fn backup(cfg: &Config, dk: &Docker, dest: &str) -> Result<(), String> {
+    crate::accounts::verify_era(cfg, dk, crate::service_credentials::era(cfg))?;
+    crate::accounts::with_servers_stopped(dk, || backup_snapshot(cfg, dk, dest))
+}
+
+fn backup_snapshot(cfg: &Config, dk: &Docker, dest: &str) -> Result<(), String> {
     let backups = cfg.state.join("backups");
     fs::create_dir_all(&backups).map_err(|e| e.to_string())?;
     let tmp = format!("ragnarokmac-{}.sql", std::process::id());
 
-    // --single-transaction keeps the server writable during the dump, which
-    // matters because the player may well be logged in while taking one.
+    crate::private_fs::directory(&backups)?;
+    // Players have been saved and game services stopped. This also makes the
+    // mixed-engine rAthena tables consistent; --single-transaction alone would
+    // only protect InnoDB, not all of the schema.
     dk.output([
         "exec", DB_CONTAINER, "sh", "-c",
-        &format!("mariadb-dump -uragnarok -pragnarok --single-transaction --routines \
-                  --databases ragnarok > /backups/{tmp}"),
+        &format!("umask 077; {} --single-transaction --routines --databases ragnarok > /backups/{tmp}", dk.database_client("mariadb-dump")?),
     ])
     .map_err(|_| "the database did not produce a dump (is the server running?)".to_string())?;
 
@@ -1793,6 +1935,8 @@ pub fn backup(cfg: &Config, dk: &Docker, dest: &str) -> Result<(), String> {
         let _ = fs::remove_file(&staged);
         return Err("the dump came out empty".into());
     }
+    crate::private_fs::protect(&staged, false)?;
+    if Path::new(dest).exists() { crate::private_fs::protect(Path::new(dest), false)?; }
     fs::rename(&staged, dest)
         .or_else(|_| fs::copy(&staged, dest).map(|_| ()))
         .map_err(|e| format!("could not write {dest}: {e}"))?;
@@ -1806,11 +1950,17 @@ pub fn restore(cfg: &Config, dk: &Docker, src: &str) -> Result<(), String> {
     if !Path::new(src).is_file() {
         return Err(format!("no such backup: {src}"));
     }
+    crate::accounts::verify_era(cfg, dk, crate::service_credentials::era(cfg))?;
+    stop_game_services(dk)?;
     let backups = cfg.state.join("backups");
-    fs::create_dir_all(&backups).map_err(|e| e.to_string())?;
+    crate::private_fs::directory(&backups)?;
+    let safety = backups.join(format!("before-restore-{}-{}.sql", crate::service_credentials::era(cfg), crate::private_fs::random_hex(8)?));
+    backup_snapshot(cfg, dk, &safety.to_string_lossy())?;
     let tmp = format!("restore-{}.sql", std::process::id());
     let staged = backups.join(&tmp);
+    if staged.exists() { crate::private_fs::protect(&staged, false)?; }
     fs::copy(src, &staged).map_err(|e| format!("staging the backup: {e}"))?;
+    crate::private_fs::protect(&staged, false)?;
     if cfg!(windows) {
         dk.copy_into(DB_CONTAINER, &backups, "/backups")?;
     }
@@ -1818,12 +1968,17 @@ pub fn restore(cfg: &Config, dk: &Docker, src: &str) -> Result<(), String> {
     // wholesale rather than merging into whatever is there now.
     let r = dk.output([
         "exec", DB_CONTAINER, "sh", "-c",
-        &format!("mariadb -uragnarok -pragnarok < /backups/{tmp}"),
+        &format!("{} < /backups/{tmp}", dk.database_client("mariadb")?),
     ]);
     let _ = fs::remove_file(&staged);
     dk.quiet(["exec", DB_CONTAINER, "rm", "-f", &format!("/backups/{tmp}")]);
-    r.map_err(|_| "restore failed; the database is unchanged".to_string())?;
-    println!("restored from {src}");
+    r.map_err(|_| "Restore failed and may have partially changed the database. Keep game services stopped and restore a verified backup.".to_string())?;
+    if let Some(credentials) = crate::service_credentials::load(&cfg.state, crate::service_credentials::era(cfg))? {
+        // An older dump may carry the old interserver login. Restore the
+        // managed service row before any subsequent player reconnect.
+        migrate_service_credentials(dk, &credentials)?;
+    }
+    println!("restored from {src}; game services are stopped. Restart the server to reconnect. A pre-restore backup was preserved.");
     Ok(())
 }
 

--- a/stack/src/cmds.rs
+++ b/stack/src/cmds.rs
@@ -1913,7 +1913,7 @@ pub fn backup(cfg: &Config, dk: &Docker, dest: &str) -> Result<(), String> {
 fn backup_snapshot(cfg: &Config, dk: &Docker, dest: &str) -> Result<(), String> {
     let backups = cfg.state.join("backups");
     fs::create_dir_all(&backups).map_err(|e| e.to_string())?;
-    let tmp = format!("ragnarokmac-{}.sql", std::process::id());
+    let tmp = format!("ragnarokmac-{}-{}.sql", std::process::id(), crate::private_fs::random_hex(12)?);
 
     crate::private_fs::directory(&backups)?;
     // Players have been saved and game services stopped. This also makes the
@@ -1936,10 +1936,10 @@ fn backup_snapshot(cfg: &Config, dk: &Docker, dest: &str) -> Result<(), String> 
         return Err("the dump came out empty".into());
     }
     crate::private_fs::protect(&staged, false)?;
-    if Path::new(dest).exists() { crate::private_fs::protect(Path::new(dest), false)?; }
-    fs::rename(&staged, dest)
-        .or_else(|_| fs::copy(&staged, dest).map(|_| ()))
-        .map_err(|e| format!("could not write {dest}: {e}"))?;
+    if fs::canonicalize(&staged).ok() == fs::canonicalize(dest).ok() {
+        return Err("Choose a backup destination outside the internal staging file".into());
+    }
+    crate::private_fs::export_file(&staged, Path::new(dest))?;
     let _ = fs::remove_file(&staged);
     dk.quiet(["exec", DB_CONTAINER, "rm", "-f", &format!("/backups/{tmp}")]);
     println!("wrote {dest} ({})", human(size));
@@ -1956,7 +1956,7 @@ pub fn restore(cfg: &Config, dk: &Docker, src: &str) -> Result<(), String> {
     crate::private_fs::directory(&backups)?;
     let safety = backups.join(format!("before-restore-{}-{}.sql", crate::service_credentials::era(cfg), crate::private_fs::random_hex(8)?));
     backup_snapshot(cfg, dk, &safety.to_string_lossy())?;
-    let tmp = format!("restore-{}.sql", std::process::id());
+    let tmp = format!("restore-{}-{}.sql", std::process::id(), crate::private_fs::random_hex(12)?);
     let staged = backups.join(&tmp);
     if staged.exists() { crate::private_fs::protect(&staged, false)?; }
     fs::copy(src, &staged).map_err(|e| format!("staging the backup: {e}"))?;

--- a/stack/src/docker.rs
+++ b/stack/src/docker.rs
@@ -17,6 +17,7 @@ use std::time::{Duration, Instant, SystemTime};
 pub struct Docker {
     bin: PathBuf,
     nebula_home: PathBuf,
+    state: PathBuf,
 }
 
 /// Storage attached to a container.
@@ -31,8 +32,8 @@ pub enum Mount {
 }
 
 impl Docker {
-    pub fn new(bin: PathBuf, nebula_home: PathBuf) -> Docker {
-        Docker { bin, nebula_home }
+    pub fn new(bin: PathBuf, nebula_home: PathBuf, state: PathBuf) -> Docker {
+        Docker { bin, nebula_home, state }
     }
 
     fn base(&self) -> Command {
@@ -154,23 +155,46 @@ impl Docker {
         }
     }
 
-    pub fn exec_sql(&self, sql: &str) -> Result<String, String> {
-        self.output([
-            "exec", "ragnarok-db", "mariadb", "--protocol=TCP", "-h127.0.0.1", "-uragnarok", "-pragnarok", "ragnarok", "-e", sql,
-        ])
+    fn sql_auth(&self) -> Result<Vec<String>, String> {
+        // Use the recorded RUNNING volume, not a just-edited era preference.
+        let volume = fs::read_to_string(self.state.join(".db-volume")).unwrap_or_default();
+        let era = if volume.trim() == "ragnarokmac-db-prere" { "prerenewal" } else { "renewal" };
+        if crate::service_credentials::load(&self.state, era)?.is_some() {
+            Ok(vec!["--defaults-extra-file=/run/ragnarok-private/database.cnf".into()])
+        } else { Ok(vec!["-uragnarok".into(), "-pragnarok".into()]) }
     }
 
-    /// Account operations send SQL through a pipe, never argv, a shell or a
-    /// temporary file. Requires docker-slim's exec stdin EOF fix (nebula #33).
-    /// Database errors can quote the query, so stderr must never reach logs.
+    pub fn database_client(&self, binary: &str) -> Result<String, String> {
+        if !["mariadb", "mariadb-dump"].contains(&binary) { return Err("Unsupported database client".into()); }
+        Ok(format!("{binary} {} --protocol=TCP -h127.0.0.1", self.sql_auth()?.join(" ")))
+    }
+
+    pub fn exec_sql(&self, sql: &str) -> Result<String, String> {
+        self.sql(sql, &self.sql_auth()?, true)
+    }
+
+    /// No query or generated password enters argv, logs or raw error text.
     pub fn private_sql(&self, sql: &str) -> Result<String, String> {
+        self.sql(sql, &self.sql_auth()?, false)
+    }
+
+    pub fn root_sql(&self, sql: &str, legacy: bool) -> Result<String, String> {
+        let auth = if legacy { vec!["-uroot".into(), "-pragnarok".into()] }
+            else { vec!["--defaults-extra-file=/run/ragnarok-private/root.cnf".into()] };
+        self.sql(sql, &auth, false)
+    }
+
+    fn sql(&self, sql: &str, auth: &[String], headers: bool) -> Result<String, String> {
         self.require_private_sql()?;
-        let failure = || "The private account database operation failed. Check that the server is running and the bundled container client supports exec stdin EOF.".to_string();
+        let failure = || "The private database operation failed. Start the server to finish any pending credential migration, or restore its matching credential journal and backup.".to_string();
         if sql.len() > 16 * 1024 { return Err(failure()); }
-        let mut child = self.base().args([
-            "exec", "-i", "ragnarok-db", "mariadb", "--protocol=TCP", "-h127.0.0.1", "-uragnarok", "-pragnarok",
-            "--batch", "--skip-column-names", "--raw", "ragnarok",
-        ]).stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::null())
+        let mut args: Vec<String> = ["exec", "-i", "ragnarok-db", "mariadb"].iter().map(|s| s.to_string()).collect();
+        args.extend(auth.iter().cloned());
+        args.extend(["--protocol=TCP", "-h127.0.0.1", "--batch", "--raw"].iter().map(|s| s.to_string()));
+        if !headers { args.push("--skip-column-names".into()); }
+        args.push("ragnarok".into());
+        let mut child = self.base().args(args)
+            .stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::null())
             .spawn().map_err(|_| failure())?;
         let mut stdin = child.stdin.take().ok_or_else(failure)?;
         let input = sql.as_bytes().to_vec();
@@ -289,8 +313,11 @@ impl Docker {
         // which is exactly where they belong.
         let dest_name = dest.rsplit('/').find(|p| !p.is_empty())
             .ok_or_else(|| format!("destination {dest} has no name"))?;
-        let stage = std::env::temp_dir().join(format!("ro-cp-{}-{}", std::process::id(), dest_name));
-        let _ = fs::remove_dir_all(&stage);
+        crate::private_fs::directory(&self.state)?;
+        let private = self.state.join("private");
+        crate::private_fs::directory(&private)?;
+        let stage = private.join(format!("copy-{}", crate::private_fs::random_hex(12)?));
+        crate::private_fs::directory(&stage)?;
         let staged = stage.join(dest_name);
         copy_dir_all(host, &staged)?;
 

--- a/stack/src/docker.rs
+++ b/stack/src/docker.rs
@@ -122,6 +122,15 @@ impl Docker {
         }
     }
 
+    pub fn load_bundle(&self, bundle: &Path) -> Result<(), String> {
+        let file = fs::File::open(bundle).map_err(|_| "Cannot open the bundled server images")?;
+        let status = self.base().arg("load").stdin(Stdio::from(file))
+            .stdout(Stdio::null()).stderr(Stdio::null()).status()
+            .map_err(|_| "Cannot run the bundled image loader")?;
+        if !status.success() { return Err("Could not load the bundled server images".into()); }
+        Ok(())
+    }
+
     pub fn image_exists(&self, image: &str) -> bool {
         self.quiet(["image", "inspect", image])
     }

--- a/stack/src/main.rs
+++ b/stack/src/main.rs
@@ -20,6 +20,8 @@ mod mapcache;
 mod mods;
 mod process_identity;
 mod registration;
+mod private_fs;
+mod service_credentials;
 mod operation_lock;
 
 use config::Config;
@@ -28,7 +30,7 @@ use std::env;
 use std::path::PathBuf;
 use std::process::exit;
 
-const USAGE: &str = "usage: ragnarok-stack mods|mod-enable NAME|mod-disable NAME|up [--lan] [--ram MiB]|down|repair [--lan] [--ram MiB]|status|logs [service] [tail]\n\
+const USAGE: &str = "usage: ragnarok-stack secure-services [--lan] [--ram MiB]|mods|mod-enable NAME|mod-disable NAME|up [--lan] [--ram MiB]|down|repair [--lan] [--ram MiB]|status|logs [service] [tail]\n\
                      \x20      backup <file>|restore <file>\n\
                      \x20      accounts (private JSON request on stdin)\n\
                      \x20      link-assets <data.grf> [rdata.grf] [official_data.grf] [bgm-dir]";
@@ -79,8 +81,8 @@ fn main() {
         Ok(c) => c,
         Err(e) => fail(verb, &e),
     };
-    let dk = Docker::new(cfg.docker.clone(), cfg.nebula_home.clone());
-    let _operation = if matches!(verb, "up" | "down" | "repair" | "backup" | "restore" | "accounts") {
+    let dk = Docker::new(cfg.docker.clone(), cfg.nebula_home.clone(), cfg.state.clone());
+    let _operation = if matches!(verb, "up" | "down" | "repair" | "backup" | "restore" | "accounts" | "secure-services") {
         match operation_lock::acquire(&cfg.state) {
             Ok(lock) => Some(lock),
             Err(error) => fail(verb, &error),
@@ -108,6 +110,7 @@ fn main() {
             }
             Ok(())
         },
+        "secure-services" => cmds::secure_services(&cfg, &dk, lan, ram_mib),
         "up" => cmds::up(&cfg, &dk, lan, ram_mib),
         "down" => cmds::down(&cfg, &dk),
         "repair" => cmds::repair(&cfg, &dk, lan, ram_mib),

--- a/stack/src/private_fs.rs
+++ b/stack/src/private_fs.rs
@@ -1,0 +1,401 @@
+//! Host-side protection for managed service material. Container-facing game
+//! config can remain 0644 below a private Unix ancestor; Windows uses DACLs.
+use std::fs::{self, File, OpenOptions};
+use std::io::{Read, Write};
+use std::path::Path;
+
+const ERROR: &str = "Cannot protect private service files. Use an owner-controlled local filesystem with permissions support.";
+
+pub fn random_hex(bytes: usize) -> Result<String, String> {
+    let mut value = vec![0u8; bytes];
+    #[cfg(unix)]
+    File::open("/dev/urandom")
+        .and_then(|mut file| file.read_exact(&mut value))
+        .map_err(|_| "System random generation failed")?;
+    #[cfg(windows)]
+    unsafe {
+        #[link(name = "bcrypt")]
+        unsafe extern "system" {
+            fn BCryptGenRandom(
+                algorithm: *mut std::ffi::c_void,
+                buffer: *mut u8,
+                size: u32,
+                flags: u32,
+            ) -> i32;
+        }
+        let len = u32::try_from(bytes).map_err(|_| "System random request is too large")?;
+        if BCryptGenRandom(std::ptr::null_mut(), value.as_mut_ptr(), len, 2) < 0 {
+            return Err("System random generation failed".into());
+        }
+    }
+    #[cfg(not(any(unix, windows)))]
+    return Err("System random generation is not supported on this platform".into());
+    Ok(value.iter().map(|byte| format!("{byte:02x}")).collect())
+}
+
+pub fn random_token(length: usize) -> Result<String, String> {
+    const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-";
+    let hex = random_hex(length)?;
+    Ok((0..length)
+        .map(|index| {
+            let byte = u8::from_str_radix(&hex[index * 2..index * 2 + 2], 16)
+                .expect("hex generated above");
+            ALPHABET[(byte & 63) as usize] as char
+        })
+        .collect())
+}
+
+fn metadata(path: &Path) -> Result<fs::Metadata, String> {
+    let info = fs::symlink_metadata(path).map_err(|_| ERROR)?;
+    if info.file_type().is_symlink() {
+        return Err(ERROR.into());
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::MetadataExt;
+        if info.file_attributes() & 0x400 != 0 {
+            return Err(ERROR.into());
+        }
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        unsafe extern "C" {
+            fn geteuid() -> u32;
+        }
+        if info.uid() != unsafe { geteuid() } {
+            return Err(ERROR.into());
+        }
+    }
+    Ok(info)
+}
+
+pub fn directory(path: &Path) -> Result<(), String> {
+    if !path.exists() {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::DirBuilderExt;
+            fs::DirBuilder::new()
+                .mode(0o700)
+                .create(path)
+                .map_err(|_| ERROR)?;
+        }
+        #[cfg(windows)]
+        fs::create_dir(path).map_err(|_| ERROR)?;
+    }
+    if !metadata(path)?.is_dir() {
+        return Err(ERROR.into());
+    }
+    protect(path, true)
+}
+
+pub fn protect(path: &Path, directory: bool) -> Result<(), String> {
+    let info = metadata(path)?;
+    if directory != info.is_dir() || (!directory && !info.is_file()) {
+        return Err(ERROR.into());
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::{MetadataExt, PermissionsExt};
+        if !directory && info.nlink() != 1 {
+            return Err(ERROR.into());
+        }
+        fs::set_permissions(
+            path,
+            fs::Permissions::from_mode(if directory { 0o700 } else { 0o600 }),
+        )
+        .map_err(|_| ERROR)?;
+    }
+    #[cfg(windows)]
+    {
+        if !directory {
+            windows::single_link(path)?;
+        }
+        windows::protect(path, directory)?;
+    }
+    Ok(())
+}
+
+/// The caller first protects the parent directory. Immutable secret material is
+/// published once, fully written and synced; a partial write is never accepted.
+pub fn create(path: &Path, bytes: &[u8]) -> Result<(), String> {
+    if fs::symlink_metadata(path).is_ok() {
+        return Err("Private service file already exists; it was not overwritten".into());
+    }
+    let parent = path.parent().ok_or(ERROR)?;
+    directory(parent)?;
+    let temporary = parent.join(format!(".private-{}.tmp", random_hex(12)?));
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let result = (|| {
+        let mut file = options.open(&temporary).map_err(|_| ERROR)?;
+        protect(&temporary, false)?;
+        file.write_all(bytes)
+            .and_then(|_| file.sync_all())
+            .map_err(|_| ERROR)?;
+        drop(file);
+        // The supervisor operation lock serializes managed writes. Recheck the
+        // target to avoid replacing unrelated files after validation.
+        if fs::symlink_metadata(path).is_ok() {
+            return Err(ERROR.into());
+        }
+        fs::rename(&temporary, path).map_err(|_| ERROR)?;
+        #[cfg(unix)]
+        File::open(parent)
+            .and_then(|file| file.sync_all())
+            .map_err(|_| ERROR)?;
+        Ok(())
+    })();
+    if temporary.exists() {
+        let _ = fs::remove_file(&temporary);
+    }
+    result
+}
+
+pub fn read(path: &Path, limit: u64) -> Result<String, String> {
+    protect(path, false)?;
+    let mut body = String::new();
+    File::open(path)
+        .map_err(|_| ERROR)?
+        .take(limit + 1)
+        .read_to_string(&mut body)
+        .map_err(|_| ERROR)?;
+    if body.len() as u64 > limit {
+        return Err("Private service file is too large".into());
+    }
+    Ok(body)
+}
+
+#[cfg(windows)]
+mod windows {
+    use super::ERROR;
+    use std::ffi::c_void;
+    use std::os::windows::ffi::OsStrExt;
+    use std::path::Path;
+    use std::ptr::null_mut;
+    type Handle = *mut c_void;
+    #[link(name = "kernel32")]
+    unsafe extern "system" {
+        fn GetCurrentProcess() -> Handle;
+        fn CloseHandle(handle: Handle) -> i32;
+        fn LocalFree(memory: Handle) -> Handle;
+        fn GetFileInformationByHandle(file: Handle, information: *mut FileInfo) -> i32;
+    }
+    #[link(name = "advapi32")]
+    unsafe extern "system" {
+        fn OpenProcessToken(process: Handle, access: u32, token: *mut Handle) -> i32;
+        fn GetTokenInformation(
+            token: Handle,
+            class: u32,
+            data: Handle,
+            size: u32,
+            required: *mut u32,
+        ) -> i32;
+        fn ConvertSidToStringSidW(sid: Handle, output: *mut *mut u16) -> i32;
+        fn ConvertStringSecurityDescriptorToSecurityDescriptorW(
+            text: *const u16,
+            revision: u32,
+            descriptor: *mut Handle,
+            size: *mut u32,
+        ) -> i32;
+        fn GetSecurityDescriptorOwner(
+            descriptor: Handle,
+            owner: *mut Handle,
+            defaulted: *mut i32,
+        ) -> i32;
+        fn GetSecurityDescriptorDacl(
+            descriptor: Handle,
+            present: *mut i32,
+            acl: *mut Handle,
+            defaulted: *mut i32,
+        ) -> i32;
+        fn SetNamedSecurityInfoW(
+            name: *mut u16,
+            kind: u32,
+            info: u32,
+            owner: Handle,
+            group: Handle,
+            dacl: Handle,
+            sacl: Handle,
+        ) -> u32;
+    }
+    #[repr(C)]
+    struct FileInfo {
+        attributes: u32,
+        creation: [u32; 2],
+        access: [u32; 2],
+        write: [u32; 2],
+        volume: u32,
+        size_high: u32,
+        size_low: u32,
+        links: u32,
+        index_high: u32,
+        index_low: u32,
+    }
+    pub fn single_link(path: &Path) -> Result<(), String> {
+        use std::os::windows::io::AsRawHandle;
+        let file = std::fs::File::open(path).map_err(|_| ERROR)?;
+        let mut info: FileInfo = unsafe { std::mem::zeroed() };
+        if unsafe { GetFileInformationByHandle(file.as_raw_handle().cast(), &mut info) } == 0
+            || info.links != 1
+        {
+            return Err(ERROR.into());
+        }
+        Ok(())
+    }
+    struct Local(Handle);
+    impl Drop for Local {
+        fn drop(&mut self) {
+            unsafe {
+                LocalFree(self.0);
+            }
+        }
+    }
+    struct Token(Handle);
+    impl Drop for Token {
+        fn drop(&mut self) {
+            unsafe {
+                CloseHandle(self.0);
+            }
+        }
+    }
+
+    fn current_sid() -> Result<String, String> {
+        unsafe {
+            let mut token = null_mut();
+            if OpenProcessToken(GetCurrentProcess(), 8, &mut token) == 0 {
+                return Err(ERROR.into());
+            }
+            let token = Token(token);
+            let mut required = 0;
+            GetTokenInformation(token.0, 1, null_mut(), 0, &mut required);
+            if required == 0 || required > 65536 {
+                return Err(ERROR.into());
+            }
+            // TOKEN_USER starts with a pointer. Allocate pointer-aligned storage.
+            let mut data = vec![0usize; (required as usize).div_ceil(std::mem::size_of::<usize>())];
+            if GetTokenInformation(
+                token.0,
+                1,
+                data.as_mut_ptr().cast(),
+                required,
+                &mut required,
+            ) == 0
+            {
+                return Err(ERROR.into());
+            }
+            let sid = *(data.as_ptr() as *const Handle);
+            let mut text = null_mut();
+            if ConvertSidToStringSidW(sid, &mut text) == 0 {
+                return Err(ERROR.into());
+            }
+            let allocated = Local(text.cast());
+            let len = (0..256).find(|i| *text.add(*i) == 0).ok_or(ERROR)?;
+            let value =
+                String::from_utf16(std::slice::from_raw_parts(text, len)).map_err(|_| ERROR)?;
+            drop(allocated);
+            Ok(value)
+        }
+    }
+
+    pub fn protect(path: &Path, directory: bool) -> Result<(), String> {
+        let sid = current_sid()?;
+        let flags = if directory { "OICI" } else { "" };
+        let descriptor: Vec<u16> = format!("O:{sid}D:P(A;{flags};FA;;;{sid})(A;{flags};FA;;;SY)")
+            .encode_utf16()
+            .chain(Some(0))
+            .collect();
+        let mut name: Vec<u16> = path.as_os_str().encode_wide().chain(Some(0)).collect();
+        unsafe {
+            let mut sd = null_mut();
+            if ConvertStringSecurityDescriptorToSecurityDescriptorW(
+                descriptor.as_ptr(),
+                1,
+                &mut sd,
+                null_mut(),
+            ) == 0
+            {
+                return Err(ERROR.into());
+            }
+            let sd = Local(sd);
+            let (mut owner, mut acl) = (null_mut(), null_mut());
+            let (mut defaulted, mut present) = (0, 0);
+            if GetSecurityDescriptorOwner(sd.0, &mut owner, &mut defaulted) == 0
+                || owner.is_null()
+                || GetSecurityDescriptorDacl(sd.0, &mut present, &mut acl, &mut defaulted) == 0
+                || present == 0
+                || acl.is_null()
+            {
+                return Err(ERROR.into());
+            }
+            // Explicit owner and protected DACL; existing inherited grants are
+            // replaced and newly created children inherit only owner + SYSTEM.
+            if SetNamedSecurityInfoW(
+                name.as_mut_ptr(),
+                1,
+                0x80000005,
+                owner,
+                null_mut(),
+                acl,
+                null_mut(),
+            ) != 0
+            {
+                return Err(ERROR.into());
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn private_files_are_exact_immutable_and_bounded() {
+        let path = std::env::temp_dir().join(format!("ro-private-{}", random_hex(12).unwrap()));
+        directory(&path).unwrap();
+        let file = path.join("secret");
+        create(&file, b" example-only-value ").unwrap();
+        assert_eq!(read(&file, 100).unwrap(), " example-only-value ");
+        assert!(create(&file, b"replacement").is_err());
+        assert!(read(&file, 3).is_err());
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+                0o700
+            );
+            assert_eq!(
+                fs::metadata(&file).unwrap().permissions().mode() & 0o777,
+                0o600
+            );
+        }
+        fs::remove_file(&file).unwrap();
+        fs::remove_dir(&path).unwrap();
+    }
+    #[cfg(unix)]
+    #[test]
+    fn links_never_become_service_secret_files() {
+        let path =
+            std::env::temp_dir().join(format!("ro-private-links-{}", random_hex(12).unwrap()));
+        directory(&path).unwrap();
+        let target = path.join("target");
+        create(&target, b"not-a-secret").unwrap();
+        let link = path.join("link");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+        assert!(read(&link, 100).is_err());
+        assert!(create(&link, b"replacement").is_err());
+        fs::remove_file(&link).unwrap();
+        fs::hard_link(&target, &link).unwrap();
+        assert!(read(&link, 100).is_err());
+        fs::remove_file(&link).unwrap();
+        fs::remove_file(&target).unwrap();
+        fs::remove_dir(&path).unwrap();
+    }
+}

--- a/stack/src/private_fs.rs
+++ b/stack/src/private_fs.rs
@@ -45,6 +45,57 @@ pub fn random_token(length: usize) -> Result<String, String> {
         .collect())
 }
 
+fn new_file(path: &Path) -> Result<File, String> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(path)
+            .map_err(|_| ERROR.into())
+    }
+    #[cfg(windows)]
+    {
+        windows::new_file(path)
+    }
+}
+
+/// Export through a private adjacent temporary file. The source and destination
+/// may be on different drives. Never inherit public destination ACLs, truncate
+/// an old backup in place, or change permissions on the user's chosen folder.
+pub fn export_file(source: &Path, destination: &Path) -> Result<(), String> {
+    let parent = destination
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let temporary = parent.join(format!(".ragnarok-backup-{}.tmp", random_hex(12)?));
+    let result = (|| {
+        let mut input = File::open(source).map_err(|_| "Cannot read the staged backup")?;
+        let mut output = new_file(&temporary)?;
+        std::io::copy(&mut input, &mut output)
+            .and_then(|_| output.sync_all())
+            .map_err(|_| "Cannot write the private backup export")?;
+        drop(output);
+        #[cfg(unix)]
+        {
+            fs::rename(&temporary, destination)
+                .map_err(|_| "Cannot replace the selected backup")?;
+            File::open(parent)
+                .and_then(|file| file.sync_all())
+                .map_err(|_| "Cannot sync the backup destination")?;
+        }
+        #[cfg(windows)]
+        windows::replace(&temporary, destination)?;
+        Ok(())
+    })();
+    if temporary.exists() {
+        let _ = fs::remove_file(&temporary);
+    }
+    result
+}
+
 fn metadata(path: &Path) -> Result<fs::Metadata, String> {
     let info = fs::symlink_metadata(path).map_err(|_| ERROR)?;
     if info.file_type().is_symlink() {
@@ -125,15 +176,8 @@ pub fn create(path: &Path, bytes: &[u8]) -> Result<(), String> {
     let parent = path.parent().ok_or(ERROR)?;
     directory(parent)?;
     let temporary = parent.join(format!(".private-{}.tmp", random_hex(12)?));
-    let mut options = OpenOptions::new();
-    options.write(true).create_new(true);
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt;
-        options.mode(0o600);
-    }
     let result = (|| {
-        let mut file = options.open(&temporary).map_err(|_| ERROR)?;
+        let mut file = new_file(&temporary)?;
         protect(&temporary, false)?;
         file.write_all(bytes)
             .and_then(|_| file.sync_all())
@@ -185,6 +229,16 @@ mod windows {
         fn CloseHandle(handle: Handle) -> i32;
         fn LocalFree(memory: Handle) -> Handle;
         fn GetFileInformationByHandle(file: Handle, information: *mut FileInfo) -> i32;
+        fn CreateFileW(
+            name: *const u16,
+            access: u32,
+            share: u32,
+            security: *const SecurityAttributes,
+            disposition: u32,
+            flags: u32,
+            template: Handle,
+        ) -> Handle;
+        fn MoveFileExW(source: *const u16, destination: *const u16, flags: u32) -> i32;
     }
     #[link(name = "advapi32")]
     unsafe extern "system" {
@@ -303,26 +357,75 @@ mod windows {
         }
     }
 
-    pub fn protect(path: &Path, directory: bool) -> Result<(), String> {
+    fn descriptor(directory: bool) -> Result<Local, String> {
         let sid = current_sid()?;
         let flags = if directory { "OICI" } else { "" };
-        let descriptor: Vec<u16> = format!("O:{sid}D:P(A;{flags};FA;;;{sid})(A;{flags};FA;;;SY)")
+        let text: Vec<u16> = format!("O:{sid}D:P(A;{flags};FA;;;{sid})(A;{flags};FA;;;SY)")
             .encode_utf16()
             .chain(Some(0))
             .collect();
-        let mut name: Vec<u16> = path.as_os_str().encode_wide().chain(Some(0)).collect();
-        unsafe {
-            let mut sd = null_mut();
-            if ConvertStringSecurityDescriptorToSecurityDescriptorW(
-                descriptor.as_ptr(),
+        let mut sd = null_mut();
+        if unsafe {
+            ConvertStringSecurityDescriptorToSecurityDescriptorW(
+                text.as_ptr(),
                 1,
                 &mut sd,
                 null_mut(),
-            ) == 0
-            {
-                return Err(ERROR.into());
-            }
-            let sd = Local(sd);
+            )
+        } == 0
+        {
+            return Err(ERROR.into());
+        }
+        Ok(Local(sd))
+    }
+
+    #[repr(C)]
+    struct SecurityAttributes {
+        length: u32,
+        descriptor: Handle,
+        inherit: i32,
+    }
+    pub fn new_file(path: &Path) -> Result<std::fs::File, String> {
+        use std::os::windows::io::FromRawHandle;
+        let sd = descriptor(false)?;
+        let attributes = SecurityAttributes {
+            length: std::mem::size_of::<SecurityAttributes>() as u32,
+            descriptor: sd.0,
+            inherit: 0,
+        };
+        let name: Vec<u16> = path.as_os_str().encode_wide().chain(Some(0)).collect();
+        let handle = unsafe {
+            CreateFileW(
+                name.as_ptr(),
+                0xc0000000,
+                7,
+                &attributes,
+                1,
+                0x80,
+                null_mut(),
+            )
+        };
+        if handle == (-1isize as Handle) {
+            return Err(ERROR.into());
+        }
+        Ok(unsafe { std::fs::File::from_raw_handle(handle) })
+    }
+    pub fn replace(source: &Path, destination: &Path) -> Result<(), String> {
+        let source: Vec<u16> = source.as_os_str().encode_wide().chain(Some(0)).collect();
+        let destination: Vec<u16> = destination
+            .as_os_str()
+            .encode_wide()
+            .chain(Some(0))
+            .collect();
+        if unsafe { MoveFileExW(source.as_ptr(), destination.as_ptr(), 9) } == 0 {
+            return Err("Cannot replace the selected backup".into());
+        }
+        Ok(())
+    }
+    pub fn protect(path: &Path, directory: bool) -> Result<(), String> {
+        let sd = descriptor(directory)?;
+        let mut name: Vec<u16> = path.as_os_str().encode_wide().chain(Some(0)).collect();
+        unsafe {
             let (mut owner, mut acl) = (null_mut(), null_mut());
             let (mut defaulted, mut present) = (0, 0);
             if GetSecurityDescriptorOwner(sd.0, &mut owner, &mut defaulted) == 0
@@ -378,6 +481,21 @@ mod tests {
         }
         fs::remove_file(&file).unwrap();
         fs::remove_dir(&path).unwrap();
+    }
+    #[test]
+    fn exports_replace_existing_files_without_changing_the_destination_directory() {
+        let root = std::env::temp_dir().join(format!("ro-export-{}", random_hex(12).unwrap()));
+        directory(&root).unwrap();
+        let source = root.join("source");
+        create(&source, b"example-private-backup").unwrap();
+        let destination = root.join("export");
+        fs::write(&destination, "old contents").unwrap();
+        export_file(&source, &destination).unwrap();
+        assert_eq!(read(&destination, 100).unwrap(), "example-private-backup");
+        assert_eq!(fs::read_dir(&root).unwrap().count(), 2);
+        fs::remove_file(source).unwrap();
+        fs::remove_file(destination).unwrap();
+        fs::remove_dir(root).unwrap();
     }
     #[cfg(unix)]
     #[test]

--- a/stack/src/service_credentials.rs
+++ b/stack/src/service_credentials.rs
@@ -1,0 +1,214 @@
+//! Durable, era-specific service credentials. Never contains player passwords.
+//! The immutable journal is published before any DB mutation. A separate ready
+//! marker is written only after both new SQL logins and the interserver database row verify.
+use crate::{
+    config::Config,
+    json::{self, Value},
+    private_fs,
+};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const ERROR: &str = "Managed service credentials are missing or damaged. Preserve the credential directory and database backup; restore them together before starting.";
+pub const CONTAINER_DIR: &str = "/run/ragnarok-private";
+
+pub struct Credentials {
+    pub directory: PathBuf,
+    pub root: String,
+    pub database: String,
+    pub interserver: String,
+    pub ready: bool,
+}
+
+pub fn era(cfg: &Config) -> &'static str {
+    if cfg.state.join("prerenewal").exists() {
+        "prerenewal"
+    } else {
+        "renewal"
+    }
+}
+
+pub fn directory(state: &Path, era: &str) -> PathBuf {
+    state.join("private").join("service-credentials").join(era)
+}
+
+fn hex(value: Option<&str>, length: usize) -> Result<String, String> {
+    let value = value.ok_or(ERROR)?;
+    if value.len() != length
+        || !value
+            .bytes()
+            .all(|c| c.is_ascii_digit() || (b'a'..=b'f').contains(&c))
+    {
+        return Err(ERROR.into());
+    }
+    Ok(value.into())
+}
+
+fn token(value: Option<&str>) -> Result<String, String> {
+    let value = value.ok_or(ERROR)?;
+    // 23 base64url characters provide 138 random bits within the game field.
+    if value.len() != 23
+        || !value
+            .bytes()
+            .all(|c| c.is_ascii_alphanumeric() || c == b'_' || c == b'-')
+    {
+        return Err(ERROR.into());
+    }
+    Ok(value.into())
+}
+
+pub fn load(state: &Path, era: &str) -> Result<Option<Credentials>, String> {
+    let dir = directory(state, era);
+    if !dir.exists() {
+        return Ok(None);
+    }
+    private_fs::directory(&dir)?;
+    let body = private_fs::read(&dir.join("credentials.json"), 4096).map_err(|_| ERROR)?;
+    let value = json::parse(&body).map_err(|_| ERROR)?;
+    if value.get("version") != Some(&Value::Number(1.0)) || value.str("era") != Some(era) {
+        return Err(ERROR.into());
+    }
+    let ready_path = dir.join("ready");
+    let ready = if ready_path.exists() {
+        if private_fs::read(&ready_path, 16)? != "v1\n" {
+            return Err(ERROR.into());
+        }
+        true
+    } else {
+        false
+    };
+    Ok(Some(Credentials {
+        directory: dir,
+        root: hex(value.str("root"), 64)?,
+        database: hex(value.str("database"), 64)?,
+        interserver: token(value.str("interserver"))?,
+        ready,
+    }))
+}
+
+pub fn prepare(cfg: &Config) -> Result<Credentials, String> {
+    private_fs::directory(&cfg.state)?;
+    for path in [
+        cfg.state.join("private"),
+        cfg.state.join("private/service-credentials"),
+    ] {
+        private_fs::directory(&path)?;
+    }
+    let selected = era(cfg);
+    if let Some(credentials) = load(&cfg.state, selected)? {
+        credentials.write_files()?;
+        return Ok(credentials);
+    }
+    let dir = directory(&cfg.state, selected);
+    let staging = cfg
+        .state
+        .join("private/service-credentials")
+        .join(format!(".prepare-{}", private_fs::random_hex(12)?));
+    private_fs::directory(&staging)?;
+    let root = private_fs::random_hex(32)?;
+    let database = private_fs::random_hex(32)?;
+    let interserver = private_fs::random_token(23)?;
+    let body = format!(
+        "{{\"version\":1,\"era\":{},\"root\":{},\"database\":{},\"interserver\":{}}}\n",
+        json::quote(selected),
+        json::quote(&root),
+        json::quote(&database),
+        json::quote(&interserver)
+    );
+    private_fs::create(&staging.join("credentials.json"), body.as_bytes())?;
+    let mut credentials = Credentials {
+        directory: staging.clone(),
+        root,
+        database,
+        interserver,
+        ready: false,
+    };
+    credentials.write_files()?;
+    fs::rename(&staging, &dir).map_err(|_| {
+        "Could not publish the credential journal; no database password was changed"
+    })?;
+    #[cfg(unix)]
+    fs::File::open(dir.parent().unwrap())
+        .and_then(|file| file.sync_all())
+        .map_err(|_| ERROR)?;
+    credentials.directory = dir;
+    Ok(credentials)
+}
+
+impl Credentials {
+    /// Files are deterministic derivatives of the immutable journal. A mismatch
+    /// is an error, not a reason to silently overwrite a supplied credential.
+    fn file(&self, name: &str, value: &str) -> Result<(), String> {
+        let path = self.directory.join(name);
+        if fs::symlink_metadata(&path).is_ok() {
+            if private_fs::read(&path, 4096)? != value {
+                return Err(ERROR.into());
+            }
+            Ok(())
+        } else {
+            private_fs::create(&path, value.as_bytes())
+        }
+    }
+
+    pub fn write_files(&self) -> Result<(), String> {
+        self.file("root.secret", &self.root)?;
+        self.file("database.secret", &self.database)?;
+        self.file(
+            "root.cnf",
+            &format!("[client]\nuser=root\npassword={}\n", self.root),
+        )?;
+        self.file(
+            "database.cnf",
+            &format!("[client]\nuser=ragnarok\npassword={}\n", self.database),
+        )?;
+        Ok(())
+    }
+
+    pub fn mark_ready(&self) -> Result<(), String> {
+        self.file("ready", "v1\n")
+    }
+
+    pub fn inter_config(&self) -> String {
+        [
+            "login_server",
+            "ipban_db",
+            "char_server",
+            "map_server",
+            "web_server",
+            "log_db",
+        ]
+        .iter()
+        .map(|prefix| format!("{prefix}_pw: {}\n", self.database))
+        .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn journals_are_era_bound_and_corruption_never_falls_back_to_defaults() {
+        let state = std::env::temp_dir().join(format!(
+            "ro-services-{}",
+            private_fs::random_hex(12).unwrap()
+        ));
+        private_fs::directory(&state).unwrap();
+        private_fs::directory(&state.join("private")).unwrap();
+        private_fs::directory(&state.join("private/service-credentials")).unwrap();
+        let dir = directory(&state, "renewal");
+        private_fs::directory(&dir).unwrap();
+        assert!(load(&state, "renewal").is_err());
+        assert!(load(&state, "prerenewal").unwrap().is_none());
+        let body = format!("{{\"version\":1,\"era\":\"renewal\",\"root\":\"{}\",\"database\":\"{}\",\"interserver\":\"{}\"}}", "a".repeat(64), "b".repeat(64), "c".repeat(23));
+        private_fs::create(&dir.join("credentials.json"), body.as_bytes()).unwrap();
+        let credentials = load(&state, "renewal").unwrap().unwrap();
+        assert!(!credentials.ready);
+        credentials.write_files().unwrap();
+        credentials.mark_ready().unwrap();
+        assert!(load(&state, "renewal").unwrap().unwrap().ready);
+        assert_eq!(credentials.inter_config().lines().count(), 6);
+        fs::write(dir.join("root.cnf"), "damaged").unwrap();
+        assert!(credentials.write_files().is_err());
+        fs::remove_dir_all(state).unwrap();
+    }
+}

--- a/tests/e2e/service-credentials-settings.cjs
+++ b/tests/e2e/service-credentials-settings.cjs
@@ -166,7 +166,7 @@ async function main() {
         await game.getByLabel('Account', { exact: true }).fill(username);
         await game.getByLabel('Password', { exact: true }).fill(replacement);
         await game.getByRole('button', { name: 'Log in', exact: true }).tap();
-        await expect(game.getByRole('button', { name: 'Character slot 1', exact: true })).toBeVisible();
+        await expect(game.getByRole('button', { name: 'Character slot 1', exact: true })).toBeVisible({ timeout: 90000 });
         await game.goto('about:blank');
         accountChecks.add(era);
         report.managedAccountActions = [...accountChecks];

--- a/tests/e2e/service-credentials-settings.cjs
+++ b/tests/e2e/service-credentials-settings.cjs
@@ -28,6 +28,7 @@ fs.mkdirSync(out, { recursive: true });
 const report = { checks: [], screens: [], pageErrors: [] };
 const serviceSecrets = [];
 const journals = new Map();
+const accountChecks = new Set();
 const env = { ...process.env, RAGNAROK_OFFLINE_HOME: world,
   RAGNAROKMAC_ROOT: path.join(world, 'runtime'), RAGNAROKMAC_STATE: state,
   NEBULA_HOME: path.join(world, 'nebula') };
@@ -104,7 +105,8 @@ async function main() {
       const previousPlayers = fingerprint(!wasManaged);
       const previousJournal = wasManaged ? journal(era) : null;
       await page.locator('#secure-services').click();
-      await expect(page.locator('#services-status')).toContainText('Internal service credentials secured for ' + era, { timeout: 300000 });
+      await expect(page.locator('#secure-services')).toBeEnabled({ timeout: 300000 });
+      await expect(page.locator('#services-status')).toHaveText('Internal service credentials secured for ' + era + '. Player accounts and characters were preserved.');
       const currentJournal = journal(era);
       if (previousJournal !== null && currentJournal !== previousJournal) throw Error('Idempotent preparation changed service credentials');
       if (fingerprint(false) !== previousPlayers) throw Error('Service migration changed player credentials or identities');
@@ -121,7 +123,12 @@ async function main() {
         expect(fs.statSync(backup).size).toBeGreaterThan(1000);
         const before = fs.readdirSync(path.join(state, 'backups')).filter(name => name.startsWith('before-service-credentials-renewal-') && name.endsWith('.sql')).sort();
         if (!before.length) throw Error('Pre-migration backup was not preserved');
-        await invoke('db_restore', { path: path.join(state, 'backups', before[0]) });
+        // Keep the fixture repeatable: current player data with the legacy
+        // interserver row exercises restore without dropping later test users.
+        const legacyBackup = path.join(world, 'account-backups', 'legacy-service-' + Date.now() + '.sql');
+        fs.writeFileSync(legacyBackup, Buffer.concat([fs.readFileSync(backup),
+          Buffer.from("\nUPDATE login SET user_pass='p1' WHERE account_id=1 AND BINARY userid='s1' AND sex='S';\n")]), { mode: 0o600, flag: 'wx' });
+        await invoke('db_restore', { path: legacyBackup });
         await invoke('stack_up');
         if (fingerprint(false) !== previousPlayers || journal(era) !== currentJournal) throw Error('Restore did not retain player identities and current service credentials');
         query('SELECT 1;', true, false);
@@ -138,6 +145,31 @@ async function main() {
         if (fingerprint(false) !== previousPlayers || journal(era) !== currentJournal) throw Error('Pending migration recovery changed player data or regenerated secrets');
         query('SELECT 1;', true, false);
         report.partialMigrationRecovered = true;
+      }
+      if (!accountChecks.has(era)) {
+        const random = require('node:crypto').randomBytes;
+        const username = 'svc' + random(7).toString('hex');
+        const password = random(9).toString('hex');
+        const replacement = ' ' + random(8).toString('hex') + "'\\! ";
+        serviceSecrets.push(password, replacement);
+        await invoke('accounts', { action: 'create', era, username, password, confirmation: password });
+        const list = await invoke('accounts', { action: 'list', era });
+        const friend = list.accounts.find(account => account.username === username);
+        expect(friend).toMatchObject({ group: 0, state: 0, defaultPassword: false });
+        const account = { era, id: friend.id, username };
+        await invoke('accounts', { ...account, action: 'password', password: replacement, confirmation: replacement });
+        await invoke('accounts', { ...account, action: 'disable' });
+        expect((await invoke('accounts', { action: 'list', era })).accounts.find(a => a.id === friend.id).state).toBe(5);
+        await invoke('accounts', { ...account, action: 'enable' });
+        expect((await invoke('accounts', { action: 'list', era })).accounts.find(a => a.id === friend.id)).toMatchObject({ ...friend, state: 0 });
+        await game.goto('http://127.0.0.1:3338/');
+        await game.getByLabel('Account', { exact: true }).fill(username);
+        await game.getByLabel('Password', { exact: true }).fill(replacement);
+        await game.getByRole('button', { name: 'Log in', exact: true }).tap();
+        await expect(game.getByRole('button', { name: 'Character slot 1', exact: true })).toBeVisible();
+        await game.goto('about:blank');
+        accountChecks.add(era);
+        report.managedAccountActions = [...accountChecks];
       }
       await page.getByRole('button', { name: 'Refresh accounts', exact: true }).click();
       await expect(page.locator('#accounts-era')).toHaveText(era === 'renewal' ? 'Renewal accounts' : 'Pre-renewal accounts');

--- a/tests/e2e/service-credentials-settings.cjs
+++ b/tests/e2e/service-credentials-settings.cjs
@@ -1,0 +1,199 @@
+// Opt-in real Settings/roBrowser service credential migration and recovery. Owns one stopped disposable
+// world for the duration; never reads or writes a player's save.
+const fs = require('node:fs');
+const path = require('node:path');
+const net = require('node:net');
+const { spawnSync } = require('node:child_process');
+const { _electron, chromium, devices, expect } = require('@playwright/test');
+const { verifyWorld, snapshot } = require('./support.cjs');
+const work = path.resolve(__dirname, '../..');
+if (!process.env.RO_E2E_WORLD || !process.env.RO_E2E_CLIENT_JSON)
+  throw Error('Set RO_E2E_WORLD and RO_E2E_CLIENT_JSON; stop the disposable world first');
+const world = fs.realpathSync(process.env.RO_E2E_WORLD);
+if (JSON.parse(fs.readFileSync(path.join(world, '.ragnarok-e2e.json'))).disposable !== true)
+  throw Error('Not a disposable world');
+const clientPath = path.join(world, 'client.json');
+if (fs.existsSync(clientPath)) throw Error('Fixture requires no existing client.json');
+const selected = JSON.parse(fs.readFileSync(process.env.RO_E2E_CLIENT_JSON));
+const state = path.join(world, 'state');
+const settingsPath = path.join(state, 'settings.json');
+const settings = fs.existsSync(settingsPath) ? fs.readFileSync(settingsPath) : null;
+if (fs.existsSync(path.join(state, 'prerenewal'))) throw Error('Start with renewal selected');
+const credentials = Object.fromEntries(['renewal', 'prerenewal'].map(era => [era,
+  JSON.parse(fs.readFileSync(path.join(world, era === 'renewal'
+    ? 'account-test-credentials.json' : 'prerenewal-account-test-credentials.json'))),
+]));
+const out = path.join(world, 'account-tests', 'service-credentials-' + Date.now());
+fs.mkdirSync(out, { recursive: true });
+const report = { checks: [], screens: [], pageErrors: [] };
+const serviceSecrets = [];
+const journals = new Map();
+const env = { ...process.env, RAGNAROK_OFFLINE_HOME: world,
+  RAGNAROKMAC_ROOT: path.join(world, 'runtime'), RAGNAROKMAC_STATE: state,
+  NEBULA_HOME: path.join(world, 'nebula') };
+function docker(args, input) {
+  const socket = path.join(world, 'nebula/run/docker.sock');
+  const host = process.platform === 'win32' ? 'tcp://127.0.0.1:' + fs.readFileSync(socket, 'utf8').trim() : 'unix://' + socket;
+  const result = spawnSync(path.join(world, 'runtime/bin/docker-slim' + (process.platform === 'win32' ? '.exe' : '')), args,
+    { env: { ...env, DOCKER_HOST: host }, encoding: 'utf8', input, timeout: 120000, maxBuffer: 1024 * 1024 });
+  return result;
+}
+function query(sql, legacy = false, success = true) {
+  const auth = legacy ? ['-uroot', '-pragnarok'] : ['--defaults-extra-file=/run/ragnarok-private/root.cnf'];
+  const result = docker(['exec', '-i', 'ragnarok-db', 'mariadb', ...auth, '--protocol=TCP', '-h127.0.0.1', '--batch', '--skip-column-names', 'ragnarok'], sql);
+  if (success && result.status !== 0) throw Error('Private test database query failed; output suppressed.');
+  if (!success && result.status === 0) throw Error('Known legacy SQL root password was unexpectedly accepted.');
+  return result.stdout.trim();
+}
+function fingerprint(legacy) {
+  return query("SET SESSION group_concat_max_len=1048576; SELECT SHA2(GROUP_CONCAT(CONCAT_WS(':',account_id,HEX(userid),HEX(user_pass),sex,group_id,state) ORDER BY account_id SEPARATOR '|'),256) FROM login WHERE sex<>'S'; SELECT SHA2(GROUP_CONCAT(CONCAT_WS(':',char_id,account_id,HEX(name)) ORDER BY char_id SEPARATOR '|'),256) FROM `char`;", legacy);
+}
+function journal(era) {
+  const file = path.join(state, 'private/service-credentials', era, 'credentials.json');
+  const body = fs.readFileSync(file, 'utf8');
+  const value = JSON.parse(body);
+  serviceSecrets.push(value.root, value.database, value.interserver);
+  if (value.era !== era || !/^[a-f0-9]{64}$/.test(value.root) || !/^[a-f0-9]{64}$/.test(value.database)
+      || !/^[A-Za-z0-9_-]{23}$/.test(value.interserver) || value.root === value.database) throw Error('Invalid generated service credential shape');
+  return body;
+}
+
+async function freePorts() {
+  for (const port of [3338, 6900, 6121, 5121, 7462]) {
+    await new Promise((resolve, reject) => {
+      const socket = net.connect(port, '127.0.0.1');
+      socket.once('connect', () => { socket.destroy(); reject(Error(`Port ${port} is occupied; stop the other host first`)); });
+      socket.once('error', e => e.code === 'ECONNREFUSED' ? resolve() : reject(e));
+      socket.setTimeout(1000, () => { socket.destroy(); reject(Error(`Port ${port} did not refuse connections`)); });
+    });
+  }
+}
+async function main() {
+  await freePorts();
+  const app = await _electron.launch({ executablePath: require('electron'),
+    args: [path.join(work, 'electron/main.js'), '--user-data-dir=' + path.join(world, 'service-credentials-electron-profile')],
+    env, cwd: work, timeout: 45000 });
+  let owner, browser;
+  const invoke = (name, args) => owner.evaluate(({ name, args }) => window.__ELECTRON__.core.invoke(name, args), { name, args });
+  try {
+    owner = await app.firstWindow();
+    await expect(owner.locator('body')).toContainText('Waiting for your client', { timeout: 30000 });
+    await invoke('set_client_paths', { paths: { ...selected, mode: 'host', lan: false, vm_ram_mib: 4096 } });
+    await invoke('start_stack');
+    await verifyWorld();
+    await invoke('open_settings');
+    await expect.poll(() => app.windows().some(p => p.url().endsWith('settings.html'))).toBe(true);
+    const page = app.windows().find(p => p.url().endsWith('settings.html'));
+    page.setDefaultTimeout(240000);
+    browser = await chromium.launch({ headless: true });
+    report.browser = browser.version();
+    const context = await browser.newContext({ ...devices['Pixel 5'] });
+    const game = await context.newPage();
+    game.setDefaultTimeout(90000);
+    game.on('pageerror', error => report.pageErrors.push(error.message));
+    for (const era of ['renewal', 'prerenewal', 'renewal']) {
+      if (report.checks.length) {
+        await game.goto('about:blank');
+        await page.locator(era === 'renewal' ? '#era-re' : '#era-pre').click();
+        const label = era === 'renewal' ? 'renewal' : 'pre-renewal';
+        await expect(page.locator('#era-status')).toContainText(`Switched to ${label} in`, { timeout: 240000 });
+      }
+      await verifyWorld();
+      const directory = path.join(state, 'private/service-credentials', era);
+      const wasManaged = fs.existsSync(path.join(directory, 'ready'));
+      const previousPlayers = fingerprint(!wasManaged);
+      const previousJournal = wasManaged ? journal(era) : null;
+      await page.locator('#secure-services').click();
+      await expect(page.locator('#services-status')).toContainText('Internal service credentials secured for ' + era, { timeout: 300000 });
+      const currentJournal = journal(era);
+      if (previousJournal !== null && currentJournal !== previousJournal) throw Error('Idempotent preparation changed service credentials');
+      if (fingerprint(false) !== previousPlayers) throw Error('Service migration changed player credentials or identities');
+      query('SELECT 1;', true, false);
+      if (journals.has(era) && journals.get(era) !== currentJournal) throw Error('Era switching changed its service journal');
+      journals.set(era, currentJournal);
+      if (era === 'prerenewal') {
+        const first = JSON.parse(journals.get('renewal')), second = JSON.parse(currentJournal);
+        if (first.root === second.root || first.database === second.database || first.interserver === second.interserver) throw Error('Eras shared service secrets');
+      }
+      if (report.checks.length === 0) {
+        const backup = path.join(world, 'account-backups', 'managed-service-test.sql');
+        await invoke('db_backup', { path: backup });
+        expect(fs.statSync(backup).size).toBeGreaterThan(1000);
+        const before = fs.readdirSync(path.join(state, 'backups')).filter(name => name.startsWith('before-service-credentials-renewal-') && name.endsWith('.sql')).sort();
+        if (!before.length) throw Error('Pre-migration backup was not preserved');
+        await invoke('db_restore', { path: path.join(state, 'backups', before[0]) });
+        await invoke('stack_up');
+        if (fingerprint(false) !== previousPlayers || journal(era) !== currentJournal) throw Error('Restore did not retain player identities and current service credentials');
+        query('SELECT 1;', true, false);
+        report.managedBackupAndLegacyRestore = true;
+        // Simulate an interrupted DDL sequence: application credentials have
+        // changed but root still uses the legacy value. Only this guarded
+        // disposable world is mutated, with its game services stopped first.
+        for (const name of ['ragnarok-map', 'ragnarok-char', 'ragnarok-login']) {
+          if (docker(['stop', '-t', '30', name]).status !== 0) throw Error('Could not stop disposable game service for recovery test');
+        }
+        fs.unlinkSync(path.join(directory, 'ready'));
+        query("ALTER USER 'root'@'localhost' IDENTIFIED BY 'ragnarok';");
+        await invoke('stack_up');
+        if (fingerprint(false) !== previousPlayers || journal(era) !== currentJournal) throw Error('Pending migration recovery changed player data or regenerated secrets');
+        query('SELECT 1;', true, false);
+        report.partialMigrationRecovered = true;
+      }
+      await page.getByRole('button', { name: 'Refresh accounts', exact: true }).click();
+      await expect(page.locator('#accounts-era')).toHaveText(era === 'renewal' ? 'Renewal accounts' : 'Pre-renewal accounts');
+      const accounts = await invoke('accounts', { action: 'list', era });
+      const gm = accounts.accounts.find(a => a.id === '2000000');
+      expect(gm).toMatchObject({ username: 'ragnarok', group: 99, state: 0, defaultPassword: false });
+      const config = await (await context.request.get('http://127.0.0.1:3338/Config.local.js')).text();
+      expect(config).toContain(`renewal: ${era === 'renewal'},`);
+      const prefix = String(report.checks.length) + '-' + era;
+      await page.locator('#accounts-panel').screenshot({ path: path.join(out, prefix + '-accounts.png') });
+      await game.goto('http://127.0.0.1:3338/');
+      await game.getByLabel('Account', { exact: true }).fill(credentials[era].account);
+      await game.getByLabel('Password', { exact: true }).fill(credentials[era].password);
+      await game.getByRole('button', { name: 'Log in', exact: true }).tap();
+      await game.getByRole('button', { name: 'Character slot 1', exact: true }).tap();
+      await game.getByRole('button', { name: 'Play / create', exact: true }).tap();
+      if (era === 'prerenewal') {
+        await expect.poll(async () => await game.getByLabel('Character name', { exact: true }).isVisible()
+          || !!(await snapshot(game))?.input?.canMove).toBe(true);
+        if (await game.getByLabel('Character name', { exact: true }).isVisible()) {
+          await game.getByLabel('Character name', { exact: true }).fill('AstraEra');
+          await game.getByRole('button', { name: 'Create', exact: true }).tap();
+          await game.getByRole('button', { name: 'Character slot 1', exact: true }).tap();
+          await game.getByRole('button', { name: 'Play / create', exact: true }).tap();
+        }
+      }
+      await expect.poll(async () => (await snapshot(game)).input.canMove, { timeout: 90000 }).toBe(true);
+      expect(await game.evaluate(() => window.ROConfigLocal.servers[0].renewal)).toBe(era === 'renewal');
+      const current = await snapshot(game);
+      report.checks.push({ era, configMatches: true, gm, player: current.player, map: current.map });
+      await game.screenshot({ path: path.join(out, prefix + '-map.png') });
+      report.screens.push(prefix + '-accounts.png', prefix + '-map.png');
+      console.log('Service credentials, retained players and native game login passed:', era);
+    }
+    expect(report.pageErrors).toEqual([]);
+    console.log('Service credential Settings/game checks passed. Evidence:', out);
+  } finally {
+    if (browser) await browser.close();
+    // Use the owning shell to stop its assets before restoring selection files.
+    // If teardown fails, retain the files so a later launch sees the true state.
+    let stopped = false;
+    try { if (owner) { await invoke('assets_stop'); await invoke('stack_down'); stopped = true; } }
+    finally {
+      await app.evaluate(({ app }) => app.exit(0)).catch(() => {});
+      if (stopped) {
+        fs.rmSync(clientPath);
+        if (settings) fs.writeFileSync(settingsPath, settings); else fs.rmSync(settingsPath, { force: true });
+        fs.rmSync(path.join(state, 'prerenewal'), { force: true });
+      }
+      fs.writeFileSync(path.join(out, 'report.json'), JSON.stringify(report, null, 2));
+    }
+  }
+}
+main().catch(error => {
+  let message = String(error.message);
+  for (const era of ['renewal', 'prerenewal']) { try { journal(era); } catch {} }
+  for (const password of [...Object.values(credentials).map(c => c.password), ...serviceSecrets]) message = message.split(password).join('[redacted]');
+  console.error(message); process.exitCode = 1;
+});


### PR DESCRIPTION
Issue #4 requires replacing the shipped database and interserver credentials before internet publication. Settings now provides **Secure internal server credentials** for the selected era. It audits the expected service accounts, saves a private backup, stops game writers, publishes an immutable credential journal, changes and verifies the SQL/interserver passwords, and restarts the game. Player accounts, passwords, IDs, groups and characters are preserved. The equivalent owner command is `ragnarok-stack secure-services`.

Credentials use OS randomness and persist separately for renewal and pre-renewal. Pending migrations resume after individual SQL statements commit; completed migrations never fall back to the shared root password. SQL clients, account actions, backups and restores use private option-file paths and bounded stdin. Generated passwords do not enter argv or container environment metadata. Unix permissions and Windows owner/SYSTEM DACLs protect host files, including creation-time private Windows backup exports. Linked or unsupported private files fail closed. No Rust crate dependencies are added.

Backups flush game writers before dumping. Restore preserves a pre-restore snapshot, reapplies the current interserver credential after an older dump, and reports partial-import failures accurately. Shutdown also flushes game services before the database. A changed bundled image archive is loaded even when fixed tags already exist in the VM cache; migration requires the image's private-credential-file capability before changing passwords. Settings shows a concise success result.

Validation:
- 59 Rust tests passed; all 48 Node tests passed with the real supervisor and pinned Rust asset server, with no skips. Syntax and diff checks passed.
- Real Electron Settings / roBrowser / rAthena acceptance passed for renewal → pre-renewal → renewal. Both eras retained existing GM characters and passwords; generated service secrets remained independent and unchanged on repeat preparation; the legacy SQL root password was rejected.
- A real pre-migration SQL backup restore and a repeatable current-player backup containing the legacy interserver row both passed. Simulated interruption between application/root password changes recovered with the same journal and player identities.
- Owner account creation, password changes with punctuation/edge spaces, disabling, re-enabling and native ordinary-account login passed against both secured databases. Zero browser page errors; Settings and game screenshots inspected. Only the guarded disposable world was modified, then fully stopped with original selection/settings restored.
- A bounded exposure audit found no generated service passwords in container metadata, recent container logs and selected host log tails. This is not a whole-history or every-process proof.
- Both native image jobs passed [run34130938680](https://github.com/Flux159/ragnarokoffline.app/actions/runs/34130938680), including real MariaDB bootstrap tests. The image content has not changed since that run. All four final application jobs passed at `1b45305` in [run34134800739](https://github.com/Flux159/ragnarokoffline.app/actions/runs/34134800739) after carrying the Windows readiness fix through the stack (client build, Linux, macOS and Windows).

Stacked on #60; draft for owner review and packaged acceptance. Test instructions and recovery limits are in `docs/SERVICE_CREDENTIALS.md` and `docs/TESTING.md`. Native packaged migration on Windows/Linux remains unverified. Invite/session authentication, mandatory internet policy, tunnel providers, the public registration portal, and broader backup scheduling/resource work remain separate requirements. This does not close #4 or make an unrestricted origin safe to publish. No merge to main or release is requested.
