### PR TITLE
Enforce internet account policy before game services start or restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ credentials. Game logins and characters are preserved. See
 [managed internal credentials](docs/SERVICE_CREDENTIALS.md) for persistence and
 recovery; internet access still requires additional safeguards.
 
+**Check internet account safeguards** in that panel reports the selected era's
+account-policy checks. It does not publish a link. See the
+[hosting policy contract](docs/HOSTING_POLICY.md) for mandatory internet defaults
+and the remaining access-protection requirements.
+
 Ordinary accounts have almost no `@` commands — rAthena keeps `@autoloot` and
 `@showexp` for GMs. Settings → Mods → **player-commands** gives player characters some common commands.
 

--- a/docs/HOSTING_POLICY.md
+++ b/docs/HOSTING_POLICY.md
@@ -1,0 +1,72 @@
+# Internet account safeguards
+
+Settings → Accounts → **Check internet account safeguards** checks the selected
+running era. It reports owner-only signup, enabled GM/admin password requirements,
+and actual managed SQL/interserver authentication. It changes no passwords or
+account records. The owner command `ragnarok-stack hosting-check` returns the same
+JSON report. Both use the supervisor operation lock and verify the running era's
+actual database volume. Remote game pages cannot invoke the owner action.
+
+An account-policy pass is **not permission to publish the server**. The report
+keeps `publicationReady: false`: authenticated HTTP/WS access, effective privilege
+and listener audits, and a validated connector remain required. Friends/Public
+sharing controls are not exposed as ready in Settings yet. There is no tunnel or
+public registration service in this change.
+
+## Mandatory policy
+
+The persistent `settings.json.hosting_scope` contract accepts exactly `local`,
+`lan`, `friends` or `public`. An absent key preserves existing behavior: the
+shell's boolean LAN preference, or a direct CLI `--lan`, selects LAN; otherwise
+hosting is local. No legacy setting implicitly enables internet mode. The existing
+LAN checkbox now writes the explicit local/LAN scope. Invalid scope or legacy LAN
+values fail closed rather than exposing a listener through truthy coercion.
+
+Friends/Public currently provide the game-side preparation contract for upcoming
+sharing controls. They force `new_account: no` after mod assembly on every startup,
+Repair and era switch, even if `open_registration` remains true. Settings shows
+the effective owner-only policy and disables the conflicting signup control;
+the saved Local/LAN preference survives unrelated edits. Internet scopes keep the
+asset listener and raw game port configuration on loopback. A conflicting direct
+`--lan` flag is rejected before engine work.
+
+Prepare an era in Local mode first: change or disable its default GM login and
+secure its internal service credentials. Internet startup requires that era's
+credential journal before engine work, completes a pending migration through the
+existing recovery path, and verifies the game-side policy before starting game
+services. No account is renamed, recreated or assigned a default password.
+
+The admin check counts every enabled non-service account with `group_id > 0`,
+including renamed GMs, plus the shipped `ragnarok` login if its group changed.
+Passwords must fit the app's 12–23 printable-ASCII game-password contract, contain
+something besides spaces, and differ from the username. This is a minimum format
+check, not an entropy estimate or a substitute for auditing custom privilege
+configuration. Password values never leave SQL. The byte-sensitive character
+check uses MariaDB's [binary REGEXP behavior](https://mariadb.com/docs/server/reference/sql-functions/string-functions/regular-expressions-overview).
+
+Owner account writes and backups recheck internet policy before restarting game
+services. For example, enabling a disabled GM that still has a short password
+updates its state but keeps game services stopped and reports that outcome.
+Change the password or disable that account, then start the server. The same
+protection applies when an operation fails and would otherwise restart the old
+services. Database and character identities are preserved.
+
+Generated signup config is checked for the final assignment and rejects custom
+imports. Service verification requires an intact, ready per-era journal and
+matching private files; it authenticates SQL root/application credentials, rejects
+the shared SQL root password and checks the managed interserver row. Missing or
+damaged state remains an explicit recovery error.
+
+## Acceptance
+
+Unit and real-binary tests cover strict/migrated scope behavior, mandatory signup,
+and invalid/conflicting/unprepared scope rejection before startup or Repair
+reaches the engine. `tests/e2e/hosting-guards-settings.cjs` owns one stopped,
+marked disposable world with both eras already secured. It uses the same
+`RO_E2E_WORLD` and read-only asset selection `RO_E2E_CLIENT_JSON` inputs as the
+era/service credential fixtures. It exercises unsafe renamed-GM startup,
+disable/enable/password recovery, enforced suffix-signup rejection despite an
+open saved preference, the Settings report and native GM gameplay in both eras.
+It deliberately inserts a disposable privileged fixture; never run it on player
+data. It restores the original owner settings and stops its own server, retaining
+only disposable fixture accounts and screenshot/report evidence.

--- a/electron/hosting-policy.js
+++ b/electron/hosting-policy.js
@@ -1,0 +1,11 @@
+'use strict';
+const scopes = new Set(['local', 'lan', 'friends', 'public']);
+function effective(client, settings) {
+  if (!Object.hasOwn(settings, 'hosting_scope') && client.lan !== undefined && typeof client.lan !== 'boolean') {
+    throw new Error('Invalid LAN setting. Repair the saved hosting setting before starting.');
+  }
+  const scope = Object.hasOwn(settings, 'hosting_scope') ? settings.hosting_scope : (client.lan ? 'lan' : 'local');
+  if (!scopes.has(scope)) throw new Error('Invalid hosting scope. Repair the saved hosting setting before starting.');
+  return { ...client, hosting_scope: scope, lan: scope === 'lan' };
+}
+module.exports = { effective };

