### PR TITLE
Add isolated native sanitizer builds for map-server investigation

### DIFF
--- a/.github/workflows/diagnostics.yml
+++ b/.github/workflows/diagnostics.yml
@@ -1,0 +1,59 @@
+name: diagnostic-images
+
+# Development-only, manual builds. No release/publish path or production tags.
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-24.04
+            arch: x64
+          - runner: ubuntu-24.04-arm
+            arch: arm64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Prepare pinned server and diagnostic sources
+        run: |
+          set -eu
+          ./scripts/vendor-fetch.sh rathena /tmp/rathena
+          ./scripts/apply-server-mods.sh /tmp/rathena
+          cp containers/rathena/Dockerfile.sanitizers /tmp/rathena/Dockerfile.sanitizers
+          cp -R tests/diagnostics /tmp/rathena/ragnarok-sanitizer-tests
+          ver=$(sed -n 's/^PACKETVER=//p' scripts/bootstrap.sh | head -1)
+          test -n "$ver"
+          echo "PACKETVER=$ver" >> "$GITHUB_ENV"
+      - name: Build diagnostic image and validate real sanitizer faults
+        run: |
+          set -eu
+          image="ragnarokmac/rathena-diagnostics:${{ github.sha }}"
+          docker build -f /tmp/rathena/Dockerfile.sanitizers \
+            --build-arg "PACKETVER=$PACKETVER" --build-arg BUILD_JOBS=2 \
+            -t "$image" /tmp/rathena
+          docker run --rm "$image" sh /diagnostics/verify.sh /tmp/runtime-fixture
+          cid=$(docker create "$image" true)
+          mkdir diagnostic-evidence
+          docker cp "$cid:/diagnostics/." diagnostic-evidence/
+          docker rm "$cid" >/dev/null
+          docker image inspect "$image" --format '{{.Id}}' > diagnostic-evidence/image-id.txt
+          printf '%s\n' '${{ github.sha }}' > diagnostic-evidence/app-source.txt
+          cp config/VENDOR_PINS diagnostic-evidence/VENDOR_PINS
+          docker save "$image" | gzip -1 > "rathena-diagnostics-${{ matrix.arch }}.tar.gz"
+          sha256sum "rathena-diagnostics-${{ matrix.arch }}.tar.gz" > "rathena-diagnostics-${{ matrix.arch }}.sha256"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: diagnostic-image-${{ matrix.arch }}
+          path: |
+            rathena-diagnostics-${{ matrix.arch }}.tar.gz
+            rathena-diagnostics-${{ matrix.arch }}.sha256
+            diagnostic-evidence/
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -47,12 +47,21 @@ on:
       - 'scripts/apply-server-mods.sh'
       - 'scripts/apply-crash-trace.py'
   workflow_dispatch:
+    inputs:
+      diagnostics:
+        description: Build development-only ASan/UBSan images instead of release images
+        type: boolean
+        default: false
 
 permissions:
   contents: write
 
 jobs:
+  diagnostics:
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.diagnostics }}
+    uses: ./.github/workflows/diagnostics.yml
   build:
+    if: ${{ github.event_name != 'workflow_dispatch' || !inputs.diagnostics }}
     strategy:
       fail-fast: false
       matrix:

--- a/containers/rathena/Dockerfile.sanitizers
+++ b/containers/rathena/Dockerfile.sanitizers
@@ -3,10 +3,11 @@
 FROM alpine:3.23 AS diagnostic-runtime
 RUN apk add --no-cache mariadb-connector-c zlib libstdc++ libgcc bash tzdata \
         compiler-rt=21.1.2-r0 llvm21=21.1.2-r1 \
+    && ln -s /usr/bin/llvm21-symbolizer /usr/local/bin/llvm-symbolizer \
     && adduser -D -h /rathena rathena
 # Stop at the first error. Do not let the game's save handler replace ASan's
 # original-fault handler, and do not produce raw cores or exit-time leak noise.
-ENV ASAN_SYMBOLIZER_PATH=/usr/bin/llvm21-symbolizer
+ENV ASAN_SYMBOLIZER_PATH=/usr/local/bin/llvm-symbolizer
 ENV ASAN_OPTIONS="detect_leaks=0:halt_on_error=1:abort_on_error=0:disable_coredump=1:handle_segv=2:handle_sigbus=2:handle_sigfpe=2:fast_unwind_on_fatal=0"
 ENV UBSAN_OPTIONS="halt_on_error=1:print_stacktrace=1"
 

