### PR TITLE
Capture original Linux crash frames and retain matching server symbols

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -105,7 +105,9 @@ jobs:
             -t ragnarokmac/debug-symbols /tmp/rathena
           cid=$(docker create ragnarokmac/debug-symbols true)
           mkdir -p native-symbols
-          docker cp "$cid:/." native-symbols/
+          docker cp "$cid:/re" native-symbols/
+          docker cp "$cid:/pre-re" native-symbols/
+          docker cp "$cid:/trace-tests" native-symbols/
           docker rm "$cid" >/dev/null
           printf '%s\n' '${{ github.sha }}' > native-symbols/app-source.txt
           docker image inspect "ragnarokmac/rathena:$PACKETVER" --format '{{.Id}}' > native-symbols/image-id.txt

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -45,6 +45,7 @@ on:
       # unbuilt behind a workflow watching only the Dockerfile.
       - 'third-party/**'
       - 'scripts/apply-server-mods.sh'
+      - 'scripts/apply-crash-trace.py'
   workflow_dispatch:
 
 permissions:
@@ -96,6 +97,21 @@ jobs:
             --build-arg "PACKETVER=$PACKETVER" \
             -t "ragnarokmac/rathena:$PACKETVER" /tmp/rathena
 
+      - name: Export matching native debug symbols
+        run: |
+          set -e
+          docker build -f /tmp/rathena/Dockerfile.ragnarokmac \
+            --build-arg "PACKETVER=$PACKETVER" --target debug-symbols \
+            -t ragnarokmac/debug-symbols /tmp/rathena
+          cid=$(docker create ragnarokmac/debug-symbols true)
+          mkdir -p native-symbols
+          docker cp "$cid:/." native-symbols/
+          docker rm "$cid" >/dev/null
+          printf '%s\n' '${{ github.sha }}' > native-symbols/app-source.txt
+          docker image inspect "ragnarokmac/rathena:$PACKETVER" --format '{{.Id}}' > native-symbols/image-id.txt
+          tar czf "rathena-symbols-${{ matrix.arch }}-${{ github.sha }}.tar.gz" -C native-symbols .
+          sha256sum "rathena-symbols-${{ matrix.arch }}-${{ github.sha }}.tar.gz" > "rathena-symbols-${{ matrix.arch }}-${{ github.sha }}.sha256"
+
       - name: Save the bundle
         run: |
           set -e
@@ -130,7 +146,9 @@ jobs:
           path: |
             images-${{ matrix.arch }}.tar.gz
             rathena-sql.tar.gz
-          retention-days: 7
+            rathena-symbols-${{ matrix.arch }}-${{ github.sha }}.tar.gz
+            rathena-symbols-${{ matrix.arch }}-${{ github.sha }}.sha256
+          retention-days: 30
           if-no-files-found: error
 
       # A rolling tag, not a version. These track the Dockerfiles, which change
@@ -152,3 +170,5 @@ jobs:
           files: |
             images-${{ matrix.arch }}.tar.gz
             rathena-sql.tar.gz
+            rathena-symbols-${{ matrix.arch }}-${{ github.sha }}.tar.gz
+            rathena-symbols-${{ matrix.arch }}-${{ github.sha }}.sha256

--- a/containers/rathena/Dockerfile
+++ b/containers/rathena/Dockerfile
@@ -89,6 +89,7 @@ RUN apk add --no-cache mariadb-connector-c zlib libstdc++ libgcc bash tzdata lib
     && adduser -D -h /rathena rathena
 
 WORKDIR /rathena
+COPY --from=build /rathena/ragnarok-crash-tests/libunwind-COPYING /usr/share/licenses/libunwind/COPYING
 COPY --from=build /out/re/login-server /out/re/char-server \
                   /out/re/map-server /out/re/web-server /rathena/
 # The pre-renewal pair sits beside them under its own names, in the same

--- a/containers/rathena/Dockerfile
+++ b/containers/rathena/Dockerfile
@@ -8,13 +8,19 @@ FROM alpine:3.23 AS build
 
 RUN apk add --no-cache \
         bash git make cmake gcc g++ \
-        zlib-dev mariadb-dev linux-headers
+        zlib-dev mariadb-dev linux-headers libunwind-dev=1.8.1-r0 binutils
 
 WORKDIR /rathena
 COPY . /rathena
 
 # Must match roBrowser's `packetver` and the era of the client GRFs.
 ARG PACKETVER=20221005
+ENV CXXFLAGS="-g -O2 -fno-omit-frame-pointer -fno-optimize-sibling-calls"
+ENV CPPFLAGS="-DRAGNAROK_CRASH_TRACE"
+ENV LIBS="-lunwind"
+ENV LDFLAGS="-Wl,--build-id=sha1 -rdynamic"
+
+RUN sh /rathena/ragnarok-crash-tests/verify.sh
 
 # Renewal, and then the same source again for pre-renewal.
 #
@@ -35,13 +41,25 @@ ARG PACKETVER=20221005
 # renewal binary under a pre-renewal name.
 RUN ./configure --enable-packetver=${PACKETVER} \
     && make -j"$(nproc)" server \
-    && strip login-server char-server map-server web-server || true
+    && mkdir -p /symbols/re \
+    && for binary in login-server char-server map-server web-server; do \
+        objcopy --only-keep-debug "$binary" "/symbols/re/$binary.debug" \
+        && readelf -n "$binary" | sed -n "s/.*Build ID: /$binary /p" >> "/symbols/re/BUILD_IDS" \
+        && strip --strip-debug "$binary" \
+        && objcopy --add-gnu-debuglink="/symbols/re/$binary.debug" "$binary" || exit 1; \
+    done
 RUN mkdir -p /out/re \
     && cp login-server char-server map-server web-server /out/re/
 RUN make clean \
     && ./configure --enable-packetver=${PACKETVER} --enable-prere \
     && make -j"$(nproc)" char map \
