### PR TITLE
Show non-LAN settings only after explicit internet setup opt-in

### DIFF
--- a/src/settings.html
+++ b/src/settings.html
@@ -131,6 +131,10 @@
     </div>
 
     <div id="mp-host">
+      <label class="row" for="mp-internet-setup">
+        <span class="name" style="width:auto">Set up sharing over the internet (non-LAN)</span>
+        <input type="checkbox" id="mp-internet-setup" aria-controls="internet-hosting" aria-expanded="false" />
+      </label>
       <div class="row">
         <span class="name">Let other machines connect</span>
         <input type="checkbox" id="mp-lan" />
@@ -202,7 +206,13 @@
     <p class="note">Create an ordinary player account with the password entered above.
       Use 4–23 letters, numbers, underscores or hyphens, without an _M or _F suffix.</p>
     <button id="account-create" class="ghost" disabled>Create friend account</button>
-    <hr />
+  </div>
+
+  <section id="internet-hosting" hidden aria-labelledby="internet-hosting-heading">
+    <h2 id="internet-hosting-heading">Internet sharing</h2>
+    <div class="panel">
+    <p class="note">Set up accounts before inviting friends outside your local network.
+      This setup does not open a public link.</p>
     <p class="note">Replace this era’s shared internal server passwords with unique credentials.
       This saves a backup and disconnects players while the server restarts. Game account
       passwords and characters are preserved. Keep the app’s private state with your save.</p>
@@ -211,7 +221,8 @@
     <div class="actions"><button id="hosting-check" class="ghost">Check internet account safeguards</button></div>
     <ul class="note" id="hosting-checks" aria-live="polite"></ul>
     <p class="note" id="hosting-readiness">Internet sharing also requires protected access and a configured connector; these account checks do not enable a public link.</p>
-  </div>
+    </div>
+  </section>
 
   <h2>Save data</h2>
   <div class="card">
@@ -327,12 +338,29 @@ async function refreshMode() {
   $('mp-host-addr').value = m.join_host || '';
   $('mp-host').style.display = m.mode === 'host' ? '' : 'none';
   $('mp-join').style.display = m.mode === 'join' ? '' : 'none';
+  paintInternetSetup(m.mode);
   // Only known once the server has started with LAN on: the address comes from
   // what the supervisor actually advertised, not a second guess made here.
   $('mp-addr').textContent = m.join_address
     || (m.lan ? 'starts with the server' : 'not shared');
   paintRegistration(await invoke('get_settings'));
 }