--- a/electron/main.js
+++ b/electron/main.js
@@ -417,10 +417,11 @@ function migrateDataRoot() {
 // rather than at each call site because there are seven of them and a missed
 // one is a setting that silently does nothing.
 function withEngineFlags(args) {
-	if (!['up', 'repair', 'secure-services'].includes(args[0])) return args;
+	if (!['up', 'repair', 'secure-services', 'hosting-check'].includes(args[0])) return args;
 	const client = getClientPaths();
 	const out = [...args];
 	if (client.lan && !out.includes('--lan')) out.push('--lan');
+	if (args[0] === 'hosting-check') return out;
 	const ram = Number(client.vm_ram_mib);
 	if (Number.isFinite(ram) && ram > 0) out.push('--ram', String(ram));
 	return out;
@@ -635,7 +636,8 @@ function getClientPaths() {
 	if (!Number.isFinite(Number(out.vm_ram_mib)) || Number(out.vm_ram_mib) <= 0) {
 		out.vm_ram_mib = defaultVmRamMib();
 	}
-	return out;
+	return require('./hosting-policy').effective(out,
+		require('./settings-store').read(path.join(stateDir(), 'settings.json'), {}));
 }
 
 // Stop joining and run the server here instead.
@@ -1645,6 +1647,10 @@ const handlers = {
 		return output.match(/^Internal service credentials secured for (?:renewal|prerenewal)\..*$/m)?.[0]
 			|| 'Internal service credentials secured. Player accounts and characters were preserved.';
 	},
+	hosting_check: async () => {
+		if (getClientPaths().mode !== 'host') throw new Error('Hosting checks belong to your own server.');
+		return JSON.parse(await runStack(['hosting-check']));
+	},
 	db_backup: ({ path: p }) => runStack(['backup', p]),
 	db_restore: ({ path: p }) => runStack(['restore', p]),
 
@@ -1722,6 +1728,11 @@ const handlers = {
 		if (next.rdata_grf && !fs.existsSync(next.rdata_grf)) {
 			throw new Error('rdata.grf is not a file');
 		}
+		if (Object.hasOwn(paths, 'lan')) {
+			next.hosting_scope = paths.lan ? 'lan' : 'local';
+			require('./settings-store').write(path.join(stateDir(), 'settings.json'),
+				{ hosting_scope: paths.lan ? 'lan' : 'local' }, SETTINGS_DEFAULTS);
+		}
 		fs.writeFileSync(clientConfigPath(), JSON.stringify(next, null, 2));
 		return linkClient(next);
 	},
@@ -1732,7 +1743,7 @@ const handlers = {
 	get_mode: () => {
 		const c = getClientPaths();
 		return {
-			mode: c.mode, lan: !!c.lan, join_host: c.join_host,
+			mode: c.mode, lan: !!c.lan, hosting_scope: c.hosting_scope, join_host: c.join_host,
 			// Only meaningful once the stack has run; before that there is no
 			// endpoint.json and no address to give out.
 			join_address: c.mode === 'host' && c.lan ? serveUrl(advertiseHost()) : '',
@@ -1747,6 +1758,11 @@ const handlers = {
 		if (lan === true && !prev.lan) await nudgeLocalNetworkPermission();
 		if (join_host !== undefined) next.join_host = join_host ? joinSession.remember(join_host) : '';
 		if (mode === 'join' && prev.mode !== 'join') await stopLocalHostForJoin();
+		if (lan !== undefined) {
+			next.hosting_scope = lan ? 'lan' : 'local';
+			require('./settings-store').write(path.join(stateDir(), 'settings.json'),
+				{ hosting_scope: lan ? 'lan' : 'local' }, SETTINGS_DEFAULTS);
+		}
 		fs.writeFileSync(clientConfigPath(), JSON.stringify(next, null, 2));
 		// Before anything slow: the mode has already changed, and leaving the
 		// window claiming (Local) over a server that is about to stop is the
@@ -1926,7 +1942,7 @@ function appLog(line) {
 const GAME_PAGE_HANDLERS = new Set([]);
 // Includes settings writes before their supervisor call: an era marker must
 // not change halfway through an account operation. Read-only status stays live.
-const SERVER_OPERATIONS = new Set(['accounts', 'save_settings', 'set_mode', 'set_client_paths', 'start_stack',
+const SERVER_OPERATIONS = new Set(['accounts', 'hosting_check', 'save_settings', 'set_mode', 'set_client_paths', 'start_stack',
 	'stack_up', 'stack_down', 'stack_repair', 'secure_services', 'db_backup', 'db_restore']);
 let serverOperationQueue = Promise.resolve();
 function queueServerOperation(operation) {

--- a/electron/settings-store.js
+++ b/electron/settings-store.js
@@ -11,6 +11,9 @@ function validate(settings) {
       (Object.hasOwn(settings, 'open_registration') && typeof settings.open_registration !== 'boolean')) {
     throw new Error(ERROR);
   }
+  if (Object.hasOwn(settings, 'hosting_scope') && !['local', 'lan', 'friends', 'public'].includes(settings.hosting_scope)) {
+    throw new Error('Invalid hosting scope. Choose local, lan, friends or public before starting.');
+  }
   return settings;
 }
 
@@ -23,8 +26,10 @@ function read(file, defaults) {
     if (error.code === 'ENOENT') return { ...defaults };
     throw new Error(ERROR);
   }
-  try { return { ...defaults, ...validate(JSON.parse(body)) }; }
+  let settings;
+  try { settings = JSON.parse(body); }
   catch { throw new Error(ERROR); }
+  return { ...defaults, ...validate(settings) };
 }
 
 function write(file, update, defaults) {

--- a/src/settings.html
+++ b/src/settings.html
@@ -179,7 +179,7 @@
       <option value="open">Anyone at the game login screen</option>
       <option value="owner">Owner only, through Settings</option>
     </select></label>
-    <p class="note">Owner only disables _M / _F signup. Existing accounts keep working.
+    <p class="note" id="registration-note">Owner only disables _M / _F signup. Existing accounts keep working.
       This policy applies to both eras. Apply and restart to change it.</p>
     <button id="registration-save" class="ghost">Apply account creation policy and restart</button>
     <p class="note" id="registration-status" role="status" aria-live="polite"></p>
@@ -208,6 +208,9 @@
       passwords and characters are preserved. Keep the app’s private state with your save.</p>
     <button id="secure-services" class="ghost">Secure internal server credentials</button>
     <p class="note" id="services-status" role="status" aria-live="polite"></p>
+    <div class="actions"><button id="hosting-check" class="ghost">Check internet account safeguards</button></div>
+    <ul class="note" id="hosting-checks" aria-live="polite"></ul>
+    <p class="note" id="hosting-readiness">Internet sharing also requires protected access and a configured connector; these account checks do not enable a public link.</p>
   </div>
 
   <h2>Save data</h2>
@@ -328,6 +331,17 @@ async function refreshMode() {
   // what the supervisor actually advertised, not a second guess made here.
   $('mp-addr').textContent = m.join_address
     || (m.lan ? 'starts with the server' : 'not shared');
+  paintRegistration(await invoke('get_settings'));
+}
+
+function paintRegistration(settings) {
+  const required = ['friends', 'public'].includes(settings.hosting_scope);
+  $('open-registration').value = required || settings.open_registration === false ? 'owner' : 'open';
+  $('open-registration').disabled = required;
+  $('registration-save').disabled = required;
+  $('registration-note').textContent = required
+    ? 'Internet modes require owner-approved accounts. Game-login signup stays off on every restart, Repair and era change. Your Local/LAN preference is preserved.'
+    : 'Owner only disables _M / _F signup. Existing accounts keep working. This policy applies to both eras. Apply and restart to change it.';
 }
 
 $('mp-mode').onchange = async () => {
@@ -711,6 +725,23 @@ $('secure-services').onclick = async () => {
   finally { button.disabled = false; }
 };
 
+$('hosting-check').onclick = async () => {
+  const button = $('hosting-check');
+  button.disabled = true;
+  $('hosting-checks').replaceChildren();
+  $('hosting-readiness').textContent = 'Checking this era’s account safeguards…';
+  try {
+    const report = await invoke('hosting_check');
+    for (const check of report.checks) {
+      const item = document.createElement('li');
+      item.textContent = `${check.passed ? 'Passed' : 'Needs attention'}: ${check.detail}`;
+      $('hosting-checks').appendChild(item);
+    }
+    $('hosting-readiness').textContent = `${report.era === 'renewal' ? 'Renewal' : 'Pre-renewal'} (${report.scope}). ${report.remaining}`;
+  } catch (error) { $('hosting-readiness').textContent = String(error); }
+  finally { button.disabled = false; }
+};
+
 $('registration-save').onclick = async () => {
   const button = $('registration-save');
   const status = $('registration-status');
@@ -724,7 +755,7 @@ $('registration-save').onclick = async () => {
     const mode = await invoke('get_mode');
     status.textContent = mode.mode === 'join'
       ? 'Saved for your own server. It will apply when you next host.'
-      : settings.open_registration ? 'Game login signup is enabled.'
+      : settings.open_registration && !['friends', 'public'].includes(mode.hosting_scope) ? 'Game login signup is enabled.'
         : 'Only the owner can create accounts through Settings. Existing accounts can still log in.';
   } catch (error) {
     status.textContent = `Could not apply account creation policy: ${String(error)}. Start the server to retry.`;
@@ -739,7 +770,7 @@ $('save').onclick = async () => {
   settings.max_aspd = Number($('max_aspd').value) || 190;
   settings.max_parameter = Number($('max_parameter').value) || 99;
   settings.free_kafra_warp = $('free_kafra_warp').checked;
-  settings.open_registration = $('open-registration').value === 'open';
+  if (!['friends', 'public'].includes(settings.hosting_scope)) settings.open_registration = $('open-registration').value === 'open';
   settings.prerenewal = eraIsPre;
   settings.zeny_from_mobs = $('zeny_from_mobs').checked;
   $('save').disabled = true;
@@ -772,7 +803,7 @@ invoke('get_settings').then(s => {
   $('max_aspd').value = s.max_aspd ?? 190;
   $('max_parameter').value = s.max_parameter ?? 99;
   $('free_kafra_warp').checked = !!s.free_kafra_warp;
-  $('open-registration').value = s.open_registration === false ? 'owner' : 'open';
+  paintRegistration(s);
   setEra(!!s.prerenewal);
   $('zeny_from_mobs').checked = !!s.zeny_from_mobs;
   $('population_enable').checked = !!s.population_enable;

--- a/stack/src/accounts.rs
+++ b/stack/src/accounts.rs
@@ -167,6 +167,7 @@ fn list(dk: &Docker, era: &str) -> Result<String, String> {
 /// record and overwrite a concurrent password change. Restart only the services
 /// that were running. The database and all account/character IDs stay intact.
 pub(crate) fn with_servers_stopped<T>(
+    cfg: &Config,
     dk: &Docker,
     operation: impl FnOnce() -> Result<T, String>,
 ) -> Result<T, String> {
@@ -184,6 +185,12 @@ pub(crate) fn with_servers_stopped<T>(
         }
     }
     let updated = result.and_then(|_| operation());
+    if crate::hosting::Scope::load(cfg, false)?.internet() {
+        if let Err(error) = crate::hosting::require_game_policy(cfg, dk) {
+            let outcome = match &updated { Ok(_) => "The operation completed".to_string(), Err(error) => error.clone() };
+            return Err(format!("{outcome}, but game services were not restarted because internet account safeguards failed: {error}"));
+        }
+    }
     let mut restarted = true;
     for service in stopped.iter().rev() {
         if dk.output(["start", service]).is_err() {
@@ -313,7 +320,7 @@ pub fn run(cfg: &Config, dk: &Docker) -> Result<(), String> {
         }
         _ => return Err("Unknown account action".into()),
     };
-    with_servers_stopped(dk, || {
+    with_servers_stopped(cfg, dk, || {
         // Recheck after shutdown, before touching any records.
         verify_era(cfg, dk, era)?;
         let output = dk.private_sql(&sql)?;

--- a/stack/src/cmds.rs
+++ b/stack/src/cmds.rs
@@ -1590,6 +1590,9 @@ pub fn secure_services(cfg: &Config, dk: &Docker, lan: bool, ram_mib: Option<u32
 pub fn up(cfg: &Config, dk: &Docker, lan: bool, ram_mib: Option<u32>) -> Result<(), String> {
     // Validate before touching the engine or replacing any running service.
     let open_registration = crate::registration::enabled(&cfg.state)?;
+    let scope = crate::hosting::Scope::load(cfg, lan)?;
+    crate::hosting::before_start(cfg, scope)?;
+    let lan = scope.lan();
     let credentials = crate::service_credentials::load(&cfg.state, crate::service_credentials::era(cfg))?;
     let conf = cfg.state.join("conf");
     for d in ["conf", "sql", "backups"] {
@@ -1802,6 +1805,7 @@ pub fn up(cfg: &Config, dk: &Docker, lan: bool, ram_mib: Option<u32>) -> Result<
     // Owner account policy is final, after mod assembly, and regenerated for
     // startup, Repair and each era. Mods cannot reopen suffix registration.
     write_conf(&conf, "login_conf.txt", &crate::registration::login_config(open_registration))?;
+    if scope.internet() { crate::hosting::require_game_policy(cfg, dk)?; }
 
     // A mod's allowlisted settings go after ours, because rAthena's config
     // reader takes the last assignment of a key: start_point in particular is
@@ -1908,7 +1912,7 @@ pub fn status(dk: &Docker) {
 
 pub fn backup(cfg: &Config, dk: &Docker, dest: &str) -> Result<(), String> {
     crate::accounts::verify_era(cfg, dk, crate::service_credentials::era(cfg))?;
-    crate::accounts::with_servers_stopped(dk, || backup_snapshot(cfg, dk, dest))
+    crate::accounts::with_servers_stopped(cfg, dk, || backup_snapshot(cfg, dk, dest))
 }
 
 fn backup_snapshot(cfg: &Config, dk: &Docker, dest: &str) -> Result<(), String> {
@@ -1991,6 +1995,7 @@ pub fn restore(cfg: &Config, dk: &Docker, src: &str) -> Result<(), String> {
 /// Player data is untouched — characters live in the ragnarokmac-db volume.
 pub fn repair(cfg: &Config, dk: &Docker, lan: bool, ram_mib: Option<u32>) -> Result<(), String> {
     crate::registration::enabled(&cfg.state)?;
+    crate::hosting::before_start(cfg, crate::hosting::Scope::load(cfg, lan)?)?;
     phase(cfg, "Repairing…");
     // Break the lock rather than wait: the usual reason to reach for repair is
     // a previous run that died holding one.

--- a/stack/src/hosting.rs
+++ b/stack/src/hosting.rs
@@ -1,0 +1,250 @@
+//! Mandatory game-side internet policy. A passing account check is only one
+//! publication prerequisite; this module never starts or authorizes a tunnel.
+use crate::{
+    accounts,
+    config::Config,
+    docker::Docker,
+    json::{self, Value},
+    registration, service_credentials,
+};
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Scope {
+    Local,
+    Lan,
+    Friends,
+    Public,
+}
+
+impl Scope {
+    pub fn from_settings(settings: &Value, legacy_lan: bool) -> Result<Self, String> {
+        let scope = match settings.get("hosting_scope") {
+            None => {
+                if legacy_lan {
+                    Self::Lan
+                } else {
+                    Self::Local
+                }
+            }
+            Some(Value::String(value)) => match value.as_str() {
+                "local" => Self::Local,
+                "lan" => Self::Lan,
+                "friends" => Self::Friends,
+                "public" => Self::Public,
+                _ => return Err(
+                    "Invalid hosting scope. Choose local, lan, friends or public before starting."
+                        .into(),
+                ),
+            },
+            _ => {
+                return Err(
+                    "Invalid hosting scope. Choose local, lan, friends or public before starting."
+                        .into(),
+                )
+            }
+        };
+        if legacy_lan && settings.get("hosting_scope").is_some() && scope != Self::Lan {
+            return Err("The --lan flag conflicts with the saved hosting scope. Internet modes require loopback game ports.".into());
+        }
+        Ok(scope)
+    }
+    pub fn load(cfg: &Config, legacy_lan: bool) -> Result<Self, String> {
+        Self::from_settings(&registration::settings(&cfg.state)?, legacy_lan)
+    }
+    pub fn internet(self) -> bool {
+        matches!(self, Self::Friends | Self::Public)
+    }
+    pub fn lan(self) -> bool {
+        self == Self::Lan
+    }
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::Local => "local",
+            Self::Lan => "lan",
+            Self::Friends => "friends",
+            Self::Public => "public",
+        }
+    }
+}
+
+pub fn before_start(cfg: &Config, scope: Scope) -> Result<(), String> {
+    if scope.internet()
+        && service_credentials::load(&cfg.state, service_credentials::era(cfg))?.is_none()
+    {
+        return Err("Internet hosting requires this era's managed service credentials. Start in Local mode, change or disable the default GM password, and use Settings → Accounts → Secure internal server credentials first.".into());
+    }
+    Ok(())
+}
+
+fn unsafe_admin_count(dk: &Docker) -> Result<u32, String> {
+    // Count every enabled privileged account, including renamed GMs. Also
+    // cover the shipped login if its group was changed. No passwords leave SQL.
+    let result = dk.private_sql("SELECT COUNT(*) FROM login WHERE sex<>'S' AND state=0 AND (group_id>0 OR LOWER(userid)='ragnarok') AND (OCTET_LENGTH(user_pass) NOT BETWEEN 12 AND 23 OR BINARY user_pass REGEXP '[^ -~]' OR TRIM(user_pass)='' OR LOWER(user_pass)=LOWER(userid));")?;
+    result
+        .trim()
+        .parse()
+        .map_err(|_| "Cannot verify enabled admin passwords".into())
+}
+
+pub fn require_admin_passwords(dk: &Docker) -> Result<(), String> {
+    let count = unsafe_admin_count(dk)?;
+    if count != 0 {
+        return Err(format!("{count} enabled GM/admin account(s) need a new password or must be disabled before internet hosting. Use Settings → Accounts for this era. Game services remain stopped; player accounts and characters were not reset."));
+    }
+    Ok(())
+}
+
+fn flag(config: &str, wanted: &str) -> Result<String, String> {
+    let mut found = None;
+    for line in config.lines() {
+        let line = line.split("//").next().unwrap_or("").trim();
+        if line.is_empty() {
+            continue;
+        }
+        let (key, value) = line
+            .split_once(':')
+            .ok_or("Cannot verify generated login configuration")?;
+        if key.trim().eq_ignore_ascii_case("import") {
+            return Err("Custom login imports need an explicit hosting audit".into());
+        }
+        if key.trim().eq_ignore_ascii_case(wanted) {
+            found = Some(value.trim().to_ascii_lowercase());
+        }
+    }
+    found.ok_or_else(|| {
+        "The generated login policy is missing; restart the server before sharing".into()
+    })
+}
+
+fn service_check(cfg: &Config, dk: &Docker) -> Result<(), String> {
+    let credentials = service_credentials::load(&cfg.state, service_credentials::era(cfg))?
+        .ok_or("Secure this era's internal server credentials in Settings → Accounts")?;
+    if !credentials.ready {
+        return Err(
+            "Service credential migration is incomplete; finish startup before sharing".into(),
+        );
+    }
+    for (name, expected) in [
+        ("root.secret", credentials.root.clone()),
+        ("database.secret", credentials.database.clone()),
+        (
+            "root.cnf",
+            format!("[client]\nuser=root\npassword={}\n", credentials.root),
+        ),
+        (
+            "database.cnf",
+            format!(
+                "[client]\nuser=ragnarok\npassword={}\n",
+                credentials.database
+            ),
+        ),
+    ] {
+        if crate::private_fs::read(&credentials.directory.join(name), 4096)? != expected {
+            return Err("Private service files do not match this era's credential journal; preserve them and recover before sharing".into());
+        }
+    }
+    if dk.root_sql("SELECT 1;", false)?.trim() != "1" || dk.private_sql("SELECT 1;")?.trim() != "1"
+    {
+        return Err("Managed database credentials did not verify".into());
+    }
+    if dk.root_sql("SELECT 1;", true).is_ok() {
+        return Err("The shared SQL root password is still accepted".into());
+    }
+    let matches = dk.private_sql(&format!("SELECT COUNT(*) FROM login WHERE account_id=1 AND BINARY userid='s1' AND sex='S' AND state=0 AND BINARY user_pass='{}';", credentials.interserver))?;
+    if matches.trim() != "1" {
+        return Err("Managed interserver credentials do not match this era's database".into());
+    }
+    Ok(())
+}
+
+fn require_registration(cfg: &Config) -> Result<(), String> {
+    if registration::enabled(&cfg.state)? {
+        return Err("Choose owner-only account creation and restart before sharing".into());
+    }
+    let config = std::fs::read_to_string(cfg.state.join("conf/login_conf.txt"))
+        .map_err(|_| "Cannot read generated login configuration")?;
+    if !["no", "off", "false", "0"].contains(&flag(&config, "new_account")?.as_str()) {
+        return Err("The generated signup policy is still open; restart before sharing".into());
+    }
+    Ok(())
+}
+
+pub fn require_game_policy(cfg: &Config, dk: &Docker) -> Result<(), String> {
+    require_registration(cfg)?;
+    require_admin_passwords(dk)?;
+    service_check(cfg, dk)
+}
+
+pub fn check(cfg: &Config, dk: &Docker, legacy_lan: bool) -> Result<String, String> {
+    let scope = Scope::load(cfg, legacy_lan)?;
+    let era = service_credentials::era(cfg);
+    accounts::verify_era(cfg, dk, era)?;
+    let mut rows = Vec::new();
+    let mut passed = true;
+    let mut add = |id: &str, result: Result<(), String>, success: &str| {
+        let (ok, detail) = match result {
+            Ok(()) => (true, success.to_string()),
+            Err(error) => (false, error),
+        };
+        passed &= ok;
+        rows.push(format!(
+            "{{\"id\":{},\"passed\":{ok},\"detail\":{}}}",
+            json::quote(id),
+            json::quote(&detail)
+        ));
+    };
+    add(
+        "registration",
+        require_registration(cfg),
+        "Owner-only signup policy is generated",
+    );
+    add(
+        "admin-passwords",
+        require_admin_passwords(dk),
+        "Enabled GM/admin passwords meet the game password requirements",
+    );
+    add(
+        "service-credentials",
+        service_check(cfg, dk),
+        "This era's managed service credentials verified; shared SQL root password rejected",
+    );
+    // Publication stays false until the access gateway, actual listener/engine
+    // bindings, privilege configuration and provider checks are integrated.
+    Ok(format!("{{\"era\":{},\"scope\":{},\"accountPolicyReady\":{passed},\"publicationReady\":false,\"checks\":[{}],\"remaining\":\"Internet access protection, effective privilege and listener checks, and a validated connector are still required. No public link is enabled.\"}}", json::quote(era), json::quote(scope.name()), rows.join(",")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn scope_migration_never_enables_internet_implicitly() {
+        let old = json::parse("{}").unwrap();
+        assert_eq!(Scope::from_settings(&old, false).unwrap(), Scope::Local);
+        assert_eq!(Scope::from_settings(&old, true).unwrap(), Scope::Lan);
+        for name in ["local", "lan", "friends", "public"] {
+            let settings =
+                json::parse(&format!("{{\"hosting_scope\":{}}}", json::quote(name))).unwrap();
+            let scope = Scope::from_settings(&settings, false).unwrap();
+            assert_eq!(scope.name(), name);
+            assert_eq!(scope.internet(), ["friends", "public"].contains(&name));
+            assert_eq!(Scope::from_settings(&settings, true).is_ok(), name == "lan");
+        }
+    }
+    #[test]
+    fn invalid_scope_and_login_imports_fail_closed() {
+        for value in ["null", "false", "23", "\"Friends\"", "\"\""] {
+            let settings = json::parse(&format!("{{\"hosting_scope\":{value}}}")).unwrap();
+            assert!(Scope::from_settings(&settings, false).is_err());
+        }
+        assert_eq!(
+            flag(
+                "new_account: yes\nnew_account: no // final\n",
+                "new_account"
+            )
+            .unwrap(),
+            "no"
+        );
+        assert!(flag("new_account: no\nimport: other.conf", "new_account").is_err());
+        assert!(flag("", "new_account").is_err());
+    }
+}

--- a/stack/src/main.rs
+++ b/stack/src/main.rs
@@ -20,6 +20,7 @@ mod mapcache;
 mod mods;
 mod process_identity;
 mod registration;
+mod hosting;
 mod private_fs;
 mod service_credentials;
 mod operation_lock;
@@ -30,7 +31,7 @@ use std::env;
 use std::path::PathBuf;
 use std::process::exit;
 
-const USAGE: &str = "usage: ragnarok-stack secure-services [--lan] [--ram MiB]|mods|mod-enable NAME|mod-disable NAME|up [--lan] [--ram MiB]|down|repair [--lan] [--ram MiB]|status|logs [service] [tail]\n\
+const USAGE: &str = "usage: ragnarok-stack hosting-check [--lan]|secure-services [--lan] [--ram MiB]|mods|mod-enable NAME|mod-disable NAME|up [--lan] [--ram MiB]|down|repair [--lan] [--ram MiB]|status|logs [service] [tail]\n\
                      \x20      backup <file>|restore <file>\n\
                      \x20      accounts (private JSON request on stdin)\n\
                      \x20      link-assets <data.grf> [rdata.grf] [official_data.grf] [bgm-dir]";
@@ -82,7 +83,7 @@ fn main() {
         Err(e) => fail(verb, &e),
     };
     let dk = Docker::new(cfg.docker.clone(), cfg.nebula_home.clone(), cfg.state.clone());
-    let _operation = if matches!(verb, "up" | "down" | "repair" | "backup" | "restore" | "accounts" | "secure-services") {
+    let _operation = if matches!(verb, "up" | "down" | "repair" | "backup" | "restore" | "accounts" | "secure-services" | "hosting-check") {
         match operation_lock::acquire(&cfg.state) {
             Ok(lock) => Some(lock),
             Err(error) => fail(verb, &error),
@@ -104,6 +105,7 @@ fn main() {
         .and_then(|v| v.parse::<u32>().ok());
 
     let result = match verb {
+        "hosting-check" => hosting::check(&cfg, &dk, lan).map(|report| println!("{report}")),
         "accounts" => {
             if let Err(error) = accounts::run(&cfg, &dk) {
                 fail(verb, &error);

--- a/stack/src/registration.rs
+++ b/stack/src/registration.rs
@@ -9,22 +9,26 @@ use std::path::Path;
 const LIMIT: u64 = 1024 * 1024;
 const ERROR: &str = "Cannot read account creation policy. Repair settings.json before starting the server; registration was not enabled.";
 
+#[cfg(test)]
 fn parse(body: &str) -> Result<bool, String> {
     let settings = json::parse(body).map_err(|_| ERROR)?;
     if !settings.is_object() {
         return Err(ERROR.into());
     }
-    match settings.get("open_registration") {
-        None => Ok(true),
-        Some(Value::Bool(value)) => Ok(*value),
-        _ => Err(ERROR.into()),
-    }
+    let requested = match settings.get("open_registration") {
+        None => true,
+        Some(Value::Bool(value)) => *value,
+        _ => return Err(ERROR.into()),
+    };
+    Ok(requested && !crate::hosting::Scope::from_settings(&settings, false)?.internet())
 }
 
-pub fn enabled(state: &Path) -> Result<bool, String> {
+pub fn settings(state: &Path) -> Result<Value, String> {
     let file = match File::open(state.join("settings.json")) {
         Ok(file) => file,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(true),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(Value::Object(Default::default()))
+        }
         Err(_) => return Err(ERROR.into()),
     };
     let mut body = String::new();
@@ -34,7 +38,21 @@ pub fn enabled(state: &Path) -> Result<bool, String> {
     if body.len() as u64 > LIMIT {
         return Err(ERROR.into());
     }
-    parse(&body)
+    let value = json::parse(&body).map_err(|_| ERROR)?;
+    if !value.is_object() {
+        return Err(ERROR.into());
+    }
+    Ok(value)
+}
+
+pub fn enabled(state: &Path) -> Result<bool, String> {
+    let settings = settings(state)?;
+    let requested = match settings.get("open_registration") {
+        None => true,
+        Some(Value::Bool(value)) => *value,
+        _ => return Err(ERROR.into()),
+    };
+    Ok(requested && !crate::hosting::Scope::from_settings(&settings, false)?.internet())
 }
 
 pub fn login_config(enabled: bool) -> String {
@@ -68,6 +86,25 @@ mod tests {
             r#"{"open_registration":0}"#,
         ] {
             assert!(parse(value).is_err());
+        }
+    }
+
+    #[test]
+    fn internet_modes_cannot_reopen_signup_with_a_saved_preference() {
+        for scope in ["friends", "public"] {
+            for request in ["true", "false"] {
+                assert!(!parse(&format!(
+                    "{{\"hosting_scope\":\"{scope}\",\"open_registration\":{request}}}"
+                ))
+                .unwrap());
+            }
+            assert!(!parse(&format!("{{\"hosting_scope\":\"{scope}\"}}")).unwrap());
+        }
+        for scope in ["local", "lan"] {
+            assert!(parse(&format!(
+                "{{\"hosting_scope\":\"{scope}\",\"open_registration\":true}}"
+            ))
+            .unwrap());
         }
     }
 }

--- a/tests/e2e/hosting-guards-settings.cjs
+++ b/tests/e2e/hosting-guards-settings.cjs
@@ -1,0 +1,220 @@
+// Opt-in real Settings/roBrowser mandatory hosting guard acceptance. Owns one stopped disposable
+// world for the duration; never reads or writes a player's save.
+const fs = require('node:fs');
+const path = require('node:path');
+const net = require('node:net');
+const { spawnSync } = require('node:child_process');
+const { _electron, chromium, devices, expect } = require('@playwright/test');
+const { verifyWorld, snapshot } = require('./support.cjs');
+const work = path.resolve(__dirname, '../..');
+if (!process.env.RO_E2E_WORLD || !process.env.RO_E2E_CLIENT_JSON)
+  throw Error('Set RO_E2E_WORLD and RO_E2E_CLIENT_JSON; stop the disposable world first');
+const world = fs.realpathSync(process.env.RO_E2E_WORLD);
+if (JSON.parse(fs.readFileSync(path.join(world, '.ragnarok-e2e.json'))).disposable !== true)
+  throw Error('Not a disposable world');
+const clientPath = path.join(world, 'client.json');
+if (fs.existsSync(clientPath)) throw Error('Fixture requires no existing client.json');
+const selected = JSON.parse(fs.readFileSync(process.env.RO_E2E_CLIENT_JSON));
+const state = path.join(world, 'state');
+const settingsPath = path.join(state, 'settings.json');
+const settings = fs.existsSync(settingsPath) ? fs.readFileSync(settingsPath) : null;
+if (fs.existsSync(path.join(state, 'prerenewal'))) throw Error('Start with renewal selected');
+const credentials = Object.fromEntries(['renewal', 'prerenewal'].map(era => [era,
+  JSON.parse(fs.readFileSync(path.join(world, era === 'renewal'
+    ? 'account-test-credentials.json' : 'prerenewal-account-test-credentials.json'))),
+]));
+const out = path.join(world, 'account-tests', 'hosting-guards-' + Date.now());
+fs.mkdirSync(out, { recursive: true });
+const report = { checks: [], screens: [], pageErrors: [] };
+const serviceSecrets = [];
+const env = { ...process.env, RAGNAROK_OFFLINE_HOME: world,
+  RAGNAROKMAC_ROOT: path.join(world, 'runtime'), RAGNAROKMAC_STATE: state,
+  NEBULA_HOME: path.join(world, 'nebula') };
+function docker(args, input) {
+  const socket = path.join(world, 'nebula/run/docker.sock');
+  const host = process.platform === 'win32' ? 'tcp://127.0.0.1:' + fs.readFileSync(socket, 'utf8').trim() : 'unix://' + socket;
+  const result = spawnSync(path.join(world, 'runtime/bin/docker-slim' + (process.platform === 'win32' ? '.exe' : '')), args,
+    { env: { ...env, DOCKER_HOST: host }, encoding: 'utf8', input, timeout: 120000, maxBuffer: 1024 * 1024 });
+  return result;
+}
+function query(sql, legacy = false, success = true) {
+  const auth = legacy ? ['-uroot', '-pragnarok'] : ['--defaults-extra-file=/run/ragnarok-private/root.cnf'];
+  const result = docker(['exec', '-i', 'ragnarok-db', 'mariadb', ...auth, '--protocol=TCP', '-h127.0.0.1', '--batch', '--skip-column-names', 'ragnarok'], sql);
+  if (success && result.status !== 0) throw Error('Private test database query failed; output suppressed.');
+  if (!success && result.status === 0) throw Error('Known legacy SQL root password was unexpectedly accepted.');
+  return result.stdout.trim();
+}
+function fingerprint(legacy) {
+  return query("SET SESSION group_concat_max_len=1048576; SELECT SHA2(GROUP_CONCAT(CONCAT_WS(':',account_id,HEX(userid),HEX(user_pass),sex,group_id,state) ORDER BY account_id SEPARATOR '|'),256) FROM login WHERE sex<>'S'; SELECT SHA2(GROUP_CONCAT(CONCAT_WS(':',char_id,account_id,HEX(name)) ORDER BY char_id SEPARATOR '|'),256) FROM `char`;", legacy);
+}
+function journal(era) {
+  const file = path.join(state, 'private/service-credentials', era, 'credentials.json');
+  const body = fs.readFileSync(file, 'utf8');
+  const value = JSON.parse(body);
+  serviceSecrets.push(value.root, value.database, value.interserver);
+  if (value.era !== era || !/^[a-f0-9]{64}$/.test(value.root) || !/^[a-f0-9]{64}$/.test(value.database)
+      || !/^[A-Za-z0-9_-]{23}$/.test(value.interserver) || value.root === value.database) throw Error('Invalid generated service credential shape');
+  return body;
+}
+
+async function freePorts() {
+  for (const port of [3338, 6900, 6121, 5121, 7462]) {
+    await new Promise((resolve, reject) => {
+      const socket = net.connect(port, '127.0.0.1');
+      socket.once('connect', () => { socket.destroy(); reject(Error(`Port ${port} is occupied; stop the other host first`)); });
+      socket.once('error', e => e.code === 'ECONNREFUSED' ? resolve() : reject(e));
+      socket.setTimeout(1000, () => { socket.destroy(); reject(Error(`Port ${port} did not refuse connections`)); });
+    });
+  }
+}
+async function main() {
+  await freePorts();
+  const app = await _electron.launch({ executablePath: require('electron'),
+    args: [path.join(work, 'electron/main.js'), '--user-data-dir=' + path.join(world, 'hosting-guards-electron-profile')],
+    env, cwd: work, timeout: 45000 });
+  let owner, browser;
+  const invoke = (name, args) => owner.evaluate(({ name, args }) => window.__ELECTRON__.core.invoke(name, args), { name, args });
+  try {
+    owner = await app.firstWindow();
+    await expect(owner.locator('body')).toContainText('Waiting for your client', { timeout: 30000 });
+    await invoke('set_client_paths', { paths: { ...selected, mode: 'host', lan: false, vm_ram_mib: 4096 } });
+    await invoke('start_stack');
+    await verifyWorld();
+    await invoke('open_settings');
+    await expect.poll(() => app.windows().some(p => p.url().endsWith('settings.html'))).toBe(true);
+    const page = app.windows().find(p => p.url().endsWith('settings.html'));
+    page.setDefaultTimeout(240000);
+    browser = await chromium.launch({ headless: true });
+    report.browser = browser.version();
+    const context = await browser.newContext({ ...devices['Pixel 5'] });
+    const game = await context.newPage();
+    game.setDefaultTimeout(90000);
+    game.on('pageerror', error => report.pageErrors.push(error.message));
+    for (const era of ['renewal', 'prerenewal', 'renewal']) {
+      if (report.checks.length) {
+        await game.goto('about:blank');
+        await page.locator(era === 'renewal' ? '#era-re' : '#era-pre').click();
+        const label = era === 'renewal' ? 'renewal' : 'pre-renewal';
+        await expect(page.locator('#era-status')).toContainText(`Switched to ${label} in`, { timeout: 240000 });
+      }
+      await verifyWorld();
+      const scope = report.checks.length === 2 ? 'public' : 'friends';
+      await invoke('save_settings', { settings: { hosting_scope: scope, open_registration: true } });
+      await verifyWorld();
+      expect((await invoke('get_mode')).hosting_scope).toBe(scope);
+      expect((await invoke('get_mode')).lan).toBe(false);
+      expect((await invoke('get_settings')).open_registration).toBe(true);
+      expect(fs.readFileSync(path.join(state, 'conf/login_conf.txt'), 'utf8')).toContain('new_account: no');
+      journal(era); // redaction only; never copy credentials to reports.
+      await page.reload();
+      await expect(page.locator('#open-registration')).toHaveValue('owner');
+      await expect(page.locator('#open-registration')).toBeDisabled();
+      await expect(page.locator('#registration-save')).toBeDisabled();
+      if (!report.guardedAdminLifecycle) {
+        const random = require('node:crypto').randomBytes;
+        const username = 'astraguard' + random(5).toString('hex');
+        const hex = value => '0x' + Buffer.from(value).toString('hex');
+        const gmBefore = query("SELECT SHA2(CONCAT_WS(':',account_id,HEX(userid),HEX(user_pass),group_id,state),256) FROM login WHERE account_id=2000000;");
+        for (const name of ['ragnarok-map', 'ragnarok-char', 'ragnarok-login']) {
+          if (docker(['stop', '-t', '30', name]).status !== 0) throw Error('Could not stop owned game service for guarded fixture');
+        }
+        query("INSERT INTO login (userid,user_pass,sex,email,group_id) VALUES (" + hex(username) + ",'ragnarok','M','a@a.com',99);");
+        let blocked = false;
+        try { await invoke('stack_up'); } catch (error) { blocked = String(error.message).includes('GM/admin'); }
+        if (!blocked) throw Error('Internet startup accepted an unsafe renamed GM');
+        const account = (await invoke('accounts', { action: 'list', era })).accounts.find(a => a.username === username);
+        expect(account).toMatchObject({ group: 99, state: 0, defaultPassword: true });
+        await invoke('accounts', { action: 'disable', era, id: account.id, username });
+        await invoke('stack_up');
+        blocked = false;
+        try { await invoke('accounts', { action: 'enable', era, id: account.id, username }); }
+        catch (error) { blocked = String(error.message).includes('internet account safeguards failed'); }
+        if (!blocked) throw Error('Enabling an unsafe GM bypassed the restart guard');
+        for (const name of ['ragnarok-map', 'ragnarok-char', 'ragnarok-login']) {
+          const status = docker(['inspect', '-f', '{{.State.Status}}', name]);
+          if (status.status !== 0 || status.stdout.trim() === 'running') throw Error('Unsafe admin edit restarted game services');
+        }
+        const password = random(9).toString('hex'); serviceSecrets.push(password);
+        await invoke('accounts', { action: 'password', era, id: account.id, username, password, confirmation: password });
+        await invoke('stack_up');
+        expect(query("SELECT SHA2(CONCAT_WS(':',account_id,HEX(userid),HEX(user_pass),group_id,state),256) FROM login WHERE account_id=2000000;")).toBe(gmBefore);
+        await invoke('accounts', { action: 'disable', era, id: account.id, username });
+        report.guardedAdminLifecycle = true;
+      }
+      await page.locator('#hosting-check').click();
+      await expect(page.locator('#hosting-check')).toBeEnabled({ timeout: 60000 });
+      await expect(page.locator('#hosting-checks li')).toHaveCount(3);
+      const readiness = await invoke('hosting_check');
+      expect(readiness).toMatchObject({ era, scope, accountPolicyReady: true, publicationReady: false });
+      expect(readiness.checks.every(check => check.passed)).toBe(true);
+      report.readiness = [...(report.readiness || []), readiness];
+      // Native suffix signup must remain off even while the saved local
+      // preference says true; no browser assertion alone proves provisioning.
+      const random = require('node:crypto').randomBytes;
+      const rejected = 'gate' + random(6).toString('hex');
+      const rejectedPassword = random(9).toString('hex'); serviceSecrets.push(rejectedPassword);
+      await game.goto('http://127.0.0.1:3338/');
+      await game.getByLabel('Account', { exact: true }).fill(rejected + '_F');
+      await game.getByLabel('Password', { exact: true }).fill(rejectedPassword);
+      await game.getByRole('button', { name: 'Log in', exact: true }).tap();
+      await expect(game.getByText('Unregistered ID', { exact: true })).toBeVisible({ timeout: 90000 });
+      expect(query("SELECT COUNT(*) FROM login WHERE userid IN ('" + rejected + "','" + rejected + "_F');")).toBe('0');
+      await game.goto('about:blank');
+      await page.getByRole('button', { name: 'Refresh accounts', exact: true }).click();
+      await expect(page.locator('#accounts-era')).toHaveText(era === 'renewal' ? 'Renewal accounts' : 'Pre-renewal accounts');
+      const accounts = await invoke('accounts', { action: 'list', era });
+      const gm = accounts.accounts.find(a => a.id === '2000000');
+      expect(gm).toMatchObject({ username: 'ragnarok', group: 99, state: 0, defaultPassword: false });
+      const config = await (await context.request.get('http://127.0.0.1:3338/Config.local.js')).text();
+      expect(config).toContain(`renewal: ${era === 'renewal'},`);
+      const prefix = String(report.checks.length) + '-' + era;
+      await page.locator('#accounts-panel').screenshot({ path: path.join(out, prefix + '-accounts.png') });
+      await game.goto('http://127.0.0.1:3338/');
+      await game.getByLabel('Account', { exact: true }).fill(credentials[era].account);
+      await game.getByLabel('Password', { exact: true }).fill(credentials[era].password);
+      await game.getByRole('button', { name: 'Log in', exact: true }).tap();
+      await game.getByRole('button', { name: 'Character slot 1', exact: true }).tap();
+      await game.getByRole('button', { name: 'Play / create', exact: true }).tap();
+      if (era === 'prerenewal') {
+        await expect.poll(async () => await game.getByLabel('Character name', { exact: true }).isVisible()
+          || !!(await snapshot(game))?.input?.canMove).toBe(true);
+        if (await game.getByLabel('Character name', { exact: true }).isVisible()) {
+          await game.getByLabel('Character name', { exact: true }).fill('AstraEra');
+          await game.getByRole('button', { name: 'Create', exact: true }).tap();
+          await game.getByRole('button', { name: 'Character slot 1', exact: true }).tap();
+          await game.getByRole('button', { name: 'Play / create', exact: true }).tap();
+        }
+      }
+      await expect.poll(async () => (await snapshot(game)).input.canMove, { timeout: 90000 }).toBe(true);
+      expect(await game.evaluate(() => window.ROConfigLocal.servers[0].renewal)).toBe(era === 'renewal');
+      const current = await snapshot(game);
+      report.checks.push({ era, configMatches: true, gm, player: current.player, map: current.map });
+      await game.screenshot({ path: path.join(out, prefix + '-map.png') });
+      report.screens.push(prefix + '-accounts.png', prefix + '-map.png');
+      console.log('Mandatory internet policy, rejected signup and native GM game login passed:', era, scope);
+    }
+    expect(report.pageErrors).toEqual([]);
+    console.log('Hosting guard Settings/game checks passed. Evidence:', out);
+  } finally {
+    if (browser) await browser.close();
+    // Use the owning shell to stop its assets before restoring selection files.
+    // If teardown fails, retain the files so a later launch sees the true state.
+    let stopped = false;
+    try { if (owner) { await invoke('assets_stop'); await invoke('stack_down'); stopped = true; } }
+    finally {
+      await app.evaluate(({ app }) => app.exit(0)).catch(() => {});
+      if (stopped) {
+        fs.rmSync(clientPath);
+        if (settings) fs.writeFileSync(settingsPath, settings); else fs.rmSync(settingsPath, { force: true });
+        fs.rmSync(path.join(state, 'prerenewal'), { force: true });
+      }
+      fs.writeFileSync(path.join(out, 'report.json'), JSON.stringify(report, null, 2));
+    }
+  }
+}
+main().catch(error => {
+  let message = String(error.message);
+  for (const era of ['renewal', 'prerenewal']) { try { journal(era); } catch {} }
+  for (const password of [...Object.values(credentials).map(c => c.password), ...serviceSecrets]) message = message.split(password).join('[redacted]');
+  console.error(message); process.exitCode = 1;
+});

--- a/tests/e2e/hosting-guards-settings.cjs
+++ b/tests/e2e/hosting-guards-settings.cjs
@@ -25,6 +25,14 @@ const credentials = Object.fromEntries(['renewal', 'prerenewal'].map(era => [era
 ]));
 const out = path.join(world, 'account-tests', 'hosting-guards-' + Date.now());
 fs.mkdirSync(out, { recursive: true });
+// Keep a private recovery copy even if the app or test process exits before
+// finally runs. Never copy account/service credentials into the report.
+const recovery = path.join(out, 'recovery');
+fs.mkdirSync(recovery, { mode: 0o700 });
+fs.writeFileSync(path.join(recovery, 'selection.json'), JSON.stringify({
+  clientExisted: false, settingsExisted: settings !== null, prerenewalExisted: false,
+}), { mode: 0o600 });
+if (settings) fs.writeFileSync(path.join(recovery, 'settings.json'), settings, { mode: 0o600 });
 const report = { checks: [], screens: [], pageErrors: [] };
 const serviceSecrets = [];
 const env = { ...process.env, RAGNAROK_OFFLINE_HOME: world,
@@ -57,6 +65,15 @@ function journal(era) {
   return body;
 }
 
+function redact(error) {
+  let message = String(error.message || error);
+  for (const era of ['renewal', 'prerenewal']) { try { journal(era); } catch {} }
+  for (const password of [...Object.values(credentials).map(c => c.password), ...serviceSecrets]) {
+    if (password) message = message.split(password).join('[redacted]');
+  }
+  return message;
+}
+
 async function freePorts() {
   for (const port of [3338, 6900, 6121, 5121, 7462]) {
     await new Promise((resolve, reject) => {
@@ -73,16 +90,54 @@ async function main() {
     args: [path.join(work, 'electron/main.js'), '--user-data-dir=' + path.join(world, 'hosting-guards-electron-profile')],
     env, cwd: work, timeout: 45000 });
   let owner, browser;
+  let failure;
   const invoke = (name, args) => owner.evaluate(({ name, args }) => window.__ELECTRON__.core.invoke(name, args), { name, args });
   try {
     owner = await app.firstWindow();
     await expect(owner.locator('body')).toContainText('Waiting for your client', { timeout: 30000 });
-    await invoke('set_client_paths', { paths: { ...selected, mode: 'host', lan: false, vm_ram_mib: 4096 } });
-    await invoke('start_stack');
-    await verifyWorld();
+    const boot = owner;
     await invoke('open_settings');
     await expect.poll(() => app.windows().some(p => p.url().endsWith('settings.html'))).toBe(true);
     const page = app.windows().find(p => p.url().endsWith('settings.html'));
+    // The game page loses privileged IPC once it navigates. Keep owner actions
+    // in Settings and complete the actual setup Continue handler instead of
+    // starting services behind an abandoned "Waiting for your client" page.
+    owner = page;
+    await expect.poll(() => app.windows().some(p => p.url().endsWith('setup.html'))).toBe(true);
+    const setup = app.windows().find(p => p.url().endsWith('setup.html'));
+    await app.evaluate(({ dialog }) => { globalThis.roOriginalOpenDialog = dialog.showOpenDialog; });
+    try {
+      for (const key of ['data_grf', 'rdata_grf', 'official_grf', 'bgm_dir']) {
+        if (!selected[key]) continue;
+        // Stub only the OS file picker; real setup selection, validation,
+        // save, boot reload, readiness and navigation all run unchanged.
+        await app.evaluate(({ dialog }, chosen) => {
+          dialog.showOpenDialog = async () => ({ canceled: false, filePaths: [chosen] });
+        }, selected[key]);
+        await setup.locator(`[data-pick="${key}"]`).click();
+        await expect(setup.locator('#p-' + key)).toHaveText(selected[key]);
+      }
+    } finally {
+      await app.evaluate(({ dialog }) => {
+        dialog.showOpenDialog = globalThis.roOriginalOpenDialog;
+        delete globalThis.roOriginalOpenDialog;
+      });
+    }
+    await setup.getByRole('button', { name: 'Continue', exact: true }).click();
+    await expect(boot).toHaveURL(/^http:\/\/127\.0\.0\.1:3338\//, { timeout: 240000 });
+    // The desktop skin uses the native WinLogin inputs; accessible Account
+    // labels belong to the mobile adapter exercised separately below.
+    await expect(boot.locator('#WinLogin .user')).toBeVisible({ timeout: 90000 });
+    await verifyWorld();
+    await boot.screenshot({ path: path.join(out, 'setup-completed-login.png') });
+    report.screens.push('setup-completed-login.png');
+    report.setupCompletedToNativeLogin = true;
+    console.log('Real setup Continue reached the owned desktop login screen.');
+    await app.evaluate(({ BrowserWindow }) => {
+      for (const win of BrowserWindow.getAllWindows()) {
+        win.setTitle('Ragnarok Offline — disposable acceptance test');
+      }
+    });
     page.setDefaultTimeout(240000);
     browser = await chromium.launch({ headless: true });
     report.browser = browser.version();
@@ -157,7 +212,7 @@ async function main() {
       await game.getByLabel('Account', { exact: true }).fill(rejected + '_F');
       await game.getByLabel('Password', { exact: true }).fill(rejectedPassword);
       await game.getByRole('button', { name: 'Log in', exact: true }).tap();
-      await expect(game.getByText('Unregistered ID', { exact: true })).toBeVisible({ timeout: 90000 });
+      await expect(game.locator('.text').filter({ hasText: /Unregistered ID/ })).toBeVisible({ timeout: 90000 });
       expect(query("SELECT COUNT(*) FROM login WHERE userid IN ('" + rejected + "','" + rejected + "_F');")).toBe('0');
       await game.goto('about:blank');
       await page.getByRole('button', { name: 'Refresh accounts', exact: true }).click();
@@ -195,14 +250,38 @@ async function main() {
     }
     expect(report.pageErrors).toEqual([]);
     console.log('Hosting guard Settings/game checks passed. Evidence:', out);
+  } catch (error) {
+    failure = error;
+    report.failure = redact(error);
+    console.error('Acceptance failed:', report.failure);
+    // Capture the failing UI before cleanup can close it. Mask form fields;
+    // no account or connector secrets should enter screenshots.
+    for (const [index, page] of app.windows().entries()) {
+      if (page.isClosed()) continue;
+      await page.screenshot({ path: path.join(out, `failure-${index}.png`),
+        mask: [page.locator('input, textarea')] }).catch(() => {});
+    }
   } finally {
-    if (browser) await browser.close();
+    if (browser) await browser.close().catch(() => {});
     // Use the owning shell to stop its assets before restoring selection files.
     // If teardown fails, retain the files so a later launch sees the true state.
     let stopped = false;
-    try { if (owner) { await invoke('assets_stop'); await invoke('stack_down'); stopped = true; } }
+    try {
+      if (owner && !owner.isClosed()) {
+        await invoke('assets_stop'); await invoke('stack_down');
+        await freePorts(); stopped = true;
+      }
+    } catch (error) {
+      report.cleanupFailure = redact(error);
+    }
     finally {
-      await app.evaluate(({ app }) => app.exit(0)).catch(() => {});
+      if (stopped) await app.evaluate(({ app }) => app.exit(0)).catch(() => {});
+      else {
+        // Request the app's normal graceful teardown, never bypass it with
+        // app.exit after a failed owner IPC call. Verify ports before restore.
+        await app.close().catch(() => {});
+        try { await freePorts(); stopped = true; } catch {}
+      }
       if (stopped) {
         fs.rmSync(clientPath);
         if (settings) fs.writeFileSync(settingsPath, settings); else fs.rmSync(settingsPath, { force: true });
@@ -210,11 +289,10 @@ async function main() {
       }
       fs.writeFileSync(path.join(out, 'report.json'), JSON.stringify(report, null, 2));
     }
+    if (!stopped && !failure) failure = Error('Owned teardown did not free all ports; selection files retained');
   }
+  if (failure) throw failure;
 }
 main().catch(error => {
-  let message = String(error.message);
-  for (const era of ['renewal', 'prerenewal']) { try { journal(era); } catch {} }
-  for (const password of [...Object.values(credentials).map(c => c.password), ...serviceSecrets]) message = message.split(password).join('[redacted]');
-  console.error(message); process.exitCode = 1;
+  console.error(redact(error)); process.exitCode = 1;
 });

--- a/tests/hosting-policy.test.cjs
+++ b/tests/hosting-policy.test.cjs
@@ -1,0 +1,60 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const { effective } = require('../electron/hosting-policy');
+const store = require('../electron/settings-store');
+
+test('legacy LAN migrates only to LAN and explicit internet scopes keep loopback bindings', () => {
+  assert.equal(effective({ lan: false }, {}).hosting_scope, 'local');
+  assert.equal(effective({ lan: true }, {}).hosting_scope, 'lan');
+  for (const lan of ['false', 'true', 1, null]) assert.throws(() => effective({ lan }, {}), /Invalid LAN setting/);
+  for (const scope of ['local', 'lan', 'friends', 'public']) {
+    const client = effective({ lan: true, mode: 'join', join_host: 'https://example.org' }, { hosting_scope: scope });
+    assert.equal(client.lan, scope === 'lan');
+    assert.equal(client.hosting_scope, scope);
+    assert.equal(client.mode, 'join');
+    assert.equal(client.join_host, 'https://example.org');
+  }
+  for (const scope of [null, undefined, true, '', 'Friends']) {
+    assert.throws(() => effective({ lan: true }, { hosting_scope: scope }), /Invalid hosting scope/);
+  }
+});
+
+test('scope is strict and survives unrelated account/era settings without silently changing legacy state', t => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ro-scope-'));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const file = path.join(dir, 'settings.json');
+  assert.equal(Object.hasOwn(store.read(file, {}), 'hosting_scope'), false);
+  store.write(file, { hosting_scope: 'friends', open_registration: true }, {});
+  store.write(file, { prerenewal: true }, {});
+  assert.deepEqual(store.read(file, {}), { hosting_scope: 'friends', open_registration: true, prerenewal: true });
+  const before = fs.readFileSync(file, 'utf8');
+  for (const hosting_scope of [null, '', 'Friends', false]) {
+    assert.throws(() => store.write(file, { hosting_scope }, {}));
+    assert.equal(fs.readFileSync(file, 'utf8'), before);
+  }
+});
+
+test('real startup and Repair reject invalid or unprepared internet scopes before engine mutation', { skip: !process.env.STACK_BIN }, t => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ro-scope-engine-'));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const fake = path.join(dir, 'must-not-execute' + (process.platform === 'win32' ? '.exe' : ''));
+  fs.writeFileSync(fake, 'not executable', { mode: 0o700 });
+  const file = path.join(dir, 'settings.json');
+  for (const hosting_scope of ['friends', 'public', 'invalid', null]) {
+    fs.writeFileSync(file, JSON.stringify({ hosting_scope, open_registration: true }));
+    for (const verb of ['up', 'repair']) for (const flags of [[], ['--lan']]) {
+      const r = spawnSync(process.env.STACK_BIN, [verb, ...flags], { encoding: 'utf8', timeout: 5000,
+        env: { ...process.env, RAGNAROK_OFFLINE_ROOT: dir, RAGNAROKMAC_STATE: dir,
+          NEBULA_HOME: path.join(dir, 'never-started'), NEBULA_BIN: fake, RAGNAROKMAC_DOCKER: fake } });
+      assert.equal(r.status, 1);
+      assert.match(r.stderr, /Invalid hosting scope|conflicts with the saved hosting scope|managed service credentials/);
+      assert.equal(fs.existsSync(path.join(dir, 'never-started')), false);
+      assert.equal(fs.existsSync(path.join(dir, 'phase')), false);
+    }
+  }
+});


### PR DESCRIPTION
Internet sharing requires mandatory account safeguards even when a saved local preference permits game-login signup. This introduces the strict Local/LAN/Friends/Public scope contract, preserves legacy LAN behavior, and forces signup off and loopback game/asset configuration for internet scopes. A conflicting direct `--lan` request or an unprepared credential journal is rejected before startup/Repair reaches the engine.

Before game services start, the supervisor verifies generated owner-only signup, every enabled privileged/default GM login's password format, and the selected era's actual managed database/interserver credentials. It also runs this guard before owner account actions or backups restart game services. Enabling an unsafe renamed admin account therefore leaves games stopped with an accurate recovery message, instead of bypassing startup checks. Account IDs, passwords and characters are never reset by these guards.

Settings now shows the enforced signup policy and provides **Check internet account safeguards** for the running era. Its report explicitly keeps `publicationReady: false`: authenticated HTTP/WS access, effective privilege/listener auditing and a validated connector remain outstanding. Friends/Public sharing controls are not advertised as ready; this implements the persistent game-side policy contract they will require.

Stacked on #61. Local validation:62 Rust tests and51 Node tests pass with real pinned binaries, no skips; syntax/diff checks pass. Deterministic tests cover strict legacy/scope migration, mandatory signup and invalid/conflicting/unprepared scope rejection before engine mutation. Real Electron/roBrowser/rAthena acceptance passed: setup Continue reaches the desktop login screen, unsafe renamed GM startup and enable/restart are rejected, native suffix signup creates no account, and existing GM characters enter their maps in renewal → pre-renewal → renewal, with Friends/Friends/Public policies and zero page errors. Screenshots and report: `artifacts/issue-6/world/account-tests/hosting-guards-1788794631082/`. All four native/client CI checks passed on final head5722b23, run34138500641. The owned test world was shut down and original local renewal selection restored; GM passwords were not reset.

See `docs/HOSTING_POLICY.md` for the exact scope, recovery behavior and remaining gates. No tunnel, release or merge is requested; this does not close issue #4. Keep the PR unmerged until the owner tests and approves it.
