### PR TITLE
Recover setup, failed navigation and terminated game windows

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -367,3 +367,12 @@ that private state with the disposable VM disk. Reports and Settings/game
 screenshots are under `account-tests/service-credentials-<timestamp>/`; they do
 not contain passwords. Native packaged migration on Windows/Linux and full
 internet-hosting safeguards remain separate acceptance requirements.
+
+### Startup recovery
+
+`node tests/e2e/startup-recovery.cjs` launches an isolated Electron profile and
+an ephemeral loopback HTTP fixture, without starting a VM. It closes/reopens
+setup, drops the game-page response after a successful host probe, verifies
+that recovery waits for Retry, then crashes only its own renderer and verifies
+another successful Retry. The remote fixture is denied owner IPC throughout.
+Screenshots are written to the reported temporary evidence directory.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -172,3 +172,11 @@ New builds authenticate their managed child and shut it down when the shell
 exits or crashes. The log's launch header records the executable fingerprint,
 configuration fingerprint and process ID; older logs are retained as
 `assets.log.1` through `.3`.
+
+If you close setup before selecting your client, use **Choose client files…**
+on the waiting screen to reopen it. The same button is available after a host
+startup failure, including when selected files have moved.
+
+A failed game-page load or terminated game window now returns to a recovery
+screen. **Retry** reopens the client so you can log in again. Joining a friend
+also offers **Play on this computer** when their host is unavailable.

--- a/electron/main.js
+++ b/electron/main.js
@@ -1173,11 +1173,17 @@ function makeWindow(id, file, opts) {
 		clientLog(level, text, line, src);
 	});
 	// A page that fails to load at all logs nothing, so it needs saying here.