+
+// This is a Settings disclosure, not a listener or hosting-policy switch.
+// Keep local/LAN play uncluttered and never open access by revealing controls.
+let internetSetup = false;
+try { internetSetup = localStorage.getItem('internet-sharing-setup') === 'true'; } catch {}
+function paintInternetSetup(mode = $('mp-mode').value) {
+  const visible = mode === 'host' && internetSetup;
+  $('mp-internet-setup').checked = internetSetup;
+  $('mp-internet-setup').setAttribute('aria-expanded', String(visible));
+  $('internet-hosting').hidden = !visible;
+}
+$('mp-internet-setup').onchange = () => {
+  internetSetup = $('mp-internet-setup').checked;
+  try { localStorage.setItem('internet-sharing-setup', String(internetSetup)); } catch {}
+  paintInternetSetup();
+};
 
 function paintRegistration(settings) {
   const required = ['friends', 'public'].includes(settings.hosting_scope);

--- a/src/settings.html
+++ b/src/settings.html
@@ -136,7 +136,7 @@
         <input type="checkbox" id="mp-internet-setup" aria-controls="internet-hosting" aria-expanded="false" />
       </label>
       <div class="row">
-        <span class="name">Let other machines connect</span>
+        <span class="name">Allow LAN connections</span>
         <input type="checkbox" id="mp-lan" />
       </div>
       <div class="row">
@@ -174,6 +174,22 @@
     </div>
   </div>
 
+  <section id="internet-hosting" hidden aria-labelledby="internet-hosting-heading">
+    <h2 id="internet-hosting-heading">Internet sharing</h2>
+    <div class="panel">
+    <p class="note">Set up accounts before inviting friends outside your local network.
+      This setup does not open a public link.</p>
+    <p class="note">Replace this era’s shared internal server passwords with unique credentials.
+      This saves a backup and disconnects players while the server restarts. Game account
+      passwords and characters are preserved. Keep the app’s private state with your save.</p>
+    <button id="secure-services" class="ghost">Secure internal server credentials</button>
+    <p class="note" id="services-status" role="status" aria-live="polite"></p>
+    <div class="actions"><button id="hosting-check" class="ghost">Check internet account safeguards</button></div>
+    <ul class="note" id="hosting-checks" aria-live="polite"></ul>
+    <p class="note" id="hosting-readiness">Internet sharing also requires protected access and a configured connector; these account checks do not enable a public link.</p>
+    </div>
+  </section>
+
   <h2>Accounts</h2>
   <div class="panel" id="accounts-panel">
     <p class="note">Manage accounts on your own running server. Renewal and pre-renewal
@@ -208,21 +224,6 @@
     <button id="account-create" class="ghost" disabled>Create friend account</button>
   </div>
 
-  <section id="internet-hosting" hidden aria-labelledby="internet-hosting-heading">
-    <h2 id="internet-hosting-heading">Internet sharing</h2>
-    <div class="panel">
-    <p class="note">Set up accounts before inviting friends outside your local network.
-      This setup does not open a public link.</p>
-    <p class="note">Replace this era’s shared internal server passwords with unique credentials.
-      This saves a backup and disconnects players while the server restarts. Game account
-      passwords and characters are preserved. Keep the app’s private state with your save.</p>
-    <button id="secure-services" class="ghost">Secure internal server credentials</button>
-    <p class="note" id="services-status" role="status" aria-live="polite"></p>
-    <div class="actions"><button id="hosting-check" class="ghost">Check internet account safeguards</button></div>
-    <ul class="note" id="hosting-checks" aria-live="polite"></ul>
-    <p class="note" id="hosting-readiness">Internet sharing also requires protected access and a configured connector; these account checks do not enable a public link.</p>
-    </div>
-  </section>
 
   <h2>Save data</h2>
   <div class="card">

--- a/tests/e2e/hosting-guards-settings.cjs
+++ b/tests/e2e/hosting-guards-settings.cjs
@@ -196,6 +196,7 @@ async function main() {
         await invoke('accounts', { action: 'disable', era, id: account.id, username });
         report.guardedAdminLifecycle = true;
       }
+      await page.locator('#mp-internet-setup').check();
       await page.locator('#hosting-check').click();
       await expect(page.locator('#hosting-check')).toBeEnabled({ timeout: 60000 });
       await expect(page.locator('#hosting-checks li')).toHaveCount(3);

--- a/tests/e2e/service-credentials-settings.cjs
+++ b/tests/e2e/service-credentials-settings.cjs
@@ -104,6 +104,7 @@ async function main() {
       const wasManaged = fs.existsSync(path.join(directory, 'ready'));
       const previousPlayers = fingerprint(!wasManaged);
       const previousJournal = wasManaged ? journal(era) : null;
+      await page.locator('#mp-internet-setup').check();
       await page.locator('#secure-services').click();
       await expect(page.locator('#secure-services')).toBeEnabled({ timeout: 300000 });
       await expect(page.locator('#services-status')).toHaveText('Internal service credentials secured for ' + era + '. Player accounts and characters were preserved.');


### PR DESCRIPTION
Non-LAN account safeguards were always visible in Settings. Move them into an Internet sharing section revealed only by the explicit “Set up sharing over the internet (non-LAN)” checkbox while hosting. Ordinary local play, LAN-only sharing and joining a friend keep the section hidden. Label the separate LAN switch explicitly.

The disclosure preference persists in the Settings profile. Revealing it does not change hosting scope, bind a listener, restart a server or open a public link. GM password/account controls remain available for local play. Existing account acceptance fixtures now explicitly open the section before using its controls.

Stacked on #66. Actual Electron/Playwright Settings checks passed local, LAN, opt-in, reload, join and opt-out cases with zero page errors. Screenshots were reviewed; the isolated UI fixture started no VM and left hosting policy unchanged. Inline JavaScript and updated fixture syntax checks passed. All four Test checks passed at `544ec9c`: client-build and Linux/macOS/Windows supervisor-and-lifecycle, [run 34147381579](https://github.com/Flux159/ragnarokoffline.app/actions/runs/34147381579).

Keep this draft unmerged until the owner tests and explicitly approves it.
