### PR TITLE
Preserve game-server crash metadata and logs before cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,8 @@ a client folder on the wrong drive, the virtual machine refusing to start,
 the first login not taking, and moving your characters to another machine —
 are collected in **[docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md)**.
 
+Unexpected game-server exits also retain private [crash evidence](docs/CRASH_DIAGNOSTICS.md) before container cleanup. Native stack traces and the intermittent crash investigation remain in progress.
+
 If yours is not there, the Settings window has a **Report a problem** button
 that copies everything a fix needs — logs, paths, versions — and opens a new
 issue ready to paste it into. Or ask in the

--- a/docs/CRASH_DIAGNOSTICS.md
+++ b/docs/CRASH_DIAGNOSTICS.md
@@ -1,0 +1,73 @@
+# Map-server crash evidence
+
+An unexpected map-server exit now creates a private incident report in
+`state/crashes/reports/`. The app checks every 15 seconds while its owned asset
+server runs. Capture also runs before game container replacement, orderly game
+stops/account changes, and Repair, so these operations preserve an existing
+failure before discarding the container. A stopped engine is never started for
+collection. The monitor queues behind owner operations and does not restart games.
+
+The report records the container/image identity, start/finish times, running
+database era, exit code and OOM indicator when available, supervisor/app version,
+compiled rAthena source pin and host architecture. It includes bounded map,
+login and char log tails. These companion tails describe capture time; they are
+not asserted to be synchronized with the original fault. The image identity is
+the authority for what ran; a compiled source pin alone cannot identify a custom
+or previously cached image.
+
+Logs are private by default and managed service credentials are redacted before
+writing. Review reports before sharing: they can contain player names or messages.
+No raw container configuration, environment, SQL data or core dump is exported.
+Invalid/unreadable credential journals cause capture to fail rather than writing
+an unredacted report. Collection failure is recorded locally; the normal stop or
+recovery operation is still allowed to proceed.
+
+New reports are immutable and deduplicated by container/start/finish identity.
+Each report is limited to 1 MiB; the newest ten reports are retained, with a
+10 MiB aggregate cap. Old legacy crash logs and unrelated files are not pruned.
+Filesystem failures leave an actionable local diagnostic rather than repeatedly
+creating partial reports. The CLI `ragnarok-stack capture-crashes` uses the same
+collector and reports any newly saved incident paths.
+
+## What this does not establish
+
+`Received a crash signal` describes rAthena's emergency handler, not the faulty
+call or a successful save. Exit code 139 by itself does not prove SIGSEGV; the
+report labels it as a nonzero exit. Missing metadata remains unknown. Collection
+can miss a container removed externally between polls or a VM destroyed before
+its logs can be read; it cannot recover evidence the engine no longer retains.
+
+**There is no native backtrace in this increment.** Issue #16 stays open. Next
+steps are matching per-era/architecture debug symbols, original-fault capture
+before the existing handler re-raises, private bounded diagnostic artifacts,
+and disposable sanitizer/reload/logout stress tests. Population cleanup contains
+possible lifetime hazards worth auditing, but no underlying intermittent fault
+has been reproduced or fixed by this logging change.
+
+## Validation
+
+`cargo test` covers classification, terminal escape removal and retention.
+With `STACK_BIN` set to the freshly built supervisor, Node tests compile a small
+portable fake engine and exercise actual CLI capture, credential redaction,
+metadata filtering, restarted-container deduplication, large stdout/stderr tails
+and clean exits. Monitor tests cover inactive ownership, overlapping polls,
+retry and sanitized error reporting. Native CI runs these on macOS, Linux and
+Windows.
+
+A separate actual-guest fixture deliberately terminates an Alpine shell with
+SIGSEGV in the marked disposable world. It verifies the engine's real exit
+metadata, retained logs, duplicate suppression and preservation through
+supervisor shutdown. It tests the capture mechanism only; it is not an rAthena
+crash reproducer. Never inject faults into a player's save or report an injected
+signal as a reproduced instance of #16.
+
+Run the opt-in guest fixture with `RO_E2E_WORLD` set to a stopped disposable
+world and `STACK_BIN` set to the newly compiled collector:
+
+```sh
+node tests/e2e/crash-capture.cjs
+```
+
+It verifies free ports, starts only that world's VM, refuses existing world
+containers, runs the faulting shell in the existing server image, and stops the
+VM after preserving its report. It never starts MariaDB or real game servers.

--- a/electron/crash-monitor.js
+++ b/electron/crash-monitor.js
@@ -1,0 +1,30 @@
+'use strict';
+
+// Serial, owner-only monitoring; it never starts an engine or restarts a game.
+class CrashMonitor {
+  constructor({ active, collect, log, interval = 15000 }) {
+    Object.assign(this, { active, collect, log, interval });
+    this.busy = false;
+    this.lastError = '';
+  }
+  async tick() {
+    if (this.busy || !this.active()) return;
+    this.busy = true;
+    try {
+      const message = await this.collect();
+      this.lastError = '';
+      if (message?.trim()) this.log(message.trim());
+    } catch {
+      const message = 'Crash evidence collection failed; check local storage and engine diagnostics.';
+      if (this.lastError !== message) this.log(message);
+      this.lastError = message;
+    } finally { this.busy = false; }
+  }
+  start() {
+    if (this.timer) return;
+    this.timer = setInterval(() => { void this.tick(); }, this.interval);
+    this.timer.unref();
+  }
+  stop() { clearInterval(this.timer); this.timer = null; }
+}
+module.exports = { CrashMonitor };