--- a/containers/rathena/Dockerfile.sanitizers
+++ b/containers/rathena/Dockerfile.sanitizers
@@ -1,0 +1,67 @@
+# Development-only image. Never used by bootstrap, release images or packaging.
+# Keep the runtime layout/packet version identical to the normal rAthena image.
+FROM alpine:3.23 AS diagnostic-runtime
+RUN apk add --no-cache mariadb-connector-c zlib libstdc++ libgcc bash tzdata \
+        compiler-rt=21.1.2-r0 llvm21=21.1.2-r1 \
+    && adduser -D -h /rathena rathena
+# Stop at the first error. Do not let the game's save handler replace ASan's
+# original-fault handler, and do not produce raw cores or exit-time leak noise.
+ENV ASAN_SYMBOLIZER_PATH=/usr/bin/llvm21-symbolizer
+ENV ASAN_OPTIONS="detect_leaks=0:halt_on_error=1:abort_on_error=0:disable_coredump=1:handle_segv=2:handle_sigbus=2:handle_sigfpe=2:fast_unwind_on_fatal=0"
+ENV UBSAN_OPTIONS="halt_on_error=1:print_stacktrace=1"
+
+FROM diagnostic-runtime AS build
+RUN apk add --no-cache git make cmake clang21=21.1.2-r2 g++ \
+        zlib-dev mariadb-dev linux-headers binutils
+WORKDIR /rathena
+COPY . /rathena
+ARG PACKETVER=20221005
+ARG BUILD_JOBS=2
+ENV CC=clang CXX=clang++
+ENV CFLAGS="-g -O1 -fno-omit-frame-pointer -fno-optimize-sibling-calls -fsanitize=address,undefined -fno-sanitize-recover=all"
+ENV CXXFLAGS="-g -O1 -fno-omit-frame-pointer -fno-optimize-sibling-calls -fsanitize=address,undefined -fno-sanitize-recover=all"
+ENV LDFLAGS="-fsanitize=address,undefined -Wl,--build-id=sha1 -rdynamic"
+# Do not enable RAGNAROK_CRASH_TRACE: sanitizer diagnostics own fault handling.
+# NO_MEMMGR exposes allocation/free boundaries that the built-in pool obscures.
+RUN mkdir -p /diagnostics \
+    && clang++ $CXXFLAGS $LDFLAGS ragnarok-sanitizer-tests/fixture.cpp -o /diagnostics/sanitizer-fixture \
+    && FIXTURE_BIN=/diagnostics/sanitizer-fixture sh ragnarok-sanitizer-tests/verify.sh /diagnostics/fixture-evidence \
+    && apk info -v > /diagnostics/packages.txt \
+    && clang++ --version > /diagnostics/compiler.txt
+RUN ./configure --enable-packetver=${PACKETVER} --enable-manager=no \
+    && make -j"$BUILD_JOBS" server \
+    && mkdir -p /out/re \
+    && cp login-server char-server map-server web-server /out/re/ \
+    && make clean \
+    && ./configure --enable-packetver=${PACKETVER} --enable-manager=no --enable-prere \
+    && make -j"$BUILD_JOBS" char map \
+    && mkdir -p /out/pre-re \
+    && cp char-server map-server /out/pre-re/
+RUN set -e; \
+    grep -qa 'npc/re/scripts_main.conf' /out/re/map-server; \
+    ! grep -qa 'npc/pre-re/scripts_main.conf' /out/re/map-server; \
+    grep -qa 'npc/pre-re/scripts_main.conf' /out/pre-re/map-server; \
+    ! grep -qa 'npc/re/scripts_main.conf' /out/pre-re/map-server; \
+    for era in re pre-re; do \
+        for binary in /out/$era/*; do \
+            readelf -n "$binary" | sed -n "s/.*Build ID: /$era $(basename "$binary") /p" >> /diagnostics/BUILD_IDS; \
+            nm "$binary" | grep -q '__asan_init'; \
+            nm "$binary" | grep -q '__ubsan_handle'; \
+        done; \
+    done
+
+FROM diagnostic-runtime
+LABEL org.ragnarokoffline.diagnostic="asan-ubsan" org.ragnarokoffline.production="false"
+WORKDIR /rathena
+COPY --from=build /out/re/ /rathena/
+COPY --from=build /out/pre-re/char-server /rathena/char-server-prere
+COPY --from=build /out/pre-re/map-server /rathena/map-server-prere
+COPY --from=build /rathena/conf /rathena/conf
+COPY --from=build /rathena/db /rathena/db
+COPY --from=build /rathena/npc /rathena/npc
+COPY --from=build /rathena/sql-files /rathena/sql-files
+COPY --from=build /diagnostics/ /diagnostics/
+COPY --from=build /rathena/ragnarok-sanitizer-tests/verify.sh /diagnostics/verify.sh
+RUN mkdir -p /rathena/log /rathena/save /rathena/conf/import \
+    && chown -R rathena:rathena /rathena
+USER rathena

--- a/docs/SANITIZER_INVESTIGATION.md
+++ b/docs/SANITIZER_INVESTIGATION.md
@@ -1,0 +1,64 @@
+# Disposable map-server investigation
+
+The normal image and diagnostic image use the same rAthena pin, population
+patches and packet version. `containers/rathena/Dockerfile.sanitizers` is a
+separate development build: Clang 21.1.2, ASan/UBSan, debug information and frame
+pointers. It compiles both eras and keeps symbols inside the diagnostic image.
+The compiler and package versions, ELF build IDs, app source and image identity
+are retained with the review artifact. It is never a release image or a shipped
+app dependency, and there is no new Rust crate.
+
+The diagnostic build uses `--enable-manager=no`. rAthena's normal pooled
+allocator keeps freed blocks in an arena, hiding allocation/free boundaries
+from AddressSanitizer. This changes allocation behavior and timing, so a clean
+sanitizer run cannot prove the production allocator has no fault. Findings need
+a reduced reproducer and validation against the normal build as well.
+
+Sanitizer errors stop the process at the first fault. Their signal handlers take
+precedence over rAthena's emergency-save handler; the normal crash-trace hook is
+not enabled in this image. Exit-time leak detection and raw cores are disabled.
+This build is only for marked disposable worlds. It is not appropriate for a
+player save and cannot promise emergency saving after an error.
+
+## Build and validation
+
+Dispatch the existing `images` workflow with `diagnostics=true` on the review
+branch. This calls the diagnostic workflow on native Linux ARM64 and x64 and
+skips the normal image jobs. Only `ragnarokmac/rathena-diagnostics:SOURCE_SHA` is
+tagged; nothing is published to releases. Review artifacts expire after 14 days.
+Preserve the downloaded archive and checksum locally while investigating.
+
+The exact diagnostic runtime must first pass three intentional faults: a
+heap-use-after-free, signed integer overflow and SIGSEGV. Each must stop with a
+symbolized source location. A deliberately installed legacy signal handler must
+not replace the sanitizer's report. The build runs this fixture before compiling
+rAthena and repeats it in the final runtime image. Before gameplay, repeat it
+inside the actual nebula guest too; a hosted runner does not prove guest support.
+
+`sh /diagnostics/verify.sh /tmp/fixture-evidence` only runs synthetic faults.
+Never feed player data to this fixture or upload live server sanitizer reports
+automatically. Those reports can contain private addresses, names or memory
+contents and need private retention and review before sharing.
+
+## Investigation matrix
+
+Use the stopped, marked disposable world with a preserved normal image and
+database backup. Retain original settings and credentials. Record the exact
+image, era, population/mod configuration, start/end time and completed cycle
+count for every row:
+
+| Axis | Cases |
+| --- | --- |
+| Era | Renewal, Pre-Renewal |
+| Population | Off; on with recorded density and active shell count |
+| Mods | Disabled baseline; enabled recorded set |
+| Events | Login/logout; disconnect/reconnect; map changes; combat; spawn/despawn; `@reloadscript` |
+
+Stop and retain the first sanitizer report or unexpected exit before replacing
+the container. Distinguish a test-injected fault, a sanitizer finding, and a
+reproduction of the reported intermittent crash. No underlying cause of #16 is
+claimed until a real failing scenario is recorded. Keep #16 open if the matrix
+does not reproduce it, with actual exposure duration and remaining hypotheses.
+
+References: [Clang ASan build and symbolization](https://clang.llvm.org/docs/AddressSanitizer.html),
+[sanitizer signal-handler controls](https://github.com/google/sanitizers/wiki/SanitizerCommonFlags).

--- a/tests/diagnostics/fixture.cpp
+++ b/tests/diagnostics/fixture.cpp
@@ -1,0 +1,37 @@
+// Deliberate faults using the diagnostic image's real sanitizer runtime.
+// Never linked into rAthena or used with player data.
+#include <climits>
+#include <csignal>
+#include <cstdlib>
+#include <cstring>
+#include <unistd.h>
+
+extern "C" __attribute__((noinline)) void release_block(int* p) { free(p); }
+extern "C" __attribute__((noinline)) int fault_uaf() {
+    int* p = static_cast<int*>(malloc(sizeof(int)));
+    *p = 17;
+    release_block(p);
+    return *static_cast<volatile int*>(p);
+}
+extern "C" __attribute__((noinline)) int fault_overflow() {
+    volatile int value = INT_MAX;
+    return value + 1;
+}
+extern "C" __attribute__((noinline, no_sanitize("undefined"))) int fault_segv() {
+    volatile int* p = nullptr;
+    return *p;
+}
+static void legacy_handler(int) {
+    constexpr char text[] = "UNEXPECTED_LEGACY_HANDLER\n";
+    write(2, text, sizeof(text) - 1);
+    _exit(91);
+}
+int main(int argc, char** argv) {
+    if (argc != 2) return 2;
+    signal(SIGSEGV, legacy_handler);
+    signal(SIGFPE, legacy_handler);
+    if (strcmp(argv[1], "uaf") == 0) return fault_uaf();
+    if (strcmp(argv[1], "overflow") == 0) return fault_overflow();
+    if (strcmp(argv[1], "segv") == 0) return fault_segv();
+    return 2;
+}

--- a/tests/diagnostics/verify.sh
+++ b/tests/diagnostics/verify.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+# Only synthetic faults are safe to emit into hosted CI logs.
+set -eu
+out=${1:?provide a private evidence directory}
+fixture=${FIXTURE_BIN:-/diagnostics/sanitizer-fixture}
+umask 077
+mkdir -p "$out"
+for mode in uaf overflow segv; do
+    status=0
+    "$fixture" "$mode" > "$out/$mode.log" 2>&1 || status=$?
+    cat "$out/$mode.log"
+    test "$status" -ne 0
+    test "$status" -ne 2
+    test "$status" -ne 91
+    ! grep -q UNEXPECTED_LEGACY_HANDLER "$out/$mode.log"
+    grep -q 'fixture.cpp:' "$out/$mode.log"
+    case "$mode" in
+        uaf) grep -q 'AddressSanitizer: heap-use-after-free' "$out/$mode.log"; grep -q fault_uaf "$out/$mode.log" ;;
+        overflow) grep -q 'runtime error: signed integer overflow' "$out/$mode.log"; grep -q fault_overflow "$out/$mode.log" ;;
+        segv) grep -q 'AddressSanitizer: SEGV' "$out/$mode.log"; grep -q fault_segv "$out/$mode.log" ;;
+    esac
+    printf '%s %s\n' "$mode" "$status" >> "$out/exits.txt"
+done
+echo 'ASan use-after-free, UBSan overflow and original SIGSEGV source lookup passed'


### PR DESCRIPTION
Issue #16 needs a reproducible original-fault report. Add a development-only Clang ASan/UBSan image built from the same pinned rAthena and Population Engine patches as the app, in both eras and native guest architectures. Direct allocation exposes frees hidden by the normal pooled allocator. The normal release image and allocator are unchanged.

The manual images workflow accepts diagnostics=true, skips production jobs, and calls a read-only diagnostic workflow. Its image has source/build identity, debug symbols and a real sanitizer fixture that checks heap-use-after-free, signed overflow and SIGSEGV source lookup before compiling the game and again in the final runtime. It never publishes a release or installs itself into player state.

Stacked on #65. This prepares investigation tooling; it does not claim to fix or reproduce the intermittent fault. All four Test checks passed at `2270844`. Native ARM64 and x64 diagnostic image builds, both-era compilation, and synthetic fault/source checks passed [run 34147137547](https://github.com/Flux159/ragnarokoffline.app/actions/runs/34147137547). The initial symbolizer-basename failure is corrected. Actual-guest validation and the recorded gameplay stress matrix remain pending. Local C++/shell syntax, workflow YAML parsing and diff checks passed.

Keep this draft unmerged until the owner tests and explicitly approves it.
