### PR TITLE
Allow delayed Windows loopback refusals during asset startup

### DIFF
--- a/electron/asset-server.js
+++ b/electron/asset-server.js
@@ -79,7 +79,9 @@ function control(identity, secret, action, timeout = 2000) {
 function portBusy(port) {
 	return new Promise((resolve, reject) => {
 		const socket = net.connect({ host: '127.0.0.1', port });
-		const timer = setTimeout(() => { socket.destroy(); reject(new Error(`Port ${port} did not respond; cannot establish whether it is free.`)); }, 1000);
+		// A closed loopback port can take more than a second to report refusal
+		// on Windows. Keep a bounded wait, and never treat silence as free.
+		const timer = setTimeout(() => { socket.destroy(); reject(new Error(`Port ${port} did not respond; cannot establish whether it is free.`)); }, 5000);
 		const finish = value => { clearTimeout(timer); socket.destroy(); resolve(value); };
 		socket.on('connect', () => finish(true));
 		socket.on('error', error => {

--- a/tests/asset-server-port-probe.test.cjs
+++ b/tests/asset-server-port-probe.test.cjs
@@ -1,0 +1,52 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { EventEmitter } = require('node:events');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const net = require('node:net');
+const { AssetServer } = require('../electron/asset-server');
+
+async function probe(t) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ro-port-probe-'));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const socket = new EventEmitter();
+  socket.destroy = t.mock.fn();
+  const connect = t.mock.method(net, 'connect', () => socket);
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+  let settled = false;
+  const result = new AssetServer().prepare(root, 3338).then(
+    () => { settled = true; return { ok: true }; },
+    error => { settled = true; return { error }; },
+  );
+  // Let the serialized prepare/stop promises reach the socket probe. Only
+  // setTimeout is mocked; setImmediate also drains the promise callbacks.
+  await new Promise(setImmediate);
+  assert.equal(connect.mock.callCount(), 1);
+  return { socket, result, settled: () => settled };
+}
+
+test('a loopback refusal arriving after one second still proves the port free', async t => {
+  const p = await probe(t);
+  t.mock.timers.tick(1500);
+  await new Promise(setImmediate);
+  assert.equal(p.settled(), false, 'must wait for the delayed refusal');
+  p.socket.emit('error', Object.assign(new Error('refused'), { code: 'ECONNREFUSED' }));
+  assert.deepEqual(await p.result, { ok: true });
+  assert.equal(p.socket.destroy.mock.callCount(), 1);
+});
+
+test('an unresponsive port remains unknown and fails closed at the bounded deadline', async t => {
+  const p = await probe(t);
+  t.mock.timers.tick(5000);
+  assert.match((await p.result).error.message, /cannot establish whether it is free/);
+  assert.equal(p.socket.destroy.mock.callCount(), 1);
+});
+
+test('a connected port is rejected as occupied without taking ownership', async t => {
+  const p = await probe(t);
+  p.socket.emit('connect');
+  assert.match((await p.result).error.message, /occupied by a server this app does not own/);
+  assert.equal(p.socket.destroy.mock.callCount(), 1);
+});


### PR DESCRIPTION
A delayed connection refusal on Windows can exceed the asset lifecycle’s one-second port probe deadline, rejecting startup before the real Rust asset server is launched. [The Windows CI failure](https://github.com/Flux159/ragnarokoffline.app/actions/runs/34142724560) exposed this during the native crash-trace work.

Allow up to five seconds for the loopback probe. Only ECONNREFUSED establishes a free port; a connection remains an ownership conflict, and an unresponsive port still fails closed. No process is adopted or stopped by port number.

Stacked on #64, a follow-up to #22. A deterministic delayed-refusal regression test fails with the previous deadline and passes with this change. Additional tests preserve occupied-port rejection and the bounded unknown-port failure. All 58 local Node tests passed with the compiled supervisor and pinned runtime Rust asset server, with no skips. [All four native/client CI checks passed](https://github.com/Flux159/ragnarokoffline.app/actions/runs/34143184806) at b6b3841, including the real Rust process protocol and new regression coverage on Windows. The parent PR also passed its one Windows rerun; the original timeout remains documented above.

Keep this draft unmerged until the owner tests and explicitly approves it.