--- a/electron/main.js
+++ b/electron/main.js
@@ -2024,6 +2024,12 @@ function buildMenu() {
 // ---------------------------------------------------------------------------
 
 let tearingDown = false;
+const crashMonitor = new (require('./crash-monitor').CrashMonitor)({
+	active: () => !tearingDown && assetServer.running,
+	collect: () => queueServerOperation(() => !tearingDown && assetServer.running
+		? runStack(['capture-crashes']) : ''),
+	log: message => appLog(message),
+});
 // Set when a launch arrives while we are quitting: see the second-instance
 // handler. Guarded because two clicks must not queue two copies.
 let relaunchQueued = false;
@@ -2137,6 +2143,7 @@ if (!app.requestSingleInstanceLock()) {
 }
 
 app.whenReady().then(() => {
+	crashMonitor.start();
 	// Before anything reads a path: an existing install still has its data
 	// under the old folder name.
 	migrateDataRoot();

--- a/stack/src/accounts.rs
+++ b/stack/src/accounts.rs
@@ -171,6 +171,7 @@ pub(crate) fn with_servers_stopped<T>(
     dk: &Docker,
     operation: impl FnOnce() -> Result<T, String>,
 ) -> Result<T, String> {
+    crate::crashes::capture_all(cfg, dk);
     let previous_start = dk.started_at("ragnarok-char");
     let mut stopped = Vec::new();
     let mut result = Ok(());

--- a/stack/src/cmds.rs
+++ b/stack/src/cmds.rs
@@ -1355,73 +1355,9 @@ fn strip_ansi(s: &str) -> String {
     out.trim().to_string()
 }
 
-/// Keep a crashed server's last words before the container is thrown away.
-///
-/// `run_server` removes the old container before starting the new one, and
-/// removing a container deletes its log with it. So every restart destroyed the
-/// only record of why the previous one died -- which, for a server that falls
-/// over intermittently, is the evidence and nothing else is.
-///
-/// rAthena prints no backtrace: `sig_proc` catches SIGSEGV, saves online
-/// characters, then re-raises with the default handler. The shipped binaries
-/// are stripped and Alpine's musl has no `execinfo`, so there is nothing to
-/// print even if it tried. What there *is* is the last few hundred lines of
-/// what the server was doing, and that is worth keeping.
-fn save_crash_log(cfg: &Config, dk: &Docker, name: &str) {
-    // "exited" covers a clean stop too, so the log is only kept when the exit
-    // looks unplanned -- a clean shutdown says so on its way out.
-    let Some(state) = dk.state(name) else { return };
-    if state != "exited" {
-        return;
-    }
-    let log = dk.logs(name, "400");
-    let crashed = log.contains("Received a crash signal")
-        || log.contains("Received another crash signal");
-    if !crashed {
-        return;
-    }
-    let dir = cfg.state.join("crashes");
-    if fs::create_dir_all(&dir).is_err() {
-        return;
-    }
-    // Seconds since the epoch: sortable, needs no date formatting, and this
-    // binary has no dependency that would provide one.
-    let stamp = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0);
-    let path = dir.join(format!("{name}-{stamp}.log"));
-    if fs::write(&path, strip_ansi_lines(&log)).is_ok() {
-        eprintln!(
-            "{name} crashed during the last run; its log was kept at {}",
-            path.display()
-        );
-        // Keep the last ten. A crash loop should not quietly fill a disk.
-        prune_crash_logs(&dir, 10);
-    }
-}
-
-/// rAthena colours its output, and a log full of escape sequences is a log
-/// nobody will read or attach to a bug report.
-fn strip_ansi_lines(s: &str) -> String {
-    s.lines().map(strip_ansi).collect::<Vec<_>>().join("\n")
-}
-
-fn prune_crash_logs(dir: &Path, keep: usize) {
-    let Ok(rd) = fs::read_dir(dir) else { return };
-    let mut files: Vec<PathBuf> = rd.flatten().map(|e| e.path()).filter(|p| p.is_file()).collect();
-    if files.len() <= keep {
-        return;
-    }
-    files.sort();
-    for p in &files[..files.len() - keep] {
-        let _ = fs::remove_file(p);
-    }
-}
-
 fn run_server(cfg: &Config, dk: &Docker, name: &str, port: u16, binary: &str, lan: bool) -> Result<(), String> {
     // Before the container goes, and with it its log.
-    save_crash_log(cfg, dk, name);
+    crate::crashes::capture_all(cfg, dk);
     dk.remove_container(name);
 
     // One directory mount, not five file mounts: a single-file bind whose host
@@ -1474,7 +1410,8 @@ fn run_server(cfg: &Config, dk: &Docker, name: &str, port: u16, binary: &str, la
         .map_err(|e| format!("starting {name}: {e}"))
 }
 
-fn stop_game_services(dk: &Docker) -> Result<(), String> {
+fn stop_game_services(cfg: &Config, dk: &Docker) -> Result<(), String> {
+    crate::crashes::capture_all(cfg, dk);
     for service in ["ragnarok-map", "ragnarok-char", "ragnarok-login"] {
         if dk.is_running(service) && (dk.output(["stop", "-t", "30", service]).is_err() || dk.is_running(service)) {
             return Err(format!("Could not stop {service} cleanly; database credentials were not changed."));
@@ -1574,7 +1511,7 @@ pub fn secure_services(cfg: &Config, dk: &Docker, lan: bool, ram_mib: Option<u32
         // includes all player data; secure its host directory before writing.
         crate::private_fs::directory(&cfg.state)?;
         let backups = cfg.state.join("backups"); crate::private_fs::directory(&backups)?;
-        stop_game_services(dk)?;
+        stop_game_services(cfg, dk)?;
         let destination = backups.join(format!("before-service-credentials-{}-{}.sql", crate::service_credentials::era(cfg), crate::private_fs::random_hex(8)?));
         if let Err(error) = backup(cfg, dk, &destination.to_string_lossy()) {
             return Err(format!("Service credentials were not changed: {error}. Start the server to reconnect."));
@@ -1610,7 +1547,7 @@ pub fn up(cfg: &Config, dk: &Docker, lan: bool, ram_mib: Option<u32>) -> Result<
         protect_game_config(cfg)?;
         // Recreate the database with the private bind/copy, including after a
         // failed migration or a runtime update. Flush players first.
-        stop_game_services(dk)?;
+        stop_game_services(cfg, dk)?;
         if dk.is_running(DB_CONTAINER) && (dk.output(["stop", "-t", "30", DB_CONTAINER]).is_err() || dk.is_running(DB_CONTAINER)) {
             return Err("Could not stop the database cleanly; credentials were not changed".into());
         }
@@ -1866,7 +1803,7 @@ pub fn up(cfg: &Config, dk: &Docker, lan: bool, ram_mib: Option<u32>) -> Result<
 
 pub fn down(cfg: &Config, dk: &Docker) -> Result<(), String> {
     let _lock = Lock::acquire(cfg)?;
-    stop_game_services(dk)?;
+    stop_game_services(cfg, dk)?;
     for c in SERVERS {
         dk.remove_container(c);
     }
@@ -1956,7 +1893,7 @@ pub fn restore(cfg: &Config, dk: &Docker, src: &str) -> Result<(), String> {
         return Err(format!("no such backup: {src}"));
     }
     crate::accounts::verify_era(cfg, dk, crate::service_credentials::era(cfg))?;
-    stop_game_services(dk)?;
+    stop_game_services(cfg, dk)?;
     let backups = cfg.state.join("backups");
     crate::private_fs::directory(&backups)?;
     let safety = backups.join(format!("before-restore-{}-{}.sql", crate::service_credentials::era(cfg), crate::private_fs::random_hex(8)?));
@@ -1996,6 +1933,7 @@ pub fn restore(cfg: &Config, dk: &Docker, src: &str) -> Result<(), String> {
 pub fn repair(cfg: &Config, dk: &Docker, lan: bool, ram_mib: Option<u32>) -> Result<(), String> {
     crate::registration::enabled(&cfg.state)?;
     crate::hosting::before_start(cfg, crate::hosting::Scope::load(cfg, lan)?)?;
+    crate::crashes::capture_all(cfg, dk);
     phase(cfg, "Repairing…");
     // Break the lock rather than wait: the usual reason to reach for repair is
     // a previous run that died holding one.

--- a/stack/src/crashes.rs
+++ b/stack/src/crashes.rs
@@ -1,0 +1,314 @@
+//! Private, bounded evidence for an exited game process, before its container
+//! disappears. This captures termination metadata/logs, not a native backtrace.
+use crate::{
+    config::Config,
+    docker::Docker,
+    json::{self, Value},
+    private_fs,
+};
+use std::{
+    fs,
+    path::Path,
+    time::{SystemTime, UNIX_EPOCH},
+};
+const SERVERS: [&str; 3] = ["ragnarok-map", "ragnarok-char", "ragnarok-login"];
+const PREFIX: &str = "incident-";
+const LOG_LIMIT: usize = 128 * 1024;
+const MAX_REPORT: u64 = 1024 * 1024;
+
+fn number(value: Option<&Value>) -> Option<i32> {
+    match value {
+        Some(Value::Number(n)) if n.is_finite() && n.fract() == 0.0 && *n >= 0.0 && *n <= 255.0 => {
+            Some(*n as i32)
+        }
+        _ => None,
+    }
+}
+fn reason(state: &Value, log: &str) -> Option<&'static str> {
+    if !matches!(state.str("Status"), Some("exited" | "dead")) {
+        return None;
+    }
+    if state.get("OOMKilled") == Some(&Value::Bool(true)) {
+        return Some("oom-killed");
+    }
+    if log.contains("Received a crash signal") || log.contains("Received another crash signal") {
+        return Some("rathena-crash-signal");
+    }
+    match number(state.get("ExitCode")) {
+        Some(0) if state.str("Status") == Some("exited") => None,
+        Some(1..=255) => Some("nonzero-exit"),
+        _ => Some("unknown-termination"),
+    }
+}
+fn hash(bytes: &[u8]) -> u64 {
+    bytes.iter().fold(0xcbf29ce484222325, |h, b| {
+        (h ^ *b as u64).wrapping_mul(0x100000001b3)
+    })
+}
+fn clean(body: &str) -> String {
+    // Remove CSI/OSC terminal escapes without interpreting them in the report.
+    let mut out = String::new();
+    let mut chars = body.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\x1b' {
+            match chars.next() {
+                Some('[') => {
+                    for c in chars.by_ref() {
+                        if ('@'..='~').contains(&c) {
+                            break;
+                        }
+                    }
+                }
+                Some(']') => {
+                    while let Some(c) = chars.next() {
+                        if c == '\x07' || (c == '\x1b' && chars.next() == Some('\\')) {
+                            break;
+                        }
+                    }
+                }
+                _ => {}
+            }
+        } else if !c.is_control() || c == '\n' || c == '\t' {
+            out.push(c);
+        }
+    }
+    out
+}
+fn redact(cfg: &Config, mut body: String) -> Result<String, String> {
+    for era in ["renewal", "prerenewal"] {
+        let file = cfg
+            .state
+            .join("private/service-credentials")
+            .join(era)
+            .join("credentials.json");
+        if !file.exists() {
+            continue;
+        }
+        let data = private_fs::read(&file, 65536)?;
+        let value = json::parse(&data)
+            .map_err(|_| "Cannot redact managed credentials from crash evidence")?;
+        for field in ["root", "database", "interserver"] {
+            let secret = value
+                .str(field)
+                .filter(|v| !v.is_empty())
+                .ok_or("Cannot redact managed credentials from crash evidence")?;
+            body = body.replace(secret, "[redacted]");
+        }
+    }
+    Ok(body)
+}
+fn prune(dir: &Path) -> Result<(), String> {
+    let mut entries = Vec::new();
+    for entry in fs::read_dir(dir).map_err(|_| "Cannot read crash evidence directory")? {
+        let entry = entry.map_err(|_| "Cannot read crash evidence entry")?;
+        let name = entry.file_name().to_string_lossy().into_owned();
+        let meta = fs::symlink_metadata(entry.path())
+            .map_err(|_| "Cannot inspect crash evidence entry")?;
+        if name.starts_with(PREFIX)
+            && name.ends_with(".log")
+            && meta.is_file()
+            && !meta.file_type().is_symlink()
+        {
+            entries.push((name, entry.path(), meta.len()));
+        }
+    }
+    entries.sort_by(|a, b| a.0.cmp(&b.0));
+    let mut bytes: u64 = entries.iter().map(|x| x.2).sum();
+    let mut count = entries.len();
+    for (_, path, size) in entries {
+        if count <= 10 && bytes <= 10 * MAX_REPORT {
+            break;
+        }
+        fs::remove_file(path).map_err(|_| "Cannot enforce crash evidence retention")?;
+        bytes = bytes.saturating_sub(size);
+        count -= 1;
+    }
+    Ok(())
+}
+
+pub fn capture(cfg: &Config, dk: &Docker, name: &str) -> Result<Option<String>, String> {
+    if !SERVERS.contains(&name) {
+        return Err("Unsupported crash evidence service".into());
+    }
+    let inspect = match dk.diagnostic_output(&["inspect", name], 64 * 1024) {
+        Ok(value) => value,
+        Err(_) => return Ok(None), // Engine stopped or container absent; never start it here.
+    };
+    let Value::Array(entries) =
+        json::parse(&inspect).map_err(|_| "Cannot parse crash termination metadata")?
+    else {
+        return Err("Invalid crash termination metadata".into());
+    };
+    if entries.len() != 1 {
+        return Err("Ambiguous crash container identity".into());
+    }
+    let container = &entries[0];
+    let state = container
+        .get("State")
+        .ok_or("Missing crash termination metadata")?;
+    if !matches!(state.str("Status"), Some("exited" | "dead")) {
+        return Ok(None);
+    }
+    let id = container
+        .str("Id")
+        .filter(|id| !id.is_empty() && id.len() <= 128 && id.bytes().all(|c| c.is_ascii_hexdigit()))
+        .ok_or("Invalid crash container identity")?;
+    let log = dk
+        .diagnostic_output(&["logs", "-t", "--tail", "400", id], LOG_LIMIT)
+        .unwrap_or_else(|_| "[Log unavailable: diagnostic command failed or timed out]".into());
+    let Some(reason) = reason(state, &log) else {
+        return Ok(None);
+    };
+    let key = hash(
+        format!(
+            "{id}:{}:{}",
+            state.str("StartedAt").unwrap_or("unknown"),
+            state.str("FinishedAt").unwrap_or("unknown")
+        )
+        .as_bytes(),
+    );
+    let dir = cfg.state.join("crashes");
+    private_fs::directory(&dir)?;
+    // Put new reports in their own directory; never prune old user artifacts.
+    let dir = dir.join("reports");
+    private_fs::directory(&dir)?;
+    let suffix = format!("-{key:016x}.log");
+    if fs::read_dir(&dir)
+        .map_err(|_| "Cannot read crash evidence directory")?
+        .flatten()
+        .any(|e| {
+            e.file_name().to_string_lossy().starts_with(PREFIX)
+                && e.file_name().to_string_lossy().ends_with(&suffix)
+        })
+    {
+        return Ok(None);
+    }
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis();
+    let path = dir.join(format!("{PREFIX}{stamp:020}-{name}{suffix}"));
+    let quote = json::quote;
+    let exit = number(state.get("ExitCode"))
+        .map(|n| n.to_string())
+        .unwrap_or("null".into());
+    let oom = match state.get("OOMKilled") {
+        Some(Value::Bool(value)) => value.to_string(),
+        _ => "null".into(),
+    };
+    let era = match fs::read_to_string(cfg.state.join(".db-volume"))
+        .unwrap_or_default()
+        .trim()
+    {
+        "ragnarokmac-db" => "renewal",
+        "ragnarokmac-db-prere" => "prerenewal",
+        _ => "unknown",
+    };
+    let mut report = format!("{{\"schema\":1,\"service\":{},\"container\":{},\"reason\":{},\"exitCode\":{exit},\"oomKilled\":{oom},\"era\":{},\"image\":{},\"startedAt\":{},\"finishedAt\":{},\"backtraceAvailable\":false}}\n\nPrivate diagnostic report. Review before sharing; logs may identify players.\nNo native fault stack was captured. Exit codes alone do not prove a particular signal.\n\n--- {name} ---\n{log}\n", quote(name), quote(id), quote(reason), quote(era), quote(container.str("Image").unwrap_or("unknown")), quote(state.str("StartedAt").unwrap_or("unknown")), quote(state.str("FinishedAt").unwrap_or("unknown")));
+    let pin = include_str!("../../config/VENDOR_PINS")
+        .lines()
+        .find_map(|line| {
+            let mut words = line.split_whitespace();
+            (words.next() == Some("rathena"))
+                .then(|| words.nth(1))
+                .flatten()
+        })
+        .unwrap_or("unknown");
+    report.push_str(&format!("\nSupervisor version: {}\nApp version: {}\nCompiled source rAthena pin: {}\nHost architecture: {}\n",
+        env!("CARGO_PKG_VERSION"), cfg.app_version.as_deref().unwrap_or("unknown"), pin, std::env::consts::ARCH));
+    for other in SERVERS {
+        if other != name {
+            report.push_str(&format!("\n--- {other} (capture-time tail) ---\n"));
+            report.push_str(
+                &dk.diagnostic_output(&["logs", "-t", "--tail", "100", other], LOG_LIMIT)
+                    .unwrap_or_else(|_| "[Log unavailable]".into()),
+            );
+        }
+    }
+    report = redact(cfg, clean(&report))?;
+    if report.len() as u64 > MAX_REPORT {
+        return Err("Crash evidence exceeds its size limit".into());
+    }
+    private_fs::create(&path, report.as_bytes())?;
+    prune(&dir)?;
+    Ok(Some(path.to_string_lossy().into_owned()))
+}
+
+pub fn capture_all(cfg: &Config, dk: &Docker) {
+    for service in SERVERS {
+        match capture(cfg, dk, service) {
+            Ok(Some(path)) => eprintln!("{service} stopped unexpectedly; private evidence saved at {path}"),
+            Err(_) => eprintln!("Could not preserve {service} crash evidence; check private directory permissions and free space"),
+            Ok(None) => {},
+        }
+    }
+}
+
+pub fn command(cfg: &Config, dk: &Docker) -> Result<(), String> {
+    for service in SERVERS {
+        if let Some(path) = capture(cfg, dk, service)? {
+            println!("{service} stopped unexpectedly; private evidence saved at {path}");
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn classifies_exit_metadata_without_inventing_a_signal() {
+        let state = |status, code, oom| {
+            json::parse(&format!(
+                "{{\"Status\":\"{status}\",\"ExitCode\":{code},\"OOMKilled\":{oom}}}"
+            ))
+            .unwrap()
+        };
+        assert_eq!(
+            reason(&state("running", 139, false), "Received a crash signal"),
+            None
+        );
+        assert_eq!(reason(&state("exited", 0, false), "Finished"), None);
+        assert_eq!(
+            reason(&state("exited", 0, false), "Received a crash signal"),
+            Some("rathena-crash-signal")
+        );
+        assert_eq!(
+            reason(&state("exited", 139, false), ""),
+            Some("nonzero-exit")
+        );
+        assert_eq!(reason(&state("exited", 137, true), ""), Some("oom-killed"));
+        assert_eq!(
+            reason(&state("dead", 0, false), ""),
+            Some("unknown-termination")
+        );
+        assert_eq!(
+            reason(&json::parse("{\"Status\":\"exited\"}").unwrap(), ""),
+            Some("unknown-termination")
+        );
+    }
+    #[test]
+    fn strips_terminal_control_sequences() {
+        assert_eq!(
+            clean("\x1b[31mFatal\x1b[0m\n\x1b]0;title\x07next\r\0"),
+            "Fatal\nnext"
+        );
+    }
+    #[test]
+    fn retention_preserves_unrelated_files_and_keeps_ten_reports() {
+        let root = std::env::temp_dir().join(format!(
+            "ro-crash-test-{}",
+            private_fs::random_hex(8).unwrap()
+        ));
+        fs::create_dir(&root).unwrap();
+        fs::write(root.join("user-notes.log"), "keep").unwrap();
+        for n in 0..12 {
+            fs::write(root.join(format!("incident-{n:020}.log")), "report").unwrap();
+        }
+        prune(&root).unwrap();
+        assert!(root.join("user-notes.log").exists());
+        assert!(!root.join("incident-00000000000000000001.log").exists());
+        assert_eq!(fs::read_dir(&root).unwrap().count(), 11);
+        fs::remove_dir_all(root).unwrap();
+    }
+}

--- a/stack/src/docker.rs
+++ b/stack/src/docker.rs
@@ -102,6 +102,45 @@ impl Docker {
         self.state(name).as_deref() == Some("running")
     }
 
+    /// Bounded diagnostic reads. Drain both pipes concurrently so a large log
+    /// cannot deadlock the CLI; retain only each stream's tail and cap time.
+    pub fn diagnostic_output(&self, args: &[&str], limit: usize) -> Result<String, String> {
+        let mut child = self.base().args(args).stdin(Stdio::null())
+            .stdout(Stdio::piped()).stderr(Stdio::piped()).spawn()
+            .map_err(|_| "Diagnostic command could not start")?;
+        fn tail(mut input: impl Read, limit: usize) -> std::io::Result<Vec<u8>> {
+            let mut out = std::collections::VecDeque::with_capacity(limit);
+            let mut buffer = [0; 8192];
+            loop {
+                let n = input.read(&mut buffer)?;
+                if n == 0 { break; }
+                for byte in &buffer[..n] {
+                    if out.len() == limit { out.pop_front(); }
+                    out.push_back(*byte);
+                }
+            }
+            Ok(out.into())
+        }
+        let stdout = child.stdout.take().unwrap();
+        let stderr = child.stderr.take().unwrap();
+        let output = std::thread::spawn(move || tail(stdout, limit));
+        let errors = std::thread::spawn(move || tail(stderr, limit));
+        let deadline = Instant::now() + Duration::from_secs(10);
+        let success = loop {
+            match child.try_wait() {
+                Ok(Some(status)) => break status.success(),
+                Ok(None) if Instant::now() < deadline => sleep(Duration::from_millis(20)),
+                _ => { let _ = child.kill(); let _ = child.wait(); break false; }
+            }
+        };
+        let out = output.join().ok().and_then(Result::ok);
+        let err = errors.join().ok().and_then(Result::ok);
+        if !success { return Err("Diagnostic command failed or timed out".into()); }
+        let mut body = String::from_utf8_lossy(&out.ok_or("Diagnostic output unavailable")?).into_owned();
+        body.push_str(&String::from_utf8_lossy(&err.ok_or("Diagnostic output unavailable")?));
+        Ok(body)
+    }
+
     /// Remove every container answering to a name, then wait for the name to be
     /// released.
     ///

--- a/stack/src/main.rs
+++ b/stack/src/main.rs
@@ -13,6 +13,7 @@ mod assets;
 mod accounts;
 mod asset_transaction;
 mod cmds;
+mod crashes;
 mod config;
 mod docker;
 mod json;
@@ -31,7 +32,7 @@ use std::env;
 use std::path::PathBuf;
 use std::process::exit;
 
-const USAGE: &str = "usage: ragnarok-stack hosting-check [--lan]|secure-services [--lan] [--ram MiB]|mods|mod-enable NAME|mod-disable NAME|up [--lan] [--ram MiB]|down|repair [--lan] [--ram MiB]|status|logs [service] [tail]\n\
+const USAGE: &str = "usage: ragnarok-stack capture-crashes|hosting-check [--lan]|secure-services [--lan] [--ram MiB]|mods|mod-enable NAME|mod-disable NAME|up [--lan] [--ram MiB]|down|repair [--lan] [--ram MiB]|status|logs [service] [tail]\n\
                      \x20      backup <file>|restore <file>\n\
                      \x20      accounts (private JSON request on stdin)\n\
                      \x20      link-assets <data.grf> [rdata.grf] [official_data.grf] [bgm-dir]";
@@ -83,7 +84,7 @@ fn main() {
         Err(e) => fail(verb, &e),
     };
     let dk = Docker::new(cfg.docker.clone(), cfg.nebula_home.clone(), cfg.state.clone());
-    let _operation = if matches!(verb, "up" | "down" | "repair" | "backup" | "restore" | "accounts" | "secure-services" | "hosting-check") {
+    let _operation = if matches!(verb, "up" | "down" | "repair" | "backup" | "restore" | "accounts" | "secure-services" | "hosting-check" | "capture-crashes") {
         match operation_lock::acquire(&cfg.state) {
             Ok(lock) => Some(lock),
             Err(error) => fail(verb, &error),
@@ -105,6 +106,7 @@ fn main() {
         .and_then(|v| v.parse::<u32>().ok());
 
     let result = match verb {
+        "capture-crashes" => crashes::command(&cfg, &dk),
         "hosting-check" => hosting::check(&cfg, &dk, lan).map(|report| println!("{report}")),
         "accounts" => {
             if let Err(error) = accounts::run(&cfg, &dk) {

--- a/tests/crash-evidence.test.cjs
+++ b/tests/crash-evidence.test.cjs
@@ -1,0 +1,58 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+test('compiled collector captures abnormal exits privately, redacts secrets, deduplicates and bounds logs',
+  { skip: !process.env.STACK_BIN }, t => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ro-crash-evidence-'));
+    t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+    const binary = path.join(root, 'engine' + (process.platform === 'win32' ? '.exe' : ''));
+    const built = spawnSync('rustc', [path.join(__dirname, 'fixtures/crash-engine.rs'), '-o', binary], { encoding: 'utf8' });
+    assert.equal(built.status, 0, built.stderr);
+    const era = path.join(root, 'private/service-credentials/renewal');
+    fs.mkdirSync(era, { recursive: true });
+    const secrets = { root: 'root-private-sentinel', database: 'db-private-sentinel', interserver: 'game-private-sentinel' };
+    fs.writeFileSync(path.join(era, 'credentials.json'), JSON.stringify(secrets), { mode: 0o600 });
+    fs.writeFileSync(path.join(root, '.db-volume'), 'ragnarokmac-db');
+    const id = 'a'.repeat(64);
+    const state = { Status: 'exited', ExitCode: 139, OOMKilled: false,
+      StartedAt: '2026-09-07T01:00:00Z', FinishedAt: '2026-09-07T02:00:00Z' };
+    const writeInspect = () => fs.writeFileSync(path.join(root, 'inspect.json'), JSON.stringify([
+      { Id: id, Image: 'sha256:image-fixture', State: state, Config: { Env: ['NEVER_EXPORT_INSPECT_SECRET'] } },
+    ]));
+    writeInspect();
+    fs.writeFileSync(path.join(root, 'map.log'), '\x1b[31mReceived a crash signal\x1b[0m\n' + Object.values(secrets).join('\n'));
+    const run = () => spawnSync(process.env.STACK_BIN, ['capture-crashes'], { encoding: 'utf8', timeout: 30000,
+      env: { ...process.env, RO_CRASH_FIXTURE: root, RAGNAROK_OFFLINE_ROOT: root,
+        RAGNAROKMAC_STATE: root, RAGNAROKMAC_DOCKER: binary, NEBULA_HOME: path.join(root, 'never-started') } });
+    let result = run(); assert.equal(result.status, 0, result.stderr);
+    const reports = path.join(root, 'crashes/reports');
+    const files = () => fs.readdirSync(reports).filter(x => x.endsWith('.log'));
+    assert.equal(files().length, 1);
+    const reportPath = path.join(reports, files()[0]);
+    const body = fs.readFileSync(reportPath, 'utf8');
+    const metadata = JSON.parse(body.split('\n')[0]);
+    assert.equal(metadata.reason, 'rathena-crash-signal');
+    assert.equal(metadata.exitCode, 139); assert.equal(metadata.backtraceAvailable, false);
+    assert.equal(metadata.era, 'renewal'); assert.equal(metadata.image, 'sha256:image-fixture');
+    for (const secret of [...Object.values(secrets), 'NEVER_EXPORT_INSPECT_SECRET']) assert.equal(body.includes(secret), false);
+    assert.equal(body.includes('\x1b'), false); assert.match(body, /last stderr context/);
+    if (process.platform !== 'win32') assert.equal(fs.statSync(reportPath).mode & 0o777, 0o600);
+    result = run(); assert.equal(result.status, 0, result.stderr); assert.equal(files().length, 1);
+    assert.equal(result.stdout.trim(), '');
+    // A restarted process in the same container is a new incident.
+    state.StartedAt = '2026-09-07T03:00:00Z'; state.ExitCode = 137; state.OOMKilled = true;
+    writeInspect(); fs.writeFileSync(path.join(root, 'map.log'), 'x'.repeat(2 * 1024 * 1024) + '\nfinal fault marker\n');
+    result = run(); assert.equal(result.status, 0, result.stderr); assert.equal(files().length, 2);
+    const latest = fs.readFileSync(path.join(reports, files().sort().at(-1)), 'utf8');
+    assert.equal(JSON.parse(latest.split('\n')[0]).reason, 'oom-killed');
+    assert.ok(latest.length < 1024 * 1024); assert.match(latest, /final fault marker/);
+    state.StartedAt = '2026-09-07T04:00:00Z'; state.OOMKilled = false; state.ExitCode = 0; writeInspect();
+    result = run(); assert.equal(result.status, 0, result.stderr); assert.equal(files().length, 2);
+    assert.equal(fs.existsSync(path.join(root, 'never-started')), false);
+    assert.ok(fs.readFileSync(path.join(root, 'calls'), 'utf8').trim().split('\n').every(x => /^(inspect|logs) /.test(x)));
+  });

--- a/tests/crash-monitor.test.cjs
+++ b/tests/crash-monitor.test.cjs
@@ -1,0 +1,31 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { CrashMonitor } = require('../electron/crash-monitor');
+
+test('crash monitoring does not run for a stopped or non-owned world or overlap a collection', async () => {
+  let active = false, calls = 0, finish;
+  const logs = [];
+  const monitor = new CrashMonitor({ active: () => active, log: x => logs.push(x),
+    collect: () => { calls++; return new Promise(resolve => { finish = resolve; }); } });
+  await monitor.tick(); assert.equal(calls, 0);
+  active = true;
+  const pending = monitor.tick();
+  await monitor.tick(); assert.equal(calls, 1);
+  finish('private incident retained'); await pending;
+  assert.deepEqual(logs, ['private incident retained']);
+  active = false; await monitor.tick(); assert.equal(calls, 1);
+});
+
+test('monitor retries failures without logging raw errors or repeated noise', async () => {
+  let fail = true;
+  const logs = [];
+  const monitor = new CrashMonitor({ active: () => true, log: x => logs.push(x),
+    collect: async () => { if (fail) throw Error('private sentinel'); return ''; } });
+  await monitor.tick(); await monitor.tick();
+  assert.equal(logs.length, 1); assert.doesNotMatch(logs[0], /sentinel/);
+  fail = false; await monitor.tick();
+  fail = true; await monitor.tick(); assert.equal(logs.length, 2);
+  monitor.start(); const timer = monitor.timer; monitor.start();
+  assert.equal(monitor.timer, timer); monitor.stop(); assert.equal(monitor.timer, null);
+});

--- a/tests/e2e/crash-capture.cjs
+++ b/tests/e2e/crash-capture.cjs
@@ -1,0 +1,91 @@
+// Opt-in engine integration. Only a marked, stopped disposable world is allowed.
+// The child shell faults; no rAthena process or player database is exercised.
+'use strict';
+const fs = require('node:fs');
+const path = require('node:path');
+const net = require('node:net');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+if (!process.env.RO_E2E_WORLD || !process.env.STACK_BIN)
+  throw Error('Set RO_E2E_WORLD to a stopped disposable world and STACK_BIN to the collector build');
+const world = fs.realpathSync(process.env.RO_E2E_WORLD);
+assert.equal(JSON.parse(fs.readFileSync(path.join(world, '.ragnarok-e2e.json'))).disposable, true);
+const suffix = process.platform === 'win32' ? '.exe' : '';
+const supervisor = path.resolve(process.env.STACK_BIN);
+const env = { ...process.env, NEBULA_HOME: path.join(world, 'nebula'),
+  RAGNAROK_OFFLINE_ROOT: path.join(world, 'runtime'), RAGNAROKMAC_STATE: path.join(world, 'state'),
+  RAGNAROKMAC_DOCKER: path.join(world, 'runtime/bin/docker-slim' + suffix),
+  NEBULA_BIN: path.join(world, 'runtime/bin/nebula' + suffix) };
+const invoke = (binary, args, timeout = 30000) => spawnSync(binary, args, { env, encoding: 'utf8', timeout });
+const dk = args => invoke(env.RAGNAROKMAC_DOCKER, args);
+const run = verb => invoke(supervisor, [verb], 120000);
+const report = { supervisorSha256: require('node:crypto').createHash('sha256').update(fs.readFileSync(supervisor)).digest('hex'), fixture: 'A child Alpine shell receives SIGSEGV; not an rAthena reproducer', checks: [] };
+async function freePorts() {
+  for (const port of [3338, 6900, 6121, 5121, 7462]) await new Promise((resolve, reject) => {
+    const socket = net.connect(port, '127.0.0.1');
+    socket.once('connect', () => { socket.destroy(); reject(Error('Occupied host port; stop the existing world first')); });
+    socket.once('error', e => e.code === 'ECONNREFUSED' ? resolve() : reject(e));
+    socket.setTimeout(1000, () => { socket.destroy(); reject(Error('Cannot verify a free host port')); });
+  });
+}
+async function main() {
+  await freePorts();
+  const out = path.join(world, 'account-tests', 'crash-capture-' + Date.now());
+  fs.mkdirSync(out, { recursive: true });
+  let started = false, created = false;
+  try {
+    assert.equal(invoke(env.NEBULA_BIN, ['up']).status, 0, 'Could not start disposable VM');
+    started = true;
+    const socket = path.join(world, 'nebula/run/docker.sock');
+    env.DOCKER_HOST = process.platform === 'win32'
+      ? 'tcp://127.0.0.1:' + fs.readFileSync(socket, 'utf8').trim() : 'unix://' + socket;
+    let healthy = false;
+    for (let n = 0; n < 60; n++) {
+      if (dk(['ps', '-aq']).status === 0) { healthy = true; break; }
+      await new Promise(resolve => setTimeout(resolve, 250));
+    }
+    assert.equal(healthy, true, 'Disposable engine did not become ready');
+    for (const name of ['ragnarok-map', 'ragnarok-char', 'ragnarok-login', 'ragnarok-db']) {
+      const result = dk(['ps', '-aq', '--filter', 'name=' + name]);
+      assert.equal(result.status, 0, 'Cannot inspect owned engine');
+      assert.equal(result.stdout.trim(), '', 'Existing world container; refused diagnostic fixture');
+    }
+    // A child process avoids Linux PID 1's special default signal semantics.
+    const command = 'echo "diagnostic fixture: deliberate shell fault"; /bin/sh -c \'kill -SEGV $$\'; result=$?; echo "child exit: $result"; exit "$result"';
+    assert.equal(dk(['run', '-d', '--name', 'ragnarok-map', 'ragnarokmac/rathena:20221005', '/bin/sh', '-c', command]).status, 0,
+      'Cannot create diagnostic fixture');
+    created = true;
+    let meta;
+    for (let n = 0; n < 60; n++) {
+      const result = dk(['inspect', 'ragnarok-map']); assert.equal(result.status, 0);
+      meta = JSON.parse(result.stdout)[0];
+      if (meta.State.Status === 'exited') break;
+      await new Promise(resolve => setTimeout(resolve, 250));
+    }
+    assert.equal(meta.State.Status, 'exited'); assert.equal(meta.State.ExitCode, 139);
+    const first = run('capture-crashes'); assert.equal(first.status, 0, 'Collector failed');
+    assert.match(first.stdout, /private evidence saved/);
+    const dir = path.join(world, 'state/crashes/reports');
+    const matching = fs.readdirSync(dir).filter(name => name.endsWith('.log')
+      && fs.readFileSync(path.join(dir, name), 'utf8').includes(meta.Id));
+    assert.equal(matching.length, 1);
+    const body = fs.readFileSync(path.join(dir, matching[0]), 'utf8');
+    const manifest = JSON.parse(body.split('\n')[0]);
+    assert.equal(manifest.reason, 'nonzero-exit'); assert.equal(manifest.exitCode, 139);
+    assert.equal(manifest.backtraceAvailable, false); assert.match(body, /deliberate shell fault/);
+    const second = run('capture-crashes'); assert.equal(second.status, 0); assert.equal(second.stdout.trim(), '');
+    report.checks.push('actual guest exit139 captured', 'fault log retained', 'matching image/container identity retained',
+      'second capture deduplicated', 'no native stack claimed');
+    report.manifest = manifest; report.artifact = matching[0];
+  } finally {
+    if (created) {
+      assert.equal(run('down').status, 0, 'Owned cleanup failed');
+      if (report.artifact) assert.ok(fs.existsSync(path.join(world, 'state/crashes/reports', report.artifact)));
+    } else if (started) assert.equal(invoke(env.NEBULA_BIN, ['down'], 120000).status, 0, 'Owned VM cleanup failed');
+    await freePorts();
+    report.checks.push('owned VM stopped and all fixed ports free');
+    fs.writeFileSync(path.join(out, 'report.json'), JSON.stringify(report, null, 2));
+  }
+  console.log('Actual guest fault-capture fixture passed. Evidence:', out);
+}
+main().catch(error => { console.error(error.message); process.exitCode = 1; });

--- a/tests/fixtures/crash-engine.rs
+++ b/tests/fixtures/crash-engine.rs
@@ -1,0 +1,19 @@
+use std::{env, fs, io::{self, Write}, path::PathBuf};
+fn main() {
+    let root = PathBuf::from(env::var_os("RO_CRASH_FIXTURE").unwrap());
+    let args: Vec<_> = env::args().skip(1).collect();
+    let mut calls = fs::OpenOptions::new().create(true).append(true).open(root.join("calls")).unwrap();
+    writeln!(calls, "{}", args.join(" ")).unwrap();
+    match args.first().map(String::as_str) {
+        Some("inspect") => {
+            if args.last().map(String::as_str) != Some("ragnarok-map") { std::process::exit(1); }
+            print!("{}", fs::read_to_string(root.join("inspect.json")).unwrap());
+        },
+        Some("logs") => {
+            let data = fs::read(root.join("map.log")).unwrap();
+            io::stdout().write_all(&data).unwrap();
+            io::stderr().write_all(b"\nlast stderr context\n").unwrap();
+        },
+        _ => std::process::exit(2),
+    }
+}


### PR DESCRIPTION
Unexpected game-server exits previously retained only a log tail containing two known crash messages, and only when the next startup replaced the container. Nonzero exits without those messages, OOM kills, and cleanup through quit or Repair could lose useful evidence.

This adds private bounded incident reports containing filtered termination metadata, image/container identity, era, build context and map/login/char log tails. Capture runs before replacement and owner stop/recovery paths, and every15 seconds while the app owns a running asset server. It never starts an engine for monitoring or automatically restarts games. Reports redact managed service credentials, deduplicate a process run, retain at most ten reports/10 MiB, and leave unrelated or legacy files alone. Settings account JSON responses remain clean; background errors are sanitized and deduplicated.

Validation:65 Rust tests and54 Node tests pass with actual compiled supervisor/pinned RemoteClient, no skips. Tests cover exit/OOM/unknown classification, bounded concurrent log streams, private report creation, credential/config filtering, deduplication, clean exits, retention and monitor ownership/retry behavior. A real disposable nebula/slimd guest fixture captured a deliberately faulting Alpine child shell's actual exit139/log/image identity, proved duplicate suppression, and preserved the report through supervisor shutdown. It started no database or real rAthena process. Repeatable fixture: `tests/e2e/crash-capture.cjs`; local evidence: `artifacts/issue-6/world/account-tests/crash-capture-1788795425172/`. All four native/client CI checks passed on final head5e78e559, run34139351905 (macOS, Linux, Windows and client build).

This is the diagnostics increment for #16, stacked on #62. **It does not add a native backtrace, reproduce the intermittent rAthena crash, or establish its cause.** Matching symbols, original-fault capture, sanitizer investigations and gameplay stress tests remain outstanding; #16 stays open. See `docs/CRASH_DIAGNOSTICS.md` for report limitations and reproduction instructions.

Keep this draft unmerged until the owner tests and explicitly approves it.