-    && (strip char-server map-server || true) \
+    && mkdir -p /symbols/pre-re \
+    && for binary in char-server map-server; do \
+        objcopy --only-keep-debug "$binary" "/symbols/pre-re/$binary.debug" \
+        && readelf -n "$binary" | sed -n "s/.*Build ID: /$binary /p" >> "/symbols/pre-re/BUILD_IDS" \
+        && strip --strip-debug "$binary" \
+        && objcopy --add-gnu-debuglink="/symbols/pre-re/$binary.debug" "$binary" || exit 1; \
+    done \
     && mkdir -p /out/pre-re \
     && cp char-server map-server /out/pre-re/
 # Prove the two binaries are actually different eras.
@@ -62,9 +80,12 @@ RUN set -e; \
     ! grep -qa "npc/re/scripts_main.conf"   /out/pre-re/map-server || { echo "pre-re map-server has renewal in it" >&2; exit 1; }; \
     echo "era check: re and pre-re map-servers differ as expected"
 
+FROM scratch AS debug-symbols
+COPY --from=build /symbols/ /
+
 FROM alpine:3.23
 
-RUN apk add --no-cache mariadb-connector-c zlib libstdc++ libgcc bash tzdata \
+RUN apk add --no-cache mariadb-connector-c zlib libstdc++ libgcc bash tzdata libunwind=1.8.1-r0 \
     && adduser -D -h /rathena rathena
 
 WORKDIR /rathena

--- a/docs/CRASH_DIAGNOSTICS.md
+++ b/docs/CRASH_DIAGNOSTICS.md
@@ -37,10 +37,13 @@ report labels it as a nonzero exit. Missing metadata remains unknown. Collection
 can miss a container removed externally between polls or a VM destroyed before
 its logs can be read; it cannot recover evidence the engine no longer retains.
 
-**There is no native backtrace in this increment.** Issue #16 stays open. Next
-steps are matching per-era/architecture debug symbols, original-fault capture
-before the existing handler re-raises, private bounded diagnostic artifacts,
-and disposable sanitizer/reload/logout stress tests. Population cleanup contains
+New server images include bounded original-context SIGSEGV/SIGFPE traces before
+rAthena's emergency-save handler. Old images still produce reports without a
+trace; `backtraceAvailable` describes the retained log evidence. Matching debug
+artifacts are exported for each image build and era. See
+[the trace hook](../third-party/crash-trace/README.md) for symbol lookup, signal
+safety and limitations. Issue #16 stays open: disposable sanitizer/reload/logout
+stress tests and the actual root-cause investigation remain outstanding. Population cleanup contains
 possible lifetime hazards worth auditing, but no underlying intermittent fault
 has been reproduced or fixed by this logging change.
 

--- a/docs/CRASH_DIAGNOSTICS.md
+++ b/docs/CRASH_DIAGNOSTICS.md
@@ -74,3 +74,18 @@ node tests/e2e/crash-capture.cjs
 It verifies free ports, starts only that world's VM, refuses existing world
 containers, runs the faulting shell in the existing server image, and stops the
 VM after preserving its report. It never starts MariaDB or real game servers.
+
+To exercise the native handler inside both real rAthena eras, the Settings/game
+acceptance fixture also accepts `RO_E2E_NATIVE_CRASH_TRACE=1`, alongside its
+required `RO_E2E_WORLD` and `RO_E2E_CLIENT_JSON`. Use a stopped, marked disposable
+world with the new server image and matching supervisor. After logging into each
+era, it injects Linux signal 11 into its own map container, checks that native
+frames precede the emergency-save message in the incident report, and restarts
+the world before continuing. The final cleanup stops the owned world and
+restores its original selection. Existing account credentials are preserved.
+
+The numeric signal is intentional: the pinned slim runtime does not recognize
+the name `SEGV` and falls back to SIGTERM. A clean shutdown from that named
+signal does not test the crash handler. The fixture records image/container
+identity and observed exit status even if incident capture fails. This remains
+an injected-signal acceptance test, not a reproduction of issue #16.

--- a/scripts/apply-crash-trace.py
+++ b/scripts/apply-crash-trace.py
@@ -17,7 +17,10 @@ if include not in source:
     anchor = '#include "core.hpp"'
     if source.count(anchor) != 1:
         raise SystemExit('Core include anchor changed; crash hook not applied')
-    source = source.replace(anchor, anchor + '\n' + include)
+    source = source.replace(anchor, include + '\n' + anchor)
+# Migrate the early development include order idempotently. rAthena redefines
+# UINT64_MAX with a cast, incompatible with libunwind's preprocessor checks.
+source = source.replace('#include "core.hpp"\n' + include, include + '\n#include "core.hpp"')
 if hook not in source:
     anchor = '\tcompat_signal(SIGFPE, sig_proc);'
     if source.count(anchor) != 1:
@@ -25,7 +28,7 @@ if hook not in source:
     source = source.replace(anchor, anchor + '\n' + hook)
 core.write_text(source)
 shutil.copyfile(root / 'third-party/crash-trace/ragnarok_crash_trace.hpp', target / 'src/common/ragnarok_crash_trace.hpp')