-	win.webContents.on('did-fail-load', (_e, code, desc, url) => {
+	win.webContents.on('did-fail-load', (_e, code, desc, url, isMainFrame) => {
 		clientLog('error', `page failed to load: ${desc} (${code}) ${url || ''}`);
+		if (id === 'game' && isMainFrame && code !== -3 && /^https?:/.test(url || '')) {
+			showGameFailure(win, 'The game page could not load. Check the host connection, then retry.');
+		}
 	});
 	win.webContents.on('render-process-gone', (_e, details) => {
 		clientLog('error', `renderer gone: ${details && details.reason}`);
+		if (id === 'game' && details?.reason !== 'clean-exit') {
+			showGameFailure(win, 'The game window stopped unexpectedly. Retry to reopen the client and log in again.');
+		}
 	});
 	// `opts.url` wins over a bundled page: a joining player's game window is
 	// the host's own client, served over HTTP, not a local copy of it.
@@ -1266,6 +1272,18 @@ function gameTitle() {
 // surfaces a failure with a retry, and only then navigates -- a joining player
 // pointed straight at a host gets a blank window when that host is down, with
 // nothing to act on. Where it navigates *to* is decided in launch_game.
+// Kept in the owner process so a failed/terminated game renderer cannot lose
+// its recovery reason. Loading the boot page never retries automatically.
+let gameFailure = null;
+function showGameFailure(win, message) {
+	if (tearingDown || !win || win.isDestroyed() || win !== windows.game || win.recoveryLoading) return;
+	gameFailure = message;
+	win.recoveryLoading = true;
+	win.loadFile(path.join(__dirname, '..', 'src', 'index.html'))
+		.catch(error => appLog(`Could not load game recovery: ${error.message}`))
+		.finally(() => { win.recoveryLoading = false; });
+}
+
 const openGame = () => {
 	const c = getClientPaths();
 	const win = makeWindow('game', 'index.html', { width: 1280, height: 800, title: gameTitle(), rememberBounds: true });
@@ -1816,7 +1834,10 @@ const handlers = {
 	// already given up stayed on screen forever, with the assets saved and the
 	// server never started. Finishing setup is exactly the event that makes
 	// the earlier answer wrong, so the page has to run again.
+	boot_failure: () => gameFailure,
+	clear_boot_failure: () => { gameFailure = null; },
 	open_game: () => {
+		gameFailure = null;
 		const existed = windows.game && !windows.game.isDestroyed();
 		const win = openGame();
 		// Load the boot page, not reload(). By the time this is called the
@@ -1845,7 +1866,12 @@ const handlers = {
 		// race for no gain.
 		if (c.mode !== 'join') await dropStaleClientCache();
 		const win = openGame();
-		await win.loadURL(c.mode === 'join' ? joinSession.url(base) : base + GAME_PATH);
+		try {
+			await win.loadURL(c.mode === 'join' ? joinSession.url(base) : base + GAME_PATH);
+		} catch (error) {
+			if (error.code !== 'ERR_ABORTED') showGameFailure(win, 'The game page could not load. Check the host connection, then retry.');
+			throw error;
+		}
 		win.setTitle(gameTitle());
 	},
 

--- a/src/index.html
+++ b/src/index.html
@@ -39,6 +39,7 @@
     <div class="status" id="status">Starting the server…</div>
     <div class="fail" id="fail" hidden></div>
     <button id="retry" hidden>Retry</button>
+    <button id="setup" class="ghost" hidden>Choose client files…</button>
     <button id="repair" class="ghost" hidden>Repair…</button>
     <button id="local" class="ghost" hidden>Play on this computer</button>
   </div>
@@ -54,6 +55,8 @@ const retry = document.getElementById('retry');
 const repair = document.getElementById('repair');
 const local = document.getElementById('local');
 const mark = document.getElementById('mark');
+const setup = document.getElementById('setup');
+let booting = false;
 // Which failures make sense to offer a way out of. Read once per boot rather
 // than assumed: the two modes fail for entirely different reasons and have
 // entirely different remedies.
@@ -81,6 +84,13 @@ const DEADLINE_MS = 180000;
 const ready = () => invoke('assets_ready');
 
 async function boot() {
+  if (booting) return;
+  booting = true;
+  let ticking = false;
+  try {
+  await invoke('clear_boot_failure');
+  setup.hidden = true;
+  lastPhase = 'Starting the server…';
   fail.hidden = true; retry.hidden = true; repair.hidden = true;
   local.hidden = true; mark.hidden = false;
 
@@ -89,6 +99,8 @@ async function boot() {
   // No client configured yet: hand off to the setup window and stop here.
   if (!(await invoke('client_ready'))) {
     status.textContent = 'Waiting for your client…';
+    mark.hidden = true;
+    setup.hidden = false;
     await invoke('open_setup');
     return;
   }
@@ -99,13 +111,13 @@ async function boot() {
   // launch, so the phase has to be polled *alongside* it rather than after —
   // otherwise the window shows one unchanging line for the whole wait and a
   // hang looks exactly like slow progress.
-  let ticking = true;
+  ticking = true;
   const show = async () => {
     while (ticking) {
       const p = await invoke('stack_phase').catch(() => '');
       if (p && p !== 'Ready') lastPhase = p;
       const secs = Math.round((Date.now() - started) / 1000);
-      status.textContent = `${lastPhase} ${secs}s`;
+      if (ticking) status.textContent = `${lastPhase} ${secs}s`;
       await new Promise(r => setTimeout(r, 1000));
     }
   };
@@ -134,6 +146,12 @@ async function boot() {
   }
   ticking = false;
   giveUp(`Stalled at: ${lastPhase}\nThe server did not come up in time.`);
+  } catch (error) {
+    giveUp(plain(error));
+  } finally {
+    ticking = false;
+    booting = false;
+  }
 }
 
 function giveUp(message) {
@@ -149,6 +167,7 @@ function giveUp(message) {
   fail.style.maxWidth = instructions ? '620px' : '460px';
   fail.hidden = false;
   retry.hidden = false;
+  setup.hidden = mode !== 'host';
   // Repair restarts the engine, and a joining player is running no engine --
   // offering it there is a button that cannot help. What can help is the game
   // they already own: the host may be offline, their own server never is.
@@ -157,6 +176,7 @@ function giveUp(message) {
 }
 
 retry.onclick = boot;
+setup.onclick = () => invoke('open_setup').catch(error => giveUp(plain(error)));
 
 // Restarting the engine is the one recovery that works when the daemon itself
 // is stuck, and it is the only one available to someone with no terminal.
@@ -187,7 +207,14 @@ local.onclick = async () => {
     local.disabled = false;
   }
 };
-boot();
+(async () => {
+  try {
+    mode = (await invoke('get_mode')).mode || 'host';
+    const failure = await invoke('boot_failure');
+    if (failure) giveUp(failure);
+    else await boot();
+  } catch (error) { giveUp(plain(error)); }
+})();
 </script>
 </body>
 </html>

--- a/tests/e2e/startup-recovery.cjs
+++ b/tests/e2e/startup-recovery.cjs
@@ -1,0 +1,63 @@
+// Real Electron recovery UI with an ephemeral HTTP host; no VM or player save.
+'use strict';
+const fs = require('node:fs'), path = require('node:path'), os = require('node:os');
+const http = require('node:http');
+const { _electron, expect } = require('@playwright/test');
+const root = path.resolve(__dirname, '../..');
+const out = fs.mkdtempSync(path.join(os.tmpdir(), 'ro-startup-recovery-'));
+const state = path.join(out, 'state');
+fs.mkdirSync(state);
+fs.writeFileSync(path.join(out, 'client.json'), '{}');
+let broken = true, requests = 0;
+const server = http.createServer((req, res) => {
+  if (req.url === '/') return res.end('ready');
+  requests++;
+  if (broken) return req.socket.destroy();
+  res.setHeader('Content-Type', 'text/html');
+  res.end('<h1>Recovered game fixture</h1>');
+});
+(async () => {
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+  const origin = 'http://127.0.0.1:' + server.address().port;
+  const app = await _electron.launch({ executablePath: require('electron'), cwd: root,
+    args: [path.join(root, 'electron/main.js'), '--user-data-dir=' + path.join(out, 'profile')],
+    env: { ...process.env, RAGNAROK_OFFLINE_HOME: out, RAGNAROKMAC_ROOT: path.join(out, 'runtime'),
+      RAGNAROKMAC_STATE: state, NEBULA_HOME: path.join(out, 'nebula') } });
+  try {
+    const game = await app.firstWindow();
+    await expect(game.locator('#status')).toHaveText('Waiting for your client…');
+    await expect.poll(() => app.windows().some(p => p.url().endsWith('setup.html'))).toBe(true);
+    await app.windows().find(p => p.url().endsWith('setup.html')).close();
+    await game.getByRole('button', { name: 'Choose client files…' }).click();
+    await expect.poll(() => app.windows().some(p => p.url().endsWith('setup.html'))).toBe(true);
+    await game.evaluate(() => window.__ELECTRON__.core.invoke('open_settings'));
+    await expect.poll(() => app.windows().some(p => p.url().endsWith('settings.html'))).toBe(true);
+    const owner = app.windows().find(p => p.url().endsWith('settings.html'));
+    const invoke = (name, args) => owner.evaluate(({name,args}) => window.__ELECTRON__.core.invoke(name,args), {name,args});
+    await invoke('set_client_paths', { paths: { mode: 'join', join_host: origin } });
+    await invoke('open_game');
+    await expect(game.locator('#fail')).toContainText('The game page could not load', { timeout: 30000 });
+    await expect(game.locator('#retry')).toBeVisible();
+    await expect(game.locator('#repair')).toBeHidden();
+    const failedRequests = requests;
+    await game.waitForTimeout(1200);
+    expect(requests).toBe(failedRequests); // Recovery does not retry in a loop.
+    await game.screenshot({ path: path.join(out, 'navigation-failure.png') });
+    broken = false;
+    await game.locator('#retry').click();
+    await expect(game.locator('h1')).toHaveText('Recovered game fixture');
+    expect(await game.evaluate(() => window.__ELECTRON__.core.invoke('boot_failure').then(() => false, () => true))).toBe(true);
+    // Crash only this fixture's renderer, then recover through the actual UI.
+    await app.evaluate(({ BrowserWindow }) => BrowserWindow.getAllWindows().find(w => w.webContents.getURL().startsWith('http:')).webContents.forcefullyCrashRenderer());
+    await expect(game.locator('#fail')).toContainText('game window stopped unexpectedly');
+    await game.screenshot({ path: path.join(out, 'renderer-failure.png') });
+    await game.locator('#retry').click();
+    await expect(game.locator('h1')).toHaveText('Recovered game fixture');
+    expect(fs.existsSync(path.join(out, 'nebula'))).toBe(false);
+    console.log('Setup cancellation, navigation failure/retry and renderer recovery passed:', out);
+  } finally {
+    await app.evaluate(({app}) => app.exit(0)).catch(() => {});
+    server.closeAllConnections();
+    await new Promise(resolve => server.close(resolve));
+  }
+})().catch(error => { console.error(error.message); process.exitCode = 1; });


### PR DESCRIPTION
Closing setup used to leave a waiting screen with no way to reopen it. A failed game navigation or crashed renderer also left the game window unusable even when the server was healthy. This adds a client-file picker button to waiting/host-failure states and returns failed game windows to a recovery screen with an explicit Retry. Recovery does not restart in a loop, and remote pages retain no owner IPC.

Based on #67; this is one consolidated continuation PR for startup/navigation recovery. No merge or release requested.

Validation: 58 Node tests passed with the compiled supervisor and pinned Rust RemoteClient, with zero skips. Real Electron acceptance passed setup cancellation/reopening, successful host probe followed by failed page navigation, explicit retry, owned renderer crash/retry, and remote IPC denial. Failure screenshots were inspected. JavaScript syntax and diff checks passed. The HTTP fixture tests shell recovery; existing real setup/game acceptance covers native login separately.

All four [CI jobs](https://github.com/Flux159/ragnarokoffline.app/actions/runs/34153292436) passed.