-for name in ['fixture.cpp', 'ragnarok_crash_trace.hpp', 'verify.sh']:
+for name in ['fixture.cpp', 'ragnarok_crash_trace.hpp', 'verify.sh', 'libunwind-COPYING']:
     folder = target / 'ragnarok-crash-tests'
     folder.mkdir(exist_ok=True)
     shutil.copyfile(root / 'third-party/crash-trace' / name, folder / name)

--- a/scripts/apply-crash-trace.py
+++ b/scripts/apply-crash-trace.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Install our small, independently idempotent core signal hook on pinned rAthena."""
+from pathlib import Path
+import shutil
+import sys
+root = Path(__file__).resolve().parent.parent
+target = Path(sys.argv[1])
+core = target / 'src/common/core.cpp'
+source = core.read_text()
+include = '#include "ragnarok_crash_trace.hpp" // RAGNAROKMAC original-fault traces'
+hook = '''#if defined(__linux__) && defined(RAGNAROK_CRASH_TRACE)
+	if (!ragnarok_crash_trace::install(sig_proc)) {
+		ShowWarning("Could not install native crash tracing; upstream signal handling remains available.\\n");
+	}
+#endif'''
+if include not in source:
+    anchor = '#include "core.hpp"'
+    if source.count(anchor) != 1:
+        raise SystemExit('Core include anchor changed; crash hook not applied')
+    source = source.replace(anchor, anchor + '\n' + include)
+if hook not in source:
+    anchor = '\tcompat_signal(SIGFPE, sig_proc);'
+    if source.count(anchor) != 1:
+        raise SystemExit('Core signal anchor changed; crash hook not applied')
+    source = source.replace(anchor, anchor + '\n' + hook)
+core.write_text(source)
+shutil.copyfile(root / 'third-party/crash-trace/ragnarok_crash_trace.hpp', target / 'src/common/ragnarok_crash_trace.hpp')
+for name in ['fixture.cpp', 'ragnarok_crash_trace.hpp', 'verify.sh']:
+    folder = target / 'ragnarok-crash-tests'
+    folder.mkdir(exist_ok=True)
+    shutil.copyfile(root / 'third-party/crash-trace' / name, folder / name)

--- a/scripts/apply-server-mods.sh
+++ b/scripts/apply-server-mods.sh
@@ -21,6 +21,8 @@ MOD="$ROOT/third-party/population-engine"
 [ -f "$TARGET/src/map/map.cpp" ] || { echo "not a rAthena checkout: $TARGET" >&2; exit 1; }
 [ -d "$MOD" ] || { echo "missing $MOD" >&2; exit 1; }
 
+python3 "$ROOT/scripts/apply-crash-trace.py" "$TARGET"
+
 echo "==> population engine: files"
 # Copied every time: these are ours alone, nothing upstream writes here, so
 # re-copying is how a third-party/ update reaches an existing checkout.

--- a/stack/src/crashes.rs
+++ b/stack/src/crashes.rs
@@ -204,7 +204,18 @@ pub fn capture(cfg: &Config, dk: &Docker, name: &str) -> Result<Option<String>, 
         "ragnarokmac-db-prere" => "prerenewal",
         _ => "unknown",
     };
-    let mut report = format!("{{\"schema\":1,\"service\":{},\"container\":{},\"reason\":{},\"exitCode\":{exit},\"oomKilled\":{oom},\"era\":{},\"image\":{},\"startedAt\":{},\"finishedAt\":{},\"backtraceAvailable\":false}}\n\nPrivate diagnostic report. Review before sharing; logs may identify players.\nNo native fault stack was captured. Exit codes alone do not prove a particular signal.\n\n--- {name} ---\n{log}\n", quote(name), quote(id), quote(reason), quote(era), quote(container.str("Image").unwrap_or("unknown")), quote(state.str("StartedAt").unwrap_or("unknown")), quote(state.str("FinishedAt").unwrap_or("unknown")));
+    let trace_present = log
+        .lines()
+        .any(|line| line.contains("RAGNAROK_CRASH_TRACE v1 signal="))
+        && log
+            .lines()
+            .any(|line| line.contains("RAGNAROK_CRASH_FRAME index=0x0 "));
+    let trace_note = if trace_present {
+        "A native original-context trace is included below; it may be partial. Use matching image debug symbols."
+    } else {
+        "No native fault stack was captured."
+    };
+    let mut report = format!("{{\"schema\":1,\"service\":{},\"container\":{},\"reason\":{},\"exitCode\":{exit},\"oomKilled\":{oom},\"era\":{},\"image\":{},\"startedAt\":{},\"finishedAt\":{},\"backtraceAvailable\":{trace_present}}}\n\nPrivate diagnostic report. Review before sharing; logs may identify players.\n{trace_note} Exit codes alone do not prove a particular signal.\n\n--- {name} ---\n{log}\n", quote(name), quote(id), quote(reason), quote(era), quote(container.str("Image").unwrap_or("unknown")), quote(state.str("StartedAt").unwrap_or("unknown")), quote(state.str("FinishedAt").unwrap_or("unknown")));
     let pin = include_str!("../../config/VENDOR_PINS")
         .lines()
         .find_map(|line| {

--- a/tests/crash-evidence.test.cjs
+++ b/tests/crash-evidence.test.cjs
@@ -53,6 +53,13 @@ test('compiled collector captures abnormal exits privately, redacts secrets, ded
     assert.ok(latest.length < 1024 * 1024); assert.match(latest, /final fault marker/);
     state.StartedAt = '2026-09-07T04:00:00Z'; state.OOMKilled = false; state.ExitCode = 0; writeInspect();
     result = run(); assert.equal(result.status, 0, result.stderr); assert.equal(files().length, 2);
+    state.StartedAt = '2026-09-07T05:00:00Z'; state.ExitCode = 139; writeInspect();
+    fs.writeFileSync(path.join(root, 'map.log'), 'RAGNAROK_CRASH_TRACE v1 signal=0xb\nRAGNAROK_CRASH_FRAME index=0x0 pc=0x42 main_offset=0x42 function=original_fault+0x1\nRAGNAROK_CRASH_TRACE_END partial\n');
+    result = run(); assert.equal(result.status, 0, result.stderr); assert.equal(files().length, 3);
+    const traced = fs.readFileSync(path.join(reports, files().sort().at(-1)), 'utf8');
+    assert.equal(JSON.parse(traced.split('\n')[0]).backtraceAvailable, true);
+    assert.match(traced, /may be partial/);
+    assert.doesNotMatch(traced, /No native fault stack was captured/);
     assert.equal(fs.existsSync(path.join(root, 'never-started')), false);
     assert.ok(fs.readFileSync(path.join(root, 'calls'), 'utf8').trim().split('\n').every(x => /^(inspect|logs) /.test(x)));
   });

--- a/tests/crash-trace-patch.test.cjs
+++ b/tests/crash-trace-patch.test.cjs
@@ -1,0 +1,30 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+test('server trace hook is idempotent, precedes legacy macros and fails on changed anchors', t => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ro-trace-hook-'));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const common = path.join(root, 'src/common'); fs.mkdirSync(common, { recursive: true });
+  const core = path.join(common, 'core.cpp');
+  const original = '#include "core.hpp"\nvoid signals_init() {\n\tcompat_signal(SIGFPE, sig_proc);\n}\n';
+  fs.writeFileSync(core, original);
+  const run = () => spawnSync(process.platform === 'win32' ? 'python' : 'python3',
+    [path.join(__dirname, '../scripts/apply-crash-trace.py'), root], { encoding: 'utf8' });
+  let result = run(); assert.equal(result.status, 0, result.stderr);
+  const once = fs.readFileSync(core, 'utf8');
+  assert.ok(once.indexOf('ragnarok_crash_trace.hpp') < once.indexOf('core.hpp'));
+  assert.match(once, /ragnarok_crash_trace::install\(sig_proc\)/);
+  result = run(); assert.equal(result.status, 0, result.stderr);
+  assert.equal(fs.readFileSync(core, 'utf8'), once);
+  assert.equal(fs.readFileSync(path.join(common, 'ragnarok_crash_trace.hpp'), 'utf8'),
+    fs.readFileSync(path.join(__dirname, '../third-party/crash-trace/ragnarok_crash_trace.hpp'), 'utf8'));
+  assert.ok(fs.statSync(path.join(root, 'ragnarok-crash-tests/libunwind-COPYING')).size > 100);
+  fs.writeFileSync(core, original.replace('SIGFPE', 'SIGBUS'));
+  result = run(); assert.notEqual(result.status, 0); assert.match(result.stderr, /signal anchor changed/);
+  assert.equal(fs.readFileSync(core, 'utf8'), original.replace('SIGFPE', 'SIGBUS'));
+});

--- a/tests/e2e/hosting-guards-settings.cjs
+++ b/tests/e2e/hosting-guards-settings.cjs
@@ -254,11 +254,19 @@ async function main() {
           && !(report.nativeTraces || []).some(trace => trace.era === era)) {
         await game.goto('about:blank');
         const before = JSON.parse(docker(['inspect', 'ragnarok-map']).stdout)[0];
-        expect(docker(['kill', '--signal', 'SEGV', 'ragnarok-map']).status).toBe(0);
+        // The pinned slim runtime accepts numeric signals, but silently maps
+        // the unsupported SEGV name to SIGTERM. Use Linux SIGSEGV explicitly.
+        expect(docker(['kill', '--signal', '11', 'ragnarok-map']).status).toBe(0);
         await expect.poll(() => {
           const value = docker(['inspect', '-f', '{{.State.Status}}', 'ragnarok-map']);
           return value.status === 0 ? value.stdout.trim() : 'unknown';
         }, { timeout: 60000 }).toBe('exited');
+        const after = JSON.parse(docker(['inspect', 'ragnarok-map']).stdout)[0];
+        // Retain only bounded, non-secret incident identity if capture fails.
+        report.nativeSignalAttempts = [...(report.nativeSignalAttempts || []), {
+          era, signal: 11, container: before.Id, image: before.Image,
+          exitCode: after.State.ExitCode, oomKilled: after.State.OOMKilled,
+        }];
         const reportsDir = path.join(state, 'crashes/reports');
         let captured;
         await expect.poll(() => {
@@ -275,12 +283,20 @@ async function main() {
         }, { timeout: 90000 }).toBe(true);
         expect(captured.metadata.backtraceAvailable).toBe(true);
         expect(captured.metadata.image).toBe(before.Image);
-        expect(captured.body).toContain('RAGNAROK_CRASH_FRAME index=0x0 ');
-        expect(captured.body).toContain('main_offset=');
+        expect(captured.body.includes('RAGNAROK_CRASH_FRAME index=0x0 ')).toBe(true);
+        expect(captured.body.includes('RAGNAROK_CRASH_TRACE v1 signal=0xb ')).toBe(true);
+        // An external signal can interrupt a libc syscall, and unwinding may
+        // stop there. Main-image frames/source lookup are asserted by the
+        // image's deliberate in-process fault fixture, not guaranteed here.
+        const frames = captured.body.split('\n').filter(line => line.includes('RAGNAROK_CRASH_FRAME '));
+        expect(frames.length).toBeGreaterThan(0);
+        expect(frames.length).toBeLessThanOrEqual(32);
         expect(captured.body.indexOf('RAGNAROK_CRASH_TRACE v1')).toBeLessThan(
           captured.body.indexOf('Received a crash signal'));
         report.nativeTraces = [...(report.nativeTraces || []), { era,
-          artifact: captured.name, metadata: captured.metadata, injectedSignal: true }];
+          artifact: captured.name, metadata: captured.metadata, frames,
+          mainImageFrameAvailable: frames.some(line => line.includes('main_offset=')),
+          injectedSignal: true }];
         await invoke('stack_up');
         await verifyWorld();
         console.log('Injected rAthena signal retained native frames before emergency-save handler:', era);

--- a/tests/e2e/hosting-guards-settings.cjs
+++ b/tests/e2e/hosting-guards-settings.cjs
@@ -247,6 +247,45 @@ async function main() {
       await game.screenshot({ path: path.join(out, prefix + '-map.png') });
       report.screens.push(prefix + '-accounts.png', prefix + '-map.png');
       console.log('Mandatory internet policy, rejected signup and native GM game login passed:', era, scope);
+      // Explicit opt-in: validate the new handler inside real rAthena, after
+      // gameplay screenshots. This is injected-signal proof, not reproduction
+      // of the intermittent crash, and runs only in this marked test world.
+      if (process.env.RO_E2E_NATIVE_CRASH_TRACE === '1'
+          && !(report.nativeTraces || []).some(trace => trace.era === era)) {
+        await game.goto('about:blank');
+        const before = JSON.parse(docker(['inspect', 'ragnarok-map']).stdout)[0];
+        expect(docker(['kill', '--signal', 'SEGV', 'ragnarok-map']).status).toBe(0);
+        await expect.poll(() => {
+          const value = docker(['inspect', '-f', '{{.State.Status}}', 'ragnarok-map']);
+          return value.status === 0 ? value.stdout.trim() : 'unknown';
+        }, { timeout: 60000 }).toBe('exited');
+        const reportsDir = path.join(state, 'crashes/reports');
+        let captured;
+        await expect.poll(() => {
+          // The owning shell's monitor may already have captured this incident.
+          spawnSync(path.join(world, 'runtime/bin/ragnarok-stack' + (process.platform === 'win32' ? '.exe' : '')),
+            ['capture-crashes'], { env, encoding: 'utf8', timeout: 60000 });
+          for (const name of fs.existsSync(reportsDir) ? fs.readdirSync(reportsDir) : []) {
+            if (!name.startsWith('incident-') || !name.endsWith('.log')) continue;
+            const body = fs.readFileSync(path.join(reportsDir, name), 'utf8');
+            const metadata = JSON.parse(body.split('\n')[0]);
+            if (metadata.container === before.Id) captured = { metadata, body, name };
+          }
+          return !!captured;
+        }, { timeout: 90000 }).toBe(true);
+        expect(captured.metadata.backtraceAvailable).toBe(true);
+        expect(captured.metadata.image).toBe(before.Image);
+        expect(captured.body).toContain('RAGNAROK_CRASH_FRAME index=0x0 ');
+        expect(captured.body).toContain('main_offset=');
+        expect(captured.body.indexOf('RAGNAROK_CRASH_TRACE v1')).toBeLessThan(
+          captured.body.indexOf('Received a crash signal'));
+        report.nativeTraces = [...(report.nativeTraces || []), { era,
+          artifact: captured.name, metadata: captured.metadata, injectedSignal: true }];
+        await invoke('stack_up');
+        await verifyWorld();
+        console.log('Injected rAthena signal retained native frames before emergency-save handler:', era);
+      }
+
     }
     expect(report.pageErrors).toEqual([]);
     console.log('Hosting guard Settings/game checks passed. Evidence:', out);

--- a/third-party/crash-trace/README.md
+++ b/third-party/crash-trace/README.md
@@ -1,0 +1,33 @@
+# Original-context Linux crash tracing
+
+Ragnarok Offline's GPL-3.0-or-later hook runs before rAthena's existing emergency
+save handler for SIGSEGV and SIGFPE. It captures the kernel-provided signal
+context with libunwind1.8.1 local unwinding, up to32 frames, using fixed buffers
+and `write`. It does not allocate, demangle, invoke stdio or dump memory/locals.
+The main thread has an alternate signal stack. Other threads retain their own
+normal stack unless they install an alternate one. Recursive faults take the
+default signal action. Upstream's character-save attempt and re-raise remain.
+
+libunwind is an MIT-licensed server-image dependency, pinned through Alpine3.23
+packages1.8.1-r0 for both supported guest architectures. It provides the unwinder
+that musl lacks; no Rust supervisor dependency is added. Local cursor operations
+used here are documented as signal-safe by the library. This is best-effort:
+a damaged stack/unwind table, another fault, or blocked log transport can still
+prevent a complete trace. Keep raw core capture and sanitizer testing separate.
+
+Sources: [local signal-frame initialization](https://www.nongnu.org/libunwind/man/unw_init_local%283%29.html),
+[local name lookup safety](https://www.nongnu.org/libunwind/man/unw_get_proc_name%283%29.html),
+[libunwind package](https://pkgs.alpinelinux.org/packages?branch=v3.23&name=libunwind-dev).
+
+The image keeps function symbols while splitting DWARF into matching debug
+artifacts. `main_offset` is relative to the main executable's recorded ELF load
+bias, so `addr2line -f -C -e map-server.debug OFFSET` can resolve those frames
+for PIE builds. Shared-library frames have absolute PCs and best-effort names;
+they need that library's symbols/mappings for further offline analysis. Return
+addresses can identify the instruction after a call. Always match image identity,
+era and ELF build ID; do not symbolize with the newest unrelated binary.
+
+`fixture.cpp` and `verify.sh` compile the exact hook, cause real SIGSEGV/SIGFPE,
+check the original fault/caller names and separately resolve the captured main
+ELF offset to source. Both native image builds run them before compiling rAthena.
+This proves the tracing mechanism, not the reported intermittent map-server bug.

--- a/third-party/crash-trace/fixture.cpp
+++ b/third-party/crash-trace/fixture.cpp
@@ -1,0 +1,14 @@
+// Standalone validation of the exact handler embedded in the server.
+#include "ragnarok_crash_trace.hpp"
+#include <cstring>
+static void original(int sig) { signal(sig, SIG_DFL); raise(sig); }
+extern "C" __attribute__((noinline)) void original_fault(bool floating) {
+    if (floating) raise(SIGFPE);
+    else { volatile int* pointer = nullptr; *pointer = 1; }
+}
+extern "C" __attribute__((noinline)) void fault_caller(bool floating) { original_fault(floating); asm volatile("" ::: "memory"); }
+int main(int argc, char** argv) {
+    if (!ragnarok_crash_trace::install(original)) return 2;
+    fault_caller(argc > 1 && std::strcmp(argv[1], "fpe") == 0);
+    return 3;
+}

--- a/third-party/crash-trace/fixture.cpp
+++ b/third-party/crash-trace/fixture.cpp
@@ -3,7 +3,16 @@
 #include <cstring>
 static void original(int sig) { signal(sig, SIG_DFL); raise(sig); }
 extern "C" __attribute__((noinline)) void original_fault(bool floating) {
-    if (floating) raise(SIGFPE);
+    if (floating) {
+#if defined(__x86_64__)
+        // Real hardware divide fault, avoiding musl raise()'s assembly frames.
+        unsigned divisor = 0;
+        asm volatile("xorl %%edx, %%edx; movl $1, %%eax; divl %0" : : "r"(divisor) : "eax", "edx", "cc");
+#else
+        // AArch64 integer division by zero does not raise SIGFPE.
+        raise(SIGFPE);
+#endif
+    }
     else { volatile int* pointer = nullptr; *pointer = 1; }
 }
 extern "C" __attribute__((noinline)) void fault_caller(bool floating) { original_fault(floating); asm volatile("" ::: "memory"); }

--- a/third-party/crash-trace/libunwind-COPYING
+++ b/third-party/crash-trace/libunwind-COPYING
@@ -1,0 +1,20 @@
+Copyright (c) 2002 Hewlett-Packard Co.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/third-party/crash-trace/ragnarok_crash_trace.hpp
+++ b/third-party/crash-trace/ragnarok_crash_trace.hpp
@@ -1,0 +1,102 @@
+// Copyright Ragnarok Offline contributors. GPL-3.0-or-later.
+// RAGNAROKMAC: bounded local unwinding of the original Linux signal context.
+#pragma once
+#if defined(__linux__) && defined(RAGNAROK_CRASH_TRACE)
+#define UNW_LOCAL_ONLY
+#include <libunwind.h>
+#include <signal.h>
+#include <unistd.h>
+#include <link.h>
+#include <stdint.h>
+#include <errno.h>
+
+namespace ragnarok_crash_trace {
+static void (*original_handler)(int) = nullptr;
+static volatile sig_atomic_t handling = 0;
+alignas(16) static unsigned char alternate_stack[128 * 1024];
+static uintptr_t executable_base = 0, executable_begin = 0, executable_end = 0;
+
+// Called at startup, outside signal handling. The first ELF object is the main
+// executable; retain its load bias so PIE addresses can be symbolized offline.
+static int find_executable(dl_phdr_info* info, size_t, void*) {
+    executable_base = info->dlpi_addr;
+    executable_begin = UINTPTR_MAX;
+    for (unsigned n = 0; n < info->dlpi_phnum; ++n) {
+        const auto& ph = info->dlpi_phdr[n];
+        if (ph.p_type != PT_LOAD) continue;
+        const uintptr_t begin = info->dlpi_addr + ph.p_vaddr;
+        const uintptr_t end = begin + ph.p_memsz;
+        if (begin < executable_begin) executable_begin = begin;
+        if (end > executable_end) executable_end = end;
+    }
+    return 1;
+}
+struct Line {
+    char data[512]; size_t used = 0;
+    void text(const char* value, size_t max = 256) {
+        for (size_t i = 0; i < max && value[i] && used < sizeof(data) - 1; ++i)
+            data[used++] = value[i];
+    }
+    void hex(uintptr_t value) {
+        text("0x"); bool started = false;
+        for (int shift = sizeof(value) * 8 - 4; shift >= 0; shift -= 4) {
+            const unsigned digit = (value >> shift) & 15;
+            if (digit || started || shift == 0) { started = true; if (used < sizeof(data) - 1) data[used++] = "0123456789abcdef"[digit]; }
+        }
+    }
+    void emit() {
+        data[used++] = '\n';
+        size_t written = 0;
+        for (unsigned tries = 0; written < used && tries < 4; ++tries) {
+            const ssize_t n = write(STDERR_FILENO, data + written, used - written);
+            if (n > 0) written += static_cast<size_t>(n);
+            else if (n < 0 && errno == EINTR) continue;
+            else break;
+        }
+    }
+};
+static void handler(int signal, siginfo_t* info, void* context) {
+    if (handling) _exit(128 + signal);
+    handling = 1;
+    Line first;
+    first.text("RAGNAROK_CRASH_TRACE v1 signal="); first.hex(signal);
+    first.text(" fault_address="); first.hex(reinterpret_cast<uintptr_t>(info ? info->si_addr : nullptr));
+    first.text(" executable_base="); first.hex(executable_base); first.emit();
+    unw_cursor_t cursor;
+    int step = -1;
+    if (context && unw_init_local2(&cursor, static_cast<unw_context_t*>(context), UNW_INIT_SIGNAL_FRAME) >= 0) {
+        for (unsigned frame = 0; frame < 32; ++frame) {
+            unw_word_t ip = 0, offset = 0;
+            if (unw_get_reg(&cursor, UNW_REG_IP, &ip) < 0) break;
+            Line line; line.text("RAGNAROK_CRASH_FRAME index="); line.hex(frame);
+            line.text(" pc="); line.hex(ip);
+            if (ip >= executable_begin && ip < executable_end) { line.text(" main_offset="); line.hex(ip - executable_base); }
+            char name[256] = {};
+            if (unw_get_proc_name(&cursor, name, sizeof(name), &offset) == 0) {
+                line.text(" function="); line.text(name, sizeof(name)); line.text("+"); line.hex(offset);
+            }
+            line.emit();
+            step = unw_step(&cursor);
+            if (step <= 0) break;
+        }
+    }
+    Line end; end.text(step == 0 ? "RAGNAROK_CRASH_TRACE_END complete" : "RAGNAROK_CRASH_TRACE_END partial"); end.emit();
+    // Preserve upstream's save attempt and its default-signal re-raise. No
+    // allocation, demangling, stdio or program recovery is attempted here.
+    original_handler(signal);
+}
+static bool install(void (*previous)(int)) {
+    original_handler = previous;
+    dl_iterate_phdr(find_executable, nullptr);
+    stack_t stack = {}; stack.ss_sp = alternate_stack; stack.ss_size = sizeof(alternate_stack);
+    if (sigaltstack(&stack, nullptr) != 0) return false;
+    struct sigaction action = {};
+    action.sa_sigaction = handler;
+    // A recursive fault goes directly to the default action, retaining whatever
+    // original-context evidence was already emitted instead of looping forever.
+    action.sa_flags = SA_SIGINFO | SA_ONSTACK | SA_RESETHAND;
+    sigemptyset(&action.sa_mask);
+    return sigaction(SIGSEGV, &action, nullptr) == 0 && sigaction(SIGFPE, &action, nullptr) == 0;
+}
+}
+#endif

--- a/third-party/crash-trace/ragnarok_crash_trace.hpp
+++ b/third-party/crash-trace/ragnarok_crash_trace.hpp
@@ -16,20 +16,32 @@ static volatile sig_atomic_t handling = 0;
 alignas(16) static unsigned char alternate_stack[128 * 1024];
 static uintptr_t executable_base = 0, executable_begin = 0, executable_end = 0;
 
-// Called at startup, outside signal handling. The first ELF object is the main
-// executable; retain its load bias so PIE addresses can be symbolized offline.
+// Record executable ELF ranges at startup, outside signal handling. Reject
+// guessed frames outside those mappings instead of printing stack data as PCs.
+struct Range { uintptr_t begin, end; };
+static Range executable_ranges[64];
+static size_t range_count = 0;
+static bool first_object = true;
 static int find_executable(dl_phdr_info* info, size_t, void*) {
-    executable_base = info->dlpi_addr;
-    executable_begin = UINTPTR_MAX;
+    if (first_object) { executable_base = info->dlpi_addr; executable_begin = UINTPTR_MAX; }
     for (unsigned n = 0; n < info->dlpi_phnum; ++n) {
         const auto& ph = info->dlpi_phdr[n];
         if (ph.p_type != PT_LOAD) continue;
         const uintptr_t begin = info->dlpi_addr + ph.p_vaddr;
         const uintptr_t end = begin + ph.p_memsz;
-        if (begin < executable_begin) executable_begin = begin;
-        if (end > executable_end) executable_end = end;
+        if (first_object) {
+            if (begin < executable_begin) executable_begin = begin;
+            if (end > executable_end) executable_end = end;
+        }
+        if ((ph.p_flags & PF_X) && range_count < 64) executable_ranges[range_count++] = {begin, end};
     }
-    return 1;
+    first_object = false;
+    return 0;
+}
+static bool mapped_instruction(uintptr_t ip) {
+    for (size_t n = 0; n < range_count; ++n)
+        if (ip >= executable_ranges[n].begin && ip < executable_ranges[n].end) return true;
+    return false;
 }
 struct Line {
     char data[512]; size_t used = 0;
@@ -68,6 +80,7 @@ static void handler(int signal, siginfo_t* info, void* context) {
         for (unsigned frame = 0; frame < 32; ++frame) {
             unw_word_t ip = 0, offset = 0;
             if (unw_get_reg(&cursor, UNW_REG_IP, &ip) < 0) break;
+            if (frame > 0 && !mapped_instruction(ip)) { step = -1; break; }
             Line line; line.text("RAGNAROK_CRASH_FRAME index="); line.hex(frame);
             line.text(" pc="); line.hex(ip);
             if (ip >= executable_begin && ip < executable_end) { line.text(" main_offset="); line.hex(ip - executable_base); }

--- a/third-party/crash-trace/verify.sh
+++ b/third-party/crash-trace/verify.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Runs in each native Alpine image build; no VM, SQL or player data involved.
+set -eu
+cd /rathena/ragnarok-crash-tests
+g++ -g -O1 -fno-omit-frame-pointer -fno-optimize-sibling-calls -DRAGNAROK_CRASH_TRACE -Wl,--build-id=sha1 -rdynamic fixture.cpp -lunwind -o fixture
+objcopy --only-keep-debug fixture fixture.debug
+strip --strip-debug fixture
+objcopy --add-gnu-debuglink=fixture.debug fixture
+for mode in segv fpe; do
+    status=0
+    ./fixture "$mode" > "$mode.log" 2>&1 || status=$?
+    if [ "$mode" = segv ]; then expected=139; else expected=136; fi
+    test "$status" = "$expected"
+    grep -q 'RAGNAROK_CRASH_TRACE v1 signal=' "$mode.log"
+    grep -q 'function=original_fault+' "$mode.log"
+    grep -q 'function=fault_caller+' "$mode.log"
+    grep -q 'RAGNAROK_CRASH_TRACE_END' "$mode.log"
+    offset=$(sed -n 's/.*main_offset=\(0x[0-9a-f]*\).*function=original_fault+.*/\1/p' "$mode.log" | head -1)
+    test -n "$offset"
+    addr2line -f -e fixture.debug "$offset" > "$mode.symbolized"
+    grep -q 'original_fault' "$mode.symbolized"
+    grep -q 'fixture.cpp:' "$mode.symbolized"
+done
+mkdir -p /symbols/trace-tests
+cp segv.log fpe.log segv.symbolized fpe.symbolized /symbols/trace-tests/
+echo 'Original-context segfault/FPE trace and separate symbol lookup passed'

--- a/third-party/crash-trace/verify.sh
+++ b/third-party/crash-trace/verify.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Runs in each native Alpine image build; no VM, SQL or player data involved.
-set -eu
+set -eux
 cd /rathena/ragnarok-crash-tests
 g++ -g -O1 -fno-omit-frame-pointer -fno-optimize-sibling-calls -DRAGNAROK_CRASH_TRACE -Wl,--build-id=sha1 -rdynamic fixture.cpp -lunwind -o fixture
 objcopy --only-keep-debug fixture fixture.debug
@@ -9,6 +9,7 @@ objcopy --add-gnu-debuglink=fixture.debug fixture
 for mode in segv fpe; do
     status=0
     ./fixture "$mode" > "$mode.log" 2>&1 || status=$?
+    cat "$mode.log"
     if [ "$mode" = segv ]; then expected=139; else expected=136; fi
     test "$status" = "$expected"
     grep -q 'RAGNAROK_CRASH_TRACE v1 signal=' "$mode.log"


### PR DESCRIPTION
rAthena’s existing crash messages do not identify the original fault. This adds a Linux SIGSEGV/SIGFPE hook that records the kernel signal context before the emergency-save handler, using bounded local libunwind calls, fixed buffers and direct writes. It preserves upstream’s save attempt and signal handling and reports partial traces honestly.

Server images pin Alpine libunwind 1.8.1-r0, retain function symbols and export separate per-era DWARF files with build IDs, source revision, image identity and checksums. Native ARM64 and x64 image builds exercise deliberate in-process SEGV/FPE fixtures and verify separate-file source lookup. Manual builds only upload review artifacts. No supervisor crate was added.

Stacked on #63 for issue #16. This supplies diagnostics; the intermittent crash remains unresolved and needs sanitizer/reload/logout/population investigation.

Validation:
- 65 Rust and 55 Node tests passed locally; the patch applied idempotently to fresh pinned rAthena e985006.
- [ARM64 and x64 image builds passed](https://github.com/Flux159/ragnarokoffline.app/actions/runs/34141772909) at 7ba1444. Both downloaded symbol archives passed checksums, contained only the intended files/directories, and resolved original_fault to fixture.cpp. Image inputs are unchanged by the later test/documentation commit.
- [All four Test checks passed](https://github.com/Flux159/ragnarokoffline.app/actions/runs/34141776915) at 7ba1444. The final harness/documentation commit 579ac11 passed client/Linux/macOS, but its [Windows run](https://github.com/Flux159/ragnarokoffline.app/actions/runs/34142724560) exposed an existing one-second loopback-probe timeout. Follow-up #65 fixes that deadline and adds a deterministic failing-before/passing-after regression test. The parent Windows job passed on one rerun, so all four current checks are green; its initial timing failure remains documented here and is addressed by #65.
- Real Mac disposable-world Playwright acceptance passed setup → native login, account safeguards, Renewal/Friends → Pre-Renewal/Friends → Renewal/Public gameplay, and injected native crash capture in both eras. Zero page errors; screenshots reviewed; graceful cleanup verified every fixed port free. Existing GM credentials and the player’s save were preserved.
- Live signal injection used the earlier successful 42af1f1 ARM image ec813673… with its matching retained symbols; native server code is unchanged. Both traces preceded emergency-save messages but stopped after two system-library frames, without a main-image source location. The deliberately faulting CI fixtures independently verify application-frame symbolization. These injected signals do not reproduce issue #16.

The runtime test sends numeric Linux signal 11 because the pinned slim runtime silently interprets unsupported named SEGV as SIGTERM. It records observed exit metadata even when capture fails; rAthena’s retained crash messages correctly trigger collection even when the engine reports exit 0.

Keep this draft unmerged until the owner tests and explicitly approves it.
