### PR TITLE
Recover crashed servers and fix sanitizer-proven startup, login and population defects

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,11 @@ jobs:
       - uses: actions/checkout@v4
       - run: bash scripts/vendor-fetch.sh rathena vendor/rathena
       - run: python3 tests/diagnostics/verify-language.py vendor/rathena --expect-fault
+      - run: python3 tests/diagnostics/verify-base-sp.py vendor/rathena --expect-fault
       - run: bash scripts/apply-server-mods.sh vendor/rathena
       - run: bash scripts/apply-server-mods.sh vendor/rathena
       - run: python3 tests/diagnostics/verify-language.py vendor/rathena
+      - run: python3 tests/diagnostics/verify-base-sp.py vendor/rathena
   client-build:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,10 +15,12 @@ jobs:
       - run: bash scripts/vendor-fetch.sh rathena vendor/rathena
       - run: python3 tests/diagnostics/verify-language.py vendor/rathena --expect-fault
       - run: python3 tests/diagnostics/verify-base-sp.py vendor/rathena --expect-fault
+      - run: python3 tests/diagnostics/verify-skill-level.py vendor/rathena --expect-fault
       - run: bash scripts/apply-server-mods.sh vendor/rathena
       - run: bash scripts/apply-server-mods.sh vendor/rathena
       - run: python3 tests/diagnostics/verify-language.py vendor/rathena
       - run: python3 tests/diagnostics/verify-base-sp.py vendor/rathena
+      - run: python3 tests/diagnostics/verify-skill-level.py vendor/rathena
   client-build:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,11 +16,13 @@ jobs:
       - run: python3 tests/diagnostics/verify-language.py vendor/rathena --expect-fault
       - run: python3 tests/diagnostics/verify-base-sp.py vendor/rathena --expect-fault
       - run: python3 tests/diagnostics/verify-skill-level.py vendor/rathena --expect-fault
+      - run: python3 tests/diagnostics/verify-weapon-bounds.py vendor/rathena --expect-fault
       - run: bash scripts/apply-server-mods.sh vendor/rathena
       - run: bash scripts/apply-server-mods.sh vendor/rathena
       - run: python3 tests/diagnostics/verify-language.py vendor/rathena
       - run: python3 tests/diagnostics/verify-base-sp.py vendor/rathena
       - run: python3 tests/diagnostics/verify-skill-level.py vendor/rathena
+      - run: python3 tests/diagnostics/verify-weapon-bounds.py vendor/rathena
   client-build:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,16 @@ on:
 permissions:
   contents: read
 jobs:
+  server-language:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - run: bash scripts/vendor-fetch.sh rathena vendor/rathena
+      - run: python3 tests/diagnostics/verify-language.py vendor/rathena --expect-fault
+      - run: bash scripts/apply-server-mods.sh vendor/rathena
+      - run: bash scripts/apply-server-mods.sh vendor/rathena
+      - run: python3 tests/diagnostics/verify-language.py vendor/rathena
   client-build:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/containers/rathena/Dockerfile.sanitizers
+++ b/containers/rathena/Dockerfile.sanitizers
@@ -19,8 +19,11 @@ COPY . /rathena
 ARG PACKETVER=20221005
 ARG BUILD_JOBS=2
 ENV CC=clang CXX=clang++
-ENV CFLAGS="-g -O1 -fno-omit-frame-pointer -fno-optimize-sibling-calls -fsanitize=address,undefined -fno-sanitize-recover=all"
-ENV CXXFLAGS="-g -O1 -fno-omit-frame-pointer -fno-optimize-sibling-calls -fsanitize=address,undefined -fno-sanitize-recover=all"
+# The pinned packet FIFO macros dereference integers at byte offsets (e.g.
+# char_logif.cpp offset 50). Exclude alignment to reach gameplay; keep ASan
+# and every other undefined-behavior check fatal. See SANITIZER_INVESTIGATION.md.
+ENV CFLAGS="-g -O1 -fno-omit-frame-pointer -fno-optimize-sibling-calls -fsanitize=address,undefined -fno-sanitize=alignment -fno-sanitize-recover=all"
+ENV CXXFLAGS="-g -O1 -fno-omit-frame-pointer -fno-optimize-sibling-calls -fsanitize=address,undefined -fno-sanitize=alignment -fno-sanitize-recover=all"
 ENV LDFLAGS="-fsanitize=address,undefined -Wl,--build-id=sha1 -rdynamic"
 # Do not enable RAGNAROK_CRASH_TRACE: sanitizer diagnostics own fault handling.
 # NO_MEMMGR exposes allocation/free boundaries that the built-in pool obscures.

--- a/docs/CRASH_DIAGNOSTICS.md
+++ b/docs/CRASH_DIAGNOSTICS.md
@@ -89,3 +89,16 @@ the name `SEGV` and falls back to SIGTERM. A clean shutdown from that named
 signal does not test the crash handler. The fixture records image/container
 identity and observed exit status even if incident capture fails. This remains
 an injected-signal acceptance test, not a reproduction of issue #16.
+
+
+When the owning app captures a new game-server incident during play, it returns
+the game window to a recovery screen. **Open crash reports** opens the private
+reports folder; review files before sharing them. **Retry** starts the server
+and reopens the login screen. Recovery waits for that action and does not loop.
+An old collector result cannot replace a newer asset launch's window.
+
+A restarted container retains its old logs. Classification now discards log
+records older than its current `StartedAt`, so an earlier crash message cannot
+turn a later clean stop into a new incident. Reports also include the packet
+version, capture-time population settings and asset overlay fingerprint; these
+are explicitly capture-time observations, not proof of the fault-time state.

--- a/docs/SANITIZER_INVESTIGATION.md
+++ b/docs/SANITIZER_INVESTIGATION.md
@@ -123,3 +123,19 @@ skill; the source-macro UBSan reduction fails before and passes after, including
 stored and extrapolated learned levels. The original private game report is
 retained. This is a reproduced login defect, not proof of the intermittent
 logout crash's cause.
+
+Both architectures passed diagnostic build `34158378360` and normal build
+`34158843298` at source `fdaf7b8ef7df95f431a1af3b39466931c0739873`. The patched
+normal ARM64 image completed all 20 extended cycles with mods disabled. The
+diagnostic image passed the guest fixture and five Pre-Renewal/population-off
+cycles, then failed during real population activation: `status.cpp:4353` read
+index 16 from `indexed_bonus.weapon_atk[16]` while a shell equipped a Katar.
+The stack includes `pc_equipitem`, `population_engine_spawn_shell` and the
+autosummon timer. The failed population assertion did not mean population was
+merely slow; the retained server log contains the fatal sanitizer report.
+
+The fourth server patch sizes `weapon_atk` and `weapon_damage_rate` from the
+complete weapon enum and guards item-script writes. Its source-derived
+reduction reproduces index 16 on the original and checks all weapon types and
+invalid indices after patching. This is a real population-path bounds defect;
+the intermittent logout scenario still needs its own reproduction evidence.

--- a/docs/SANITIZER_INVESTIGATION.md
+++ b/docs/SANITIZER_INVESTIGATION.md
@@ -105,3 +105,11 @@ screen and returned to native login through Retry. The stress fixture also
 supports `RO_E2E_STRESS_MODS=off`, preserving/restoring mod selection files, and
 records the actual mod list. Population rows explicitly stop and respawn 100
 shells between map transitions before reloading scripts.
+
+After that fix, build `34155293027` passed both architecture jobs and the actual
+guest fixture. Real startup then found a negative-to-unsigned conversion in
+`JobDatabase::calc_basesp` (`pc.cpp:13822`, via `loadingFinished`). A Ninja-mapped
+job with default coefficients computes -2 at level 10. The second small server
+patch clamps the floating-point value to the unsigned return range before the
+cast. `verify-base-sp.py` reproduces the original UBSan failure and verifies the
+fix, ordinary values and overflow. Again this is a separate startup finding.

--- a/docs/SANITIZER_INVESTIGATION.md
+++ b/docs/SANITIZER_INVESTIGATION.md
@@ -113,3 +113,13 @@ job with default coefficients computes -2 at level 10. The second small server
 patch clamps the floating-point value to the unsigned return range before the
 cast. `verify-base-sp.py` reproduces the original UBSan failure and verifies the
 fix, ordinary values and overflow. Again this is a separate startup finding.
+
+Build `34156678115` (source `eedaaf2fd466eb6c96730dc2904d6f6e5e4fcbc9`)
+passed both architectures and the guest fixture, then reached actual character
+login. The Pre-Renewal/population-off row stopped at `skill_get_sp` with index -1
+while `clif_skillinfoblock` built the unlearned skill list after `LoadEndAck`.
+`0003-unlearned-skill-level.patch` returns zero before indexing a level-zero
+skill; the source-macro UBSan reduction fails before and passes after, including
+stored and extrapolated learned levels. The original private game report is
+retained. This is a reproduced login defect, not proof of the intermittent
+logout crash's cause.

--- a/docs/SANITIZER_INVESTIGATION.md
+++ b/docs/SANITIZER_INVESTIGATION.md
@@ -139,3 +139,20 @@ complete weapon enum and guards item-script writes. Its source-derived
 reduction reproduces index 16 on the original and checks all weapon types and
 invalid indices after patching. This is a real population-path bounds defect;
 the intermittent logout scenario still needs its own reproduction evidence.
+
+Source `dd39509a16e57666834f404a532403a13a47063d`, containing all four fixes,
+passed both architectures in diagnostic build `34160404547` and normal build
+`34160406889`. The diagnostic ARM64 image
+`202bc00ca59d311214f8d7116d1ca3b684e0855d897ba84dab457a50dd0434e3`
+passed the actual guest synthetic fixture, then completed all 20 extended
+gameplay cycles with mods disabled: five for each era/population combination.
+The recorded exposure was 22:51:01–22:58:24 UTC, with no sanitizer fault,
+browser error or cleanup failure. Positive population counts were required;
+population rows issued stop/100-shell spawn requests as well as map changes,
+script reloads and both native logout and abrupt disconnects.
+
+An earlier run with this same image completed five population-off cycles but
+checked population before the next demand-driven timer tick. It retained zero
+stats and healthy server logs, not a sanitizer finding. The fixture now polls
+for a positive count, checking server health on each attempt. That timing
+failure and the original fourth-fault evidence remain retained separately.

--- a/docs/SANITIZER_INVESTIGATION.md
+++ b/docs/SANITIZER_INVESTIGATION.md
@@ -62,3 +62,26 @@ does not reproduce it, with actual exposure duration and remaining hypotheses.
 
 References: [Clang ASan build and symbolization](https://clang.llvm.org/docs/AddressSanitizer.html),
 [sanitizer signal-handler controls](https://github.com/google/sanitizers/wiki/SanitizerCommonFlags).
+
+## September 7 continuation
+
+The original image passed the synthetic fixture inside the actual ARM64 guest,
+but real game startup failed UBSan at `char_logif.cpp:827`: `WFIFOL(fd,50)`
+casts a byte-offset FIFO pointer to `uint32*`. Similar unaligned accesses are
+pervasive in the pinned packet macros. This is real C++ alignment UB, not a
+reproduction of the intermittent logout crash. The gameplay diagnostic image
+excludes only `alignment`; ASan and the other UBSan checks remain fatal. It
+cannot be used to claim the absence of alignment defects. See the
+[Clang per-check controls](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html#usage).
+
+`tests/e2e/sanitizer-guest.cjs` verifies the archive checksum and deliberately
+faulting runtime inside a stopped, marked disposable world, then waits for
+owned shutdown to release its ports. `tests/e2e/map-crash-stress.cjs` backs up
+each era before repeated real client login, warp, script reload, native
+character-select logout and abrupt navigation disconnect. It records completed
+counts and image identity, and preserves the first detected game fault.
+
+Normal ARM64 image `ec813673406bdfa995723535f926697f1167467ab105a0e5f938d96236d61660`
+completed 20 reload/logout cycles: five per era/population-off-or-on combination.
+Bundled mobile and keyboard mods were enabled. No crash was reproduced; this
+short exposure is not closure of #16 or the full acceptance matrix.

--- a/docs/SANITIZER_INVESTIGATION.md
+++ b/docs/SANITIZER_INVESTIGATION.md
@@ -85,3 +85,23 @@ Normal ARM64 image `ec813673406bdfa995723535f926697f1167467ab105a0e5f938d96236d6
 completed 20 reload/logout cycles: five per era/population-off-or-on combination.
 Bundled mobile and keyboard mods were enabled. No crash was reproduced; this
 short exposure is not closure of #16 or the full acceptance matrix.
+
+The corrected diagnostic image from build `34153441798` (source
+`7cd027d67218ee40e6829579da3d82d32d37ca87`, ARM64 image
+`5b4dc29e9dce57b3969af9e84e92c1acf40c2f87048c1f02a62030d60203a8cd`)
+passed the synthetic guest fixture, then found another real startup defect:
+`msg_checklangtype(0)` shifts by -1 before its English early return. The retained
+stack starts at `msg_conf.cpp:133`, called by `map_do_init_msg`. The small
+`third-party/server-fixes/0001-language-mask.patch` moves the early return and
+range checks before the shift. It applies to both normal and diagnostic builds.
+`tests/diagnostics/verify-language.py` compiles that actual source function with
+UBSan: the pinned original fails on English; the patched checker passes English,
+all nine other languages, three enable masks and invalid integer bounds.
+This is a startup UB finding, not evidence of the intermittent logout fault.
+
+The real injected-map-fault recovery test passed with the normal image:
+`RO_E2E_RECOVERY_SMOKE=1` detected the stopped map, showed its private-report
+screen and returned to native login through Retry. The stress fixture also
+supports `RO_E2E_STRESS_MODS=off`, preserving/restoring mod selection files, and
+records the actual mod list. Population rows explicitly stop and respawn 100
+shells between map transitions before reloading scripts.

--- a/electron/crash-monitor.js
+++ b/electron/crash-monitor.js
@@ -2,18 +2,23 @@
 
 // Serial, owner-only monitoring; it never starts an engine or restarts a game.
 class CrashMonitor {
-  constructor({ active, collect, log, interval = 15000 }) {
-    Object.assign(this, { active, collect, log, interval });
+  constructor({ active, collect, log, onCrash = () => {}, interval = 15000 }) {
+    Object.assign(this, { active, collect, log, onCrash, interval });
     this.busy = false;
     this.lastError = '';
   }
   async tick() {
-    if (this.busy || !this.active()) return;
+    const owner = this.active();
+    if (this.busy || !owner) return;
     this.busy = true;
     try {
       const message = await this.collect();
       this.lastError = '';
-      if (message?.trim()) this.log(message.trim());
+      if (message?.trim()) {
+        this.log(message.trim());
+        const services = [...message.matchAll(/^ragnarok-(map|char|login) stopped unexpectedly; private evidence saved at /gm)].map(match => match[1]);
+        if (services.length && this.active() === owner) await this.onCrash([...new Set(services)]);
+      }
     } catch {
       const message = 'Crash evidence collection failed; check local storage and engine diagnostics.';
       if (this.lastError !== message) this.log(message);

--- a/electron/main.js
+++ b/electron/main.js
@@ -1834,6 +1834,12 @@ const handlers = {
 	// already given up stayed on screen forever, with the assets saved and the
 	// server never started. Finishing setup is exactly the event that makes
 	// the earlier answer wrong, so the page has to run again.
+	open_crash_reports: async () => {
+		const directory = path.join(stateDir(), 'crashes', 'reports');
+		if (!fs.existsSync(directory)) throw new Error('No crash reports have been saved yet.');
+		const error = await shell.openPath(directory);
+		if (error) throw new Error('Could not open the crash reports folder.');
+	},
 	boot_failure: () => gameFailure,
 	clear_boot_failure: () => { gameFailure = null; },
 	open_game: () => {
@@ -2051,10 +2057,14 @@ function buildMenu() {
 
 let tearingDown = false;
 const crashMonitor = new (require('./crash-monitor').CrashMonitor)({
-	active: () => !tearingDown && assetServer.running,
+	active: () => !tearingDown && assetServer.running && assetServer.current?.identity?.launchId,
 	collect: () => queueServerOperation(() => !tearingDown && assetServer.running
 		? runStack(['capture-crashes']) : ''),
 	log: message => appLog(message),
+	onCrash: services => {
+		const label = services.includes('map') ? 'Map server' : 'Game server';
+		showGameFailure(windows.game, `${label} stopped unexpectedly. A private crash report was saved. Retry to restart the server and log in again.`);
+	},
 });
 // Set when a launch arrives while we are quitting: see the second-instance
 // handler. Guarded because two clicks must not queue two copies.

--- a/scripts/apply-server-mods.sh
+++ b/scripts/apply-server-mods.sh
@@ -23,6 +23,18 @@ MOD="$ROOT/third-party/population-engine"
 
 python3 "$ROOT/scripts/apply-crash-trace.py" "$TARGET"
 
+# Small upstream corrections also apply to both normal and diagnostic images.
+for fix in "$ROOT"/third-party/server-fixes/*.patch; do
+    if patch -d "$TARGET" -p1 --dry-run --forward < "$fix" >/dev/null 2>&1; then
+        patch -d "$TARGET" -p1 --forward < "$fix"
+    elif patch -d "$TARGET" -p1 --dry-run --reverse < "$fix" >/dev/null 2>&1; then
+        echo "    already applied $(basename "$fix")"
+    else
+        echo "server fix no longer matches: $fix" >&2
+        exit 1
+    fi
+done
+
 echo "==> population engine: files"
 # Copied every time: these are ours alone, nothing upstream writes here, so
 # re-copying is how a third-party/ update reaches an existing checkout.

--- a/src/index.html
+++ b/src/index.html
@@ -39,6 +39,7 @@
     <div class="status" id="status">Starting the server…</div>
     <div class="fail" id="fail" hidden></div>
     <button id="retry" hidden>Retry</button>
+    <button id="reports" class="ghost" hidden>Open crash reports</button>
     <button id="setup" class="ghost" hidden>Choose client files…</button>
     <button id="repair" class="ghost" hidden>Repair…</button>
     <button id="local" class="ghost" hidden>Play on this computer</button>
@@ -56,6 +57,7 @@ const repair = document.getElementById('repair');
 const local = document.getElementById('local');
 const mark = document.getElementById('mark');
 const setup = document.getElementById('setup');
+const reports = document.getElementById('reports');
 let booting = false;
 // Which failures make sense to offer a way out of. Read once per boot rather
 // than assumed: the two modes fail for entirely different reasons and have
@@ -90,6 +92,7 @@ async function boot() {
   try {
   await invoke('clear_boot_failure');
   setup.hidden = true;
+  reports.hidden = true;
   lastPhase = 'Starting the server…';
   fail.hidden = true; retry.hidden = true; repair.hidden = true;
   local.hidden = true; mark.hidden = false;
@@ -166,6 +169,7 @@ function giveUp(message) {
   fail.style.textAlign = instructions ? 'left' : 'center';
   fail.style.maxWidth = instructions ? '620px' : '460px';
   fail.hidden = false;
+  reports.hidden = !message.includes('A private crash report was saved.');
   retry.hidden = false;
   setup.hidden = mode !== 'host';
   // Repair restarts the engine, and a joining player is running no engine --
@@ -176,6 +180,7 @@ function giveUp(message) {
 }
 
 retry.onclick = boot;
+reports.onclick = () => invoke('open_crash_reports').catch(error => { fail.textContent = plain(error); });
 setup.onclick = () => invoke('open_setup').catch(error => giveUp(plain(error)));
 
 // Restarting the engine is the one recovery that works when the daemon itself

--- a/stack/src/crashes.rs
+++ b/stack/src/crashes.rs
@@ -1,5 +1,5 @@
 //! Private, bounded evidence for an exited game process, before its container
-//! disappears. This captures termination metadata/logs, not a native backtrace.
+//! disappears. Native traces are retained when the server emitted them.
 use crate::{
     config::Config,
     docker::Docker,
@@ -24,6 +24,41 @@ fn number(value: Option<&Value>) -> Option<i32> {
         _ => None,
     }
 }
+// Container logs survive `docker start`. Classify only this process's records,
+// or a later clean stop can be mistaken for an earlier captured crash.
+fn current_log(log: &str, started: Option<&str>) -> String {
+    let Some(started) = started.filter(|s| s.len() >= 20 && s.ends_with('Z')) else {
+        return log.to_string();
+    };
+    let mut current = true;
+    let mut output = String::new();
+    for line in log.lines() {
+        if let Some((stamp, _)) = line.split_once(' ') {
+            if stamp.len() >= 20 && stamp.ends_with('Z') && stamp.as_bytes().get(10) == Some(&b'T')
+            {
+                // Compare seconds first, then fractional digits normalized to
+                // nanoseconds (engine timestamps may omit the fraction).
+                let key = |value: &str| {
+                    let mut value = value.trim_end_matches('Z').to_string();
+                    if value.len() == 19 {
+                        value.push('.');
+                    }
+                    while value.len() < 29 {
+                        value.push('0');
+                    }
+                    value
+                };
+                current = key(stamp) >= key(started);
+            }
+        }
+        if current {
+            output.push_str(line);
+            output.push('\n');
+        }
+    }
+    output
+}
+
 fn reason(state: &Value, log: &str) -> Option<&'static str> {
     if !matches!(state.str("Status"), Some("exited" | "dead")) {
         return None;
@@ -156,6 +191,7 @@ pub fn capture(cfg: &Config, dk: &Docker, name: &str) -> Result<Option<String>, 
     let log = dk
         .diagnostic_output(&["logs", "-t", "--tail", "400", id], LOG_LIMIT)
         .unwrap_or_else(|_| "[Log unavailable: diagnostic command failed or timed out]".into());
+    let log = current_log(&log, state.str("StartedAt"));
     let Some(reason) = reason(state, &log) else {
         return Ok(None);
     };
@@ -236,6 +272,36 @@ pub fn capture(cfg: &Config, dk: &Docker, name: &str) -> Result<Option<String>, 
             );
         }
     }
+    // Whitelist operational context; never dump settings or client selections,
+    // which may acquire private fields as hosting features evolve.
+    if let Ok(settings) = crate::registration::settings(&cfg.state) {
+        report.push_str("\nCapture-time settings (not necessarily fault-time settings):\n");
+        for key in [
+            "population_enable",
+            "population_max",
+            "population_density",
+            "prerenewal",
+        ] {
+            match settings.get(key) {
+                Some(Value::Bool(v)) => report.push_str(&format!("{key}: {v}\n")),
+                Some(Value::Number(v)) if v.is_finite() => {
+                    report.push_str(&format!("{key}: {v}\n"))
+                }
+                _ => {}
+            }
+        }
+    }
+    let packet = include_str!("../../scripts/bootstrap.sh")
+        .lines()
+        .find_map(|line| line.strip_prefix("PACKETVER="))
+        .filter(|value| value.bytes().all(|c| c.is_ascii_digit()))
+        .unwrap_or("unknown");
+    report.push_str(&format!("Compiled packet version: {packet}\n"));
+    if let Ok(overlay) = fs::read_to_string(cfg.state.join("assets/overlay.id")) {
+        if overlay.len() <= 128 && overlay.trim().bytes().all(|c| c.is_ascii_hexdigit()) {
+            report.push_str(&format!("Capture-time asset overlay: {}\n", overlay.trim()));
+        }
+    }
     report = redact(cfg, clean(&report))?;
     if report.len() as u64 > MAX_REPORT {
         return Err("Crash evidence exceeds its size limit".into());
@@ -297,6 +363,17 @@ mod tests {
             reason(&json::parse("{\"Status\":\"exited\"}").unwrap(), ""),
             Some("unknown-termination")
         );
+    }
+    #[test]
+    fn retained_faults_do_not_reclassify_a_later_clean_stop() {
+        let log = "2026-09-07T01:00:00.000000001Z Received a crash signal\nold frame\n2026-09-07T02:00:00Z Finished\n";
+        let current = current_log(log, Some("2026-09-07T02:00:00.000000000Z"));
+        assert!(!current.contains("crash signal"));
+        assert!(!current.contains("old frame"));
+        assert!(current.contains("Finished"));
+        let state = json::parse("{\"Status\":\"exited\",\"ExitCode\":0}").unwrap();
+        assert_eq!(reason(&state, &current), None);
+        assert!(current_log(log, None).contains("crash signal"));
     }
     #[test]
     fn strips_terminal_control_sequences() {

--- a/tests/crash-evidence.test.cjs
+++ b/tests/crash-evidence.test.cjs
@@ -53,6 +53,8 @@ test('compiled collector captures abnormal exits privately, redacts secrets, ded
     assert.ok(latest.length < 1024 * 1024); assert.match(latest, /final fault marker/);
     state.StartedAt = '2026-09-07T04:00:00Z'; state.OOMKilled = false; state.ExitCode = 0; writeInspect();
     result = run(); assert.equal(result.status, 0, result.stderr); assert.equal(files().length, 2);
+    fs.writeFileSync(path.join(root, 'map.log'), '2026-09-07T01:00:00.000000000Z Received a crash signal\nold trace\n2026-09-07T04:00:01Z Finished\n');
+    result = run(); assert.equal(result.status, 0, result.stderr); assert.equal(files().length, 2);
     state.StartedAt = '2026-09-07T05:00:00Z'; state.ExitCode = 139; writeInspect();
     fs.writeFileSync(path.join(root, 'map.log'), 'RAGNAROK_CRASH_TRACE v1 signal=0xb\nRAGNAROK_CRASH_FRAME index=0x0 pc=0x42 main_offset=0x42 function=original_fault+0x1\nRAGNAROK_CRASH_TRACE_END partial\n');
     result = run(); assert.equal(result.status, 0, result.stderr); assert.equal(files().length, 3);

--- a/tests/crash-monitor.test.cjs
+++ b/tests/crash-monitor.test.cjs
@@ -29,3 +29,31 @@ test('monitor retries failures without logging raw errors or repeated noise', as
   monitor.start(); const timer = monitor.timer; monitor.start();
   assert.equal(monitor.timer, timer); monitor.stop(); assert.equal(monitor.timer, null);
 });
+
+
+test('a retained incident notifies recovery once per collection only while still owned', async () => {
+  let active = true;
+  const recovered = [];
+  let reply = 'ragnarok-map stopped unexpectedly; private evidence saved at /private/report.log\n';
+  const monitor = new CrashMonitor({ active: () => active, log: () => {},
+    onCrash: services => recovered.push(services), collect: async () => reply });
+  await monitor.tick();
+  assert.deepEqual(recovered, [['map']]);
+  reply = ''; await monitor.tick();
+  assert.equal(recovered.length, 1);
+  monitor.collect = async () => { active = false; return 'ragnarok-map stopped unexpectedly; private evidence saved at /private/late.log'; };
+  await monitor.tick();
+  assert.equal(recovered.length, 1);
+});
+
+
+test('an old collection cannot replace the UI of a new asset launch', async () => {
+  let owner = 'first', notify = 0;
+  const monitor = new CrashMonitor({ active: () => owner, log: () => {},
+    onCrash: () => notify++, collect: async () => {
+      owner = 'replacement';
+      return 'ragnarok-map stopped unexpectedly; private evidence saved at /private/old.log';
+    } });
+  await monitor.tick();
+  assert.equal(notify, 0);
+});

--- a/tests/diagnostics/verify-base-sp.py
+++ b/tests/diagnostics/verify-base-sp.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""UBSan reduction of the actual pinned base-SP function and boundary inputs."""
+import os, pathlib, subprocess, sys, tempfile
+source = (pathlib.Path(sys.argv[1]) / 'src/map/pc.cpp').read_text()
+start = source.index('uint32 JobDatabase::calc_basesp(')
+end = source.index('\n}\n', start) + 3
+function = source[start:end]
+with tempfile.TemporaryDirectory(prefix='ro-base-sp-') as directory:
+    root = pathlib.Path(directory)
+    (root / 'check.cpp').write_text('''#include <cstdint>
+#include <climits>
+#include <cmath>
+#include <memory>
+#include <cassert>
+using uint16=uint16_t; using uint32=uint32_t; using uint64=uint64_t;
+constexpr uint64 MAPID_FIRSTMASK=255, MAPID_NINJA=1, MAPID_GUNSLINGER=2, MAPID_SUMMONER=3;
+uint64 pc_jobid2mapid(uint32 job) { return job; }
+struct s_job_info { uint32 job_id=MAPID_NINJA, sp_factor=0, sp_increase=100; };
+struct JobDatabase { uint32 calc_basesp(uint16 level, const std::shared_ptr<s_job_info>& job); };
+''' + function + '''
+int main() {
+    JobDatabase database; auto job=std::make_shared<s_job_info>();
+    assert(database.calc_basesp(10, job) == 0); // 10 + 10 - 22 = -2 before clamping
+    assert(database.calc_basesp(9, job) == 38);
+    job->job_id=0; assert(database.calc_basesp(10, job) == 20);
+    job->job_id=MAPID_SUMMONER; assert(database.calc_basesp(10, job) == 30);
+    job->sp_factor=UINT_MAX; job->sp_increase=UINT_MAX;
+    assert(database.calc_basesp(250, job) == UINT_MAX);
+}
+''')
+    subprocess.run([os.environ.get('CXX', 'clang++'), '-std=c++11', '-O1', '-fsanitize=undefined', '-fno-sanitize-recover=all', str(root/'check.cpp'), '-o', str(root/'check')], check=True)
+    result = subprocess.run([str(root/'check')], capture_output=True, text=True)
+    if '--expect-fault' in sys.argv:
+        assert result.returncode != 0 and 'outside the range of representable values' in result.stderr, result.stderr
+    else:
+        assert result.returncode == 0, result.stderr
+print('Expected negative base-SP conversion reproduced' if '--expect-fault' in sys.argv else 'Base SP normal values and unsigned bounds passed UBSan')

--- a/tests/diagnostics/verify-language.py
+++ b/tests/diagnostics/verify-language.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Compile the actual pinned language checker as a UBSan reduction.
+Usage: verify-language.py /path/to/rathena [--expect-fault]
+"""
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+
+root = pathlib.Path(sys.argv[1])
+source = (root / 'src/common/msg_conf.cpp').read_text()
+function = source[source.index('int32 msg_checklangtype('):].strip()
+assert function.endswith('}') and function.count('int32 msg_checklangtype(') == 1
+header = (root / 'src/common/msg_conf.hpp').read_text()
+enum = header[header.index('enum lang_types {'):header.index('};') + 2]
+with tempfile.TemporaryDirectory(prefix='ro-language-') as temp:
+    path = pathlib.Path(temp)
+    (path / 'check.cpp').write_text('''#include <cstdint>
+#include <climits>
+#include <cassert>
+using int32 = int32_t; using uint16 = uint16_t;
+#define ShowDebug(...) ((void)0)
+''' + enum + '\n' + function + '''
+int main() {
+    assert(msg_checklangtype(0, false) == 1);
+    for (int lang = 1; lang <= 9; ++lang)
+        assert(msg_checklangtype(lang, false) == ((LANG_ENABLE & (1u << (lang-1))) ? 1 : -2));
+    for (int lang : {INT_MIN, -1, 10, 16, 17, 31, 32, INT_MAX})
+        assert(msg_checklangtype(lang, false) == -1);
+}
+'''.replace('int main()', '#include <initializer_list>\nint main()'))
+    for mask in ['0', '0x1ff', '0x101']:
+        subprocess.run([os.environ.get('CXX', 'clang++'), '-std=c++11', '-O1',
+            '-fsanitize=undefined', '-fno-sanitize-recover=all', '-DLANG_ENABLE=' + mask,
+            str(path / 'check.cpp'), '-o', str(path / 'check')], check=True)
+        result = subprocess.run([str(path / 'check')], capture_output=True, text=True)
+        if '--expect-fault' in sys.argv:
+            assert result.returncode != 0 and 'shift exponent -1 is negative' in result.stderr, result.stderr
+        else:
+            assert result.returncode == 0, result.stderr
+print('Expected English shift fault reproduced' if '--expect-fault' in sys.argv else 'English, all languages, masks and invalid bounds passed UBSan')

--- a/tests/diagnostics/verify-skill-level.py
+++ b/tests/diagnostics/verify-skill-level.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""UBSan reduction of the actual skill-level macro used at character login."""
+import os, pathlib, subprocess, sys, tempfile
+source = (pathlib.Path(sys.argv[1]) / 'src/map/skill.cpp').read_text()
+start = source.index('#define skill_get_lv(')
+end = source.index('} while(0)', start) + len('} while(0)')
+macro = source[start:end]
+with tempfile.TemporaryDirectory(prefix='ro-skill-level-') as directory:
+    root = pathlib.Path(directory)
+    (root/'check.cpp').write_text('''#include <cstdint>
+#include <algorithm>
+#include <cassert>
+using int32=int32_t; using uint16=uint16_t;
+#define MAX_SKILL_LEVEL 13
+#define min(a,b) std::min<int32>(a,b)
+bool skill_check(uint16 id) { return id == 1; }
+''' + macro + '''
+int32 get(uint16 id, uint16 level) {
+    int32 table[MAX_SKILL_LEVEL] = {1,2,3,4,5,6,7,8,9,10,11,12,13};
+    skill_get_lv(id, level, table);
+}
+int main() {
+    assert(get(1,0) == 0);
+    assert(get(0,0) == 0); assert(get(0,1) == 0);
+    for (uint16 level=1; level<=MAX_SKILL_LEVEL; ++level) assert(get(1,level) == level);
+    assert(get(1,14) == 14); assert(get(1,15) == 15);
+}
+''')
+    subprocess.run([os.environ.get('CXX', 'clang++'), '-std=c++11', '-O1', '-fsanitize=undefined', '-fno-sanitize-recover=all', str(root/'check.cpp'), '-o', str(root/'check')], check=True)
+    result = subprocess.run([str(root/'check')], capture_output=True, text=True)
+    if '--expect-fault' in sys.argv:
+        assert result.returncode != 0 and 'index -1 out of bounds' in result.stderr, result.stderr
+    else:
+        assert result.returncode == 0, result.stderr
+print('Expected unlearned skill index fault reproduced' if '--expect-fault' in sys.argv else 'Unlearned, invalid, stored and extrapolated skill levels passed UBSan')

--- a/tests/diagnostics/verify-weapon-bounds.py
+++ b/tests/diagnostics/verify-weapon-bounds.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Exercise actual weapon declarations, bonus setters and Pre-Renewal status read."""
+import os, pathlib, re, subprocess, sys, tempfile
+root=pathlib.Path(sys.argv[1])/'src/map'
+hpp=(root/'pc.hpp').read_text(); pc=(root/'pc.cpp').read_text(); status=(root/'status.cpp').read_text()
+enum=re.search(r'enum weapon_type : uint8 \{.*?\n\};',hpp,re.S).group()
+arrays='\n'.join(re.findall(r'int32 weapon_(?:atk|damage_rate)\[[^\]]+\];',hpp))
+start=pc.index('\tcase SP_WEAPON_ATK:'); end=pc.index('\tcase SP_CRITICAL_ADDRACE:',start)
+setter=pc[start:end]
+start=status.index('\tif (sd->status.weapon < MAX_WEAPON_TYPE && sd->indexed_bonus.weapon_atk')
+end=status.index('\n',status.index('base_status->batk +=',start))
+reader=status[start:end]
+program='''#include <cstdint>
+#include <cassert>
+#include <climits>
+using uint8=uint8_t; using int32=int32_t;
+'''+enum+'''
+struct Player { struct { int weapon=0; } status; struct { int lr_flag=0; } state; struct {'''+arrays+'''} indexed_bonus{}; };
+struct Status { int batk=0; };
+int read(Player* sd) { Status value; auto base_status=&value;
+'''+reader+'''
+return value.batk; }
+enum {SP_WEAPON_ATK, SP_WEAPON_DAMAGE_RATE, LR_FLAG_ARROW};
+void bonus(Player* sd, int type, int type2, int val) { switch(type) {
+'''+setter+'''
+} }
+int main() {
+ Player player; player.status.weapon=W_KATAR; assert(read(&player)==0);
+ for(int weapon=0; weapon<MAX_WEAPON_TYPE; weapon++) {
+  player.status.weapon=weapon; bonus(&player,SP_WEAPON_ATK,weapon,3); bonus(&player,SP_WEAPON_DAMAGE_RATE,weapon,4);
+  assert(read(&player)==3); assert(player.indexed_bonus.weapon_damage_rate[weapon]==4);
+ }
+ for(int invalid : {-1, MAX_WEAPON_TYPE, INT_MAX}) {
+  bonus(&player,SP_WEAPON_ATK,invalid,90); bonus(&player,SP_WEAPON_DAMAGE_RATE,invalid,90);
+ }
+ player.status.weapon=W_KATAR; assert(read(&player)==3);
+}
+'''
+program='#include <initializer_list>\n'+program.replace('{-1, MAX_WEAPON_TYPE, INT_MAX}', '{-1, static_cast<int>(MAX_WEAPON_TYPE), INT_MAX}')
+with tempfile.TemporaryDirectory(prefix='ro-weapon-bounds-') as temporary:
+ folder=pathlib.Path(temporary); (folder/'check.cpp').write_text(program)
+ subprocess.run([os.environ.get('CXX','clang++'),'-std=c++11','-O1','-fsanitize=undefined','-fno-sanitize-recover=all',str(folder/'check.cpp'),'-o',str(folder/'check')],check=True)
+ result=subprocess.run([str(folder/'check')],capture_output=True,text=True)
+ if '--expect-fault' in sys.argv:
+  assert result.returncode and 'index 16 out of bounds' in result.stderr,result.stderr
+ else: assert result.returncode==0,result.stderr
+print('Original weapon index 16 fault reproduced' if '--expect-fault' in sys.argv else 'All weapon types and invalid bonus indices passed UBSan')

--- a/tests/e2e/map-crash-stress.cjs
+++ b/tests/e2e/map-crash-stress.cjs
@@ -219,9 +219,16 @@ async function main() {
           await expect.poll(async () => (await snapshot(game)).map, { timeout: 60000 }).toMatch(/^prontera/);
           await expect.poll(async () => (await snapshot(game)).input.canMove).toBe(true);
           if (population) {
-            await command('@populate stats', 'Active / created / errors');
-            row.populationStats = await chatText();
-            if (!/Active \/ created \/ errors\s*:\s*[1-9]/.test(row.populationStats)) { await healthy(); throw Error('Population did not actually spawn'); }
+            // Demand-driven population fills on a timer after the player
+            // arrives. A fast login can legitimately see zero before its
+            // first tick. Require a positive count, checking real faults on
+            // every retry instead of treating that first zero as a crash.
+            await expect.poll(async () => {
+              await healthy();
+              await command('@populate stats', 'Active / created / errors');
+              row.populationStats = await chatText();
+              return /Active \/ created \/ errors\s*:\s*[1-9]/.test(row.populationStats);
+            }, { timeout: 30000, intervals: [1000], message: 'Population must actually spawn' }).toBe(true);
           }
           await command('@warp prt_fild08 170 200');
           await expect.poll(async () => (await snapshot(game)).map, { timeout: 60000 }).toMatch(/^prt_fild08/);

--- a/tests/e2e/map-crash-stress.cjs
+++ b/tests/e2e/map-crash-stress.cjs
@@ -221,7 +221,7 @@ async function main() {
           if (population) {
             await command('@populate stats', 'Active / created / errors');
             row.populationStats = await chatText();
-            if (!/Active \/ created \/ errors\s*:\s*[1-9]/.test(row.populationStats)) throw Error('Population did not actually spawn');
+            if (!/Active \/ created \/ errors\s*:\s*[1-9]/.test(row.populationStats)) { await healthy(); throw Error('Population did not actually spawn'); }
           }
           await command('@warp prt_fild08 170 200');
           await expect.poll(async () => (await snapshot(game)).map, { timeout: 60000 }).toMatch(/^prt_fild08/);

--- a/tests/e2e/map-crash-stress.cjs
+++ b/tests/e2e/map-crash-stress.cjs
@@ -1,4 +1,4 @@
-// Opt-in real Settings/roBrowser mandatory hosting guard acceptance. Owns one stopped disposable
+// Opt-in real rAthena reload/logout and server-recovery acceptance. Owns one stopped disposable
 // world for the duration; never reads or writes a player's save.
 const fs = require('node:fs');
 const path = require('node:path');
@@ -18,6 +18,10 @@ const selected = JSON.parse(fs.readFileSync(process.env.RO_E2E_CLIENT_JSON));
 const state = path.join(world, 'state');
 const settingsPath = path.join(state, 'settings.json');
 const settings = fs.existsSync(settingsPath) ? fs.readFileSync(settingsPath) : null;
+const modSelection = Object.fromEntries(['enabled.txt', 'disabled.txt'].map(name => {
+  const file = path.join(state, 'mods', name);
+  return [name, fs.existsSync(file) ? fs.readFileSync(file) : null];
+}));
 if (fs.existsSync(path.join(state, 'prerenewal'))) throw Error('Start with renewal selected');
 const credentials = Object.fromEntries(['renewal', 'prerenewal'].map(era => [era,
   JSON.parse(fs.readFileSync(path.join(world, era === 'renewal'
@@ -33,6 +37,9 @@ fs.writeFileSync(path.join(recovery, 'selection.json'), JSON.stringify({
   clientExisted: false, settingsExisted: settings !== null, prerenewalExisted: false,
 }), { mode: 0o600 });
 if (settings) fs.writeFileSync(path.join(recovery, 'settings.json'), settings, { mode: 0o600 });
+for (const [name, bytes] of Object.entries(modSelection)) {
+  if (bytes !== null) fs.writeFileSync(path.join(recovery, name), bytes, { mode: 0o600 });
+}
 const report = { checks: [], screens: [], pageErrors: [], startedAt: new Date().toISOString() };
 const serviceSecrets = [];
 const env = { ...process.env, RAGNAROK_OFFLINE_HOME: world,
@@ -86,6 +93,10 @@ async function main() {
     owner = await app.firstWindow();
     await expect(owner.locator('body')).toContainText('Waiting for your client', { timeout: 30000 });
     const boot = owner;
+    // A server disconnect can open roBrowser's unload confirmation while the
+    // shell navigates to recovery. Own the dialog so Playwright does not race
+    // its automatic handler against that navigation.
+    boot.on('dialog', dialog => dialog.accept().catch(() => {}));
     await invoke('open_settings');
     await expect.poll(() => app.windows().some(p => p.url().endsWith('settings.html'))).toBe(true);
     const page = app.windows().find(p => p.url().endsWith('settings.html'));
@@ -93,6 +104,10 @@ async function main() {
     // in Settings and complete the actual setup Continue handler instead of
     // starting services behind an abandoned "Waiting for your client" page.
     owner = page;
+    if (process.env.RO_E2E_STRESS_MODS === 'off') {
+      for (const mod of await invoke('list_mods')) await invoke('set_mod_enabled', { name: mod.name, enabled: false });
+    }
+    report.mods = await invoke('list_mods');
     await expect.poll(() => app.windows().some(p => p.url().endsWith('setup.html'))).toBe(true);
     const setup = app.windows().find(p => p.url().endsWith('setup.html'));
     await app.evaluate(({ dialog }) => { globalThis.roOriginalOpenDialog = dialog.showOpenDialog; });
@@ -161,12 +176,14 @@ async function main() {
       await game.locator('#slot0').dblclick();
       await expect.poll(async () => (await snapshot(game)).input.canMove, { timeout: 90000 }).toBe(true);
     }
+    const chatText = () => game.locator('#ChatBox').evaluate(host => host.shadowRoot?.textContent || host.textContent);
     async function command(value, acknowledgement) {
+      const previous = acknowledgement ? (await chatText()).split(acknowledgement).length : 0;
       await game.keyboard.press('Enter');
       const chat = game.locator('.input-chatbox');
       await chat.fill(value);
       await game.keyboard.press('Enter');
-      if (acknowledgement) await expect(game.locator('#ChatBox')).toContainText(acknowledgement, { timeout: 60000 });
+      if (acknowledgement) await expect.poll(async () => (await chatText()).split(acknowledgement).length, { timeout: 60000 }).toBeGreaterThan(previous);
       await game.locator('.input-chatbox').blur();
     }
     async function healthy() {
@@ -203,8 +220,16 @@ async function main() {
           await expect.poll(async () => (await snapshot(game)).input.canMove).toBe(true);
           if (population) {
             await command('@populate stats', 'Active / created / errors');
-            row.populationStats = await game.locator('#ChatBox').evaluate(host => host.shadowRoot?.textContent || host.textContent);
+            row.populationStats = await chatText();
             if (!/Active \/ created \/ errors\s*:\s*[1-9]/.test(row.populationStats)) throw Error('Population did not actually spawn');
+          }
+          await command('@warp prt_fild08 170 200');
+          await expect.poll(async () => (await snapshot(game)).map, { timeout: 60000 }).toMatch(/^prt_fild08/);
+          await expect.poll(async () => (await snapshot(game)).input.canMove).toBe(true);
+          if (population) {
+            await command('@populate stop', 'Population engine stopped and cleaned up');
+            await command('@populate 100 prt_fild08', 'Population PCs spawned:');
+            row.events.push('population stop and 100-shell spawn');
           }
           await command('@reloadscript', 'Scripts have been reloaded.');
           await healthy();
@@ -230,6 +255,10 @@ async function main() {
   } catch (error) {
     failure = error;
     report.failure = redact(error);
+    for (const service of ['ragnarok-map', 'ragnarok-char', 'ragnarok-login']) {
+      const logs = docker(['logs', '--tail', '200', service]);
+      if (logs.status === 0) fs.writeFileSync(path.join(out, service + '-failure.log'), redact(logs.stdout + logs.stderr), { mode: 0o600 });
+    }
     console.error('Acceptance failed:', report.failure);
     if (game && !game.isClosed()) await game.screenshot({ path: path.join(out, 'failed-game.png'), mask: [game.locator('input, textarea')] }).catch(() => {});
     // Capture the failing UI before cleanup can close it. Mask form fields;
@@ -263,6 +292,10 @@ async function main() {
       if (stopped) {
         fs.rmSync(clientPath);
         if (settings) fs.writeFileSync(settingsPath, settings); else fs.rmSync(settingsPath, { force: true });
+        for (const [name, bytes] of Object.entries(modSelection)) {
+          const file = path.join(state, 'mods', name);
+          if (bytes !== null) fs.writeFileSync(file, bytes); else fs.rmSync(file, { force: true });
+        }
         fs.rmSync(path.join(state, 'prerenewal'), { force: true });
       }
       report.finishedAt = new Date().toISOString();

--- a/tests/e2e/map-crash-stress.cjs
+++ b/tests/e2e/map-crash-stress.cjs
@@ -45,16 +45,6 @@ function docker(args, input) {
     { env: { ...env, DOCKER_HOST: host }, encoding: 'utf8', input, timeout: 120000, maxBuffer: 1024 * 1024 });
   return result;
 }
-function query(sql, legacy = false, success = true) {
-  const auth = legacy ? ['-uroot', '-pragnarok'] : ['--defaults-extra-file=/run/ragnarok-private/root.cnf'];
-  const result = docker(['exec', '-i', 'ragnarok-db', 'mariadb', ...auth, '--protocol=TCP', '-h127.0.0.1', '--batch', '--skip-column-names', 'ragnarok'], sql);
-  if (success && result.status !== 0) throw Error('Private test database query failed; output suppressed.');
-  if (!success && result.status === 0) throw Error('Known legacy SQL root password was unexpectedly accepted.');
-  return result.stdout.trim();
-}
-function fingerprint(legacy) {
-  return query("SET SESSION group_concat_max_len=1048576; SELECT SHA2(GROUP_CONCAT(CONCAT_WS(':',account_id,HEX(userid),HEX(user_pass),sex,group_id,state) ORDER BY account_id SEPARATOR '|'),256) FROM login WHERE sex<>'S'; SELECT SHA2(GROUP_CONCAT(CONCAT_WS(':',char_id,account_id,HEX(name)) ORDER BY char_id SEPARATOR '|'),256) FROM `char`;", legacy);
-}
 function journal(era) {
   const file = path.join(state, 'private/service-credentials', era, 'credentials.json');
   const body = fs.readFileSync(file, 'utf8');
@@ -89,7 +79,7 @@ async function main() {
   const app = await _electron.launch({ executablePath: require('electron'),
     args: [path.join(work, 'electron/main.js'), '--user-data-dir=' + path.join(world, 'map-stress-electron-profile')],
     env, cwd: work, timeout: 45000 });
-  let owner, browser;
+  let owner, browser, game;
   let failure;
   const invoke = (name, args) => owner.evaluate(({ name, args }) => window.__ELECTRON__.core.invoke(name, args), { name, args });
   try {
@@ -124,7 +114,10 @@ async function main() {
       });
     }
     await setup.getByRole('button', { name: 'Continue', exact: true }).click();
-    await expect(boot).toHaveURL(/^http:\/\/127\.0\.0\.1:3338\//, { timeout: 240000 });
+    await Promise.race([
+      boot.waitForURL(/^http:\/\/127\.0\.0\.1:3338\//, { timeout: 240000 }),
+      boot.locator('#fail').waitFor({ state: 'visible', timeout: 240000 }).then(async () => { throw Error(await boot.locator('#fail').textContent()); }),
+    ]);
     // The desktop skin uses the native WinLogin inputs; accessible Account
     // labels belong to the mobile adapter exercised separately below.
     await expect(boot.locator('#WinLogin .user')).toBeVisible({ timeout: 90000 });
@@ -138,12 +131,24 @@ async function main() {
         win.setTitle('Ragnarok Offline — disposable acceptance test');
       }
     });
+    if (process.env.RO_E2E_RECOVERY_SMOKE === '1') {
+      const meta = JSON.parse(docker(['inspect', 'ragnarok-map']).stdout)[0];
+      if (docker(['kill', '--signal', '11', 'ragnarok-map']).status !== 0) throw Error('Owned map fault injection failed');
+      await expect(boot.locator('#fail')).toContainText('Map server stopped unexpectedly', { timeout: 45000 });
+      await expect(boot.locator('#reports')).toBeVisible();
+      await boot.screenshot({ path: path.join(out, 'map-recovery.png') });
+      await boot.locator('#retry').click();
+      await expect(boot.locator('#WinLogin .user')).toBeVisible({ timeout: 120000 });
+      await verifyWorld();
+      report.checks.push({ injectedSignal: 11, container: meta.Id, image: meta.Image, recoveryAndRetry: true });
+      console.log('Actual map fault produced recovery UI and Retry reached native login:', out);
+    } else {
     page.setDefaultTimeout(240000);
     browser = await chromium.launch({ headless: true });
     report.browser = browser.version();
     report.requestedImage = process.env.RAGNAROKMAC_IMAGE || 'normal runtime image';
     const context = await browser.newContext({ viewport: { width: 1440, height: 900 } });
-    const game = await context.newPage();
+    game = await context.newPage();
     game.setDefaultTimeout(60000);
     game.on('pageerror', error => report.pageErrors.push(error.message));
     const cycles = Number(process.env.RO_E2E_STRESS_CYCLES || 5);
@@ -221,10 +226,12 @@ async function main() {
       }
     }
     await game.goto('about:blank');
+    }
   } catch (error) {
     failure = error;
     report.failure = redact(error);
     console.error('Acceptance failed:', report.failure);
+    if (game && !game.isClosed()) await game.screenshot({ path: path.join(out, 'failed-game.png'), mask: [game.locator('input, textarea')] }).catch(() => {});
     // Capture the failing UI before cleanup can close it. Mask form fields;
     // no account or connector secrets should enter screenshots.
     for (const [index, page] of app.windows().entries()) {

--- a/tests/e2e/map-crash-stress.cjs
+++ b/tests/e2e/map-crash-stress.cjs
@@ -1,0 +1,270 @@
+// Opt-in real Settings/roBrowser mandatory hosting guard acceptance. Owns one stopped disposable
+// world for the duration; never reads or writes a player's save.
+const fs = require('node:fs');
+const path = require('node:path');
+const net = require('node:net');
+const { spawnSync } = require('node:child_process');
+const { _electron, chromium, devices, expect } = require('@playwright/test');
+const { verifyWorld, snapshot } = require('./support.cjs');
+const work = path.resolve(__dirname, '../..');
+if (!process.env.RO_E2E_WORLD || !process.env.RO_E2E_CLIENT_JSON)
+  throw Error('Set RO_E2E_WORLD and RO_E2E_CLIENT_JSON; stop the disposable world first');
+const world = fs.realpathSync(process.env.RO_E2E_WORLD);
+if (JSON.parse(fs.readFileSync(path.join(world, '.ragnarok-e2e.json'))).disposable !== true)
+  throw Error('Not a disposable world');
+const clientPath = path.join(world, 'client.json');
+if (fs.existsSync(clientPath)) throw Error('Fixture requires no existing client.json');
+const selected = JSON.parse(fs.readFileSync(process.env.RO_E2E_CLIENT_JSON));
+const state = path.join(world, 'state');
+const settingsPath = path.join(state, 'settings.json');
+const settings = fs.existsSync(settingsPath) ? fs.readFileSync(settingsPath) : null;
+if (fs.existsSync(path.join(state, 'prerenewal'))) throw Error('Start with renewal selected');
+const credentials = Object.fromEntries(['renewal', 'prerenewal'].map(era => [era,
+  JSON.parse(fs.readFileSync(path.join(world, era === 'renewal'
+    ? 'account-test-credentials.json' : 'prerenewal-account-test-credentials.json'))),
+]));
+const out = path.join(world, 'account-tests', 'map-stress-' + Date.now());
+fs.mkdirSync(out, { recursive: true });
+// Keep a private recovery copy even if the app or test process exits before
+// finally runs. Never copy account/service credentials into the report.
+const recovery = path.join(out, 'recovery');
+fs.mkdirSync(recovery, { mode: 0o700 });
+fs.writeFileSync(path.join(recovery, 'selection.json'), JSON.stringify({
+  clientExisted: false, settingsExisted: settings !== null, prerenewalExisted: false,
+}), { mode: 0o600 });
+if (settings) fs.writeFileSync(path.join(recovery, 'settings.json'), settings, { mode: 0o600 });
+const report = { checks: [], screens: [], pageErrors: [], startedAt: new Date().toISOString() };
+const serviceSecrets = [];
+const env = { ...process.env, RAGNAROK_OFFLINE_HOME: world,
+  RAGNAROKMAC_ROOT: path.join(world, 'runtime'), RAGNAROKMAC_STATE: state,
+  NEBULA_HOME: path.join(world, 'nebula') };
+function docker(args, input) {
+  const socket = path.join(world, 'nebula/run/docker.sock');
+  const host = process.platform === 'win32' ? 'tcp://127.0.0.1:' + fs.readFileSync(socket, 'utf8').trim() : 'unix://' + socket;
+  const result = spawnSync(path.join(world, 'runtime/bin/docker-slim' + (process.platform === 'win32' ? '.exe' : '')), args,
+    { env: { ...env, DOCKER_HOST: host }, encoding: 'utf8', input, timeout: 120000, maxBuffer: 1024 * 1024 });
+  return result;
+}
+function query(sql, legacy = false, success = true) {
+  const auth = legacy ? ['-uroot', '-pragnarok'] : ['--defaults-extra-file=/run/ragnarok-private/root.cnf'];
+  const result = docker(['exec', '-i', 'ragnarok-db', 'mariadb', ...auth, '--protocol=TCP', '-h127.0.0.1', '--batch', '--skip-column-names', 'ragnarok'], sql);
+  if (success && result.status !== 0) throw Error('Private test database query failed; output suppressed.');
+  if (!success && result.status === 0) throw Error('Known legacy SQL root password was unexpectedly accepted.');
+  return result.stdout.trim();
+}
+function fingerprint(legacy) {
+  return query("SET SESSION group_concat_max_len=1048576; SELECT SHA2(GROUP_CONCAT(CONCAT_WS(':',account_id,HEX(userid),HEX(user_pass),sex,group_id,state) ORDER BY account_id SEPARATOR '|'),256) FROM login WHERE sex<>'S'; SELECT SHA2(GROUP_CONCAT(CONCAT_WS(':',char_id,account_id,HEX(name)) ORDER BY char_id SEPARATOR '|'),256) FROM `char`;", legacy);
+}
+function journal(era) {
+  const file = path.join(state, 'private/service-credentials', era, 'credentials.json');
+  const body = fs.readFileSync(file, 'utf8');
+  const value = JSON.parse(body);
+  serviceSecrets.push(value.root, value.database, value.interserver);
+  if (value.era !== era || !/^[a-f0-9]{64}$/.test(value.root) || !/^[a-f0-9]{64}$/.test(value.database)
+      || !/^[A-Za-z0-9_-]{23}$/.test(value.interserver) || value.root === value.database) throw Error('Invalid generated service credential shape');
+  return body;
+}
+
+function redact(error) {
+  let message = String(error.message || error);
+  for (const era of ['renewal', 'prerenewal']) { try { journal(era); } catch {} }
+  for (const password of [...Object.values(credentials).map(c => c.password), ...serviceSecrets]) {
+    if (password) message = message.split(password).join('[redacted]');
+  }
+  return message;
+}
+
+async function freePorts() {
+  for (const port of [3338, 6900, 6121, 5121, 7462]) {
+    await new Promise((resolve, reject) => {
+      const socket = net.connect(port, '127.0.0.1');
+      socket.once('connect', () => { socket.destroy(); reject(Error(`Port ${port} is occupied; stop the other host first`)); });
+      socket.once('error', e => e.code === 'ECONNREFUSED' ? resolve() : reject(e));
+      socket.setTimeout(1000, () => { socket.destroy(); reject(Error(`Port ${port} did not refuse connections`)); });
+    });
+  }
+}
+async function main() {
+  await freePorts();
+  const app = await _electron.launch({ executablePath: require('electron'),
+    args: [path.join(work, 'electron/main.js'), '--user-data-dir=' + path.join(world, 'map-stress-electron-profile')],
+    env, cwd: work, timeout: 45000 });
+  let owner, browser;
+  let failure;
+  const invoke = (name, args) => owner.evaluate(({ name, args }) => window.__ELECTRON__.core.invoke(name, args), { name, args });
+  try {
+    owner = await app.firstWindow();
+    await expect(owner.locator('body')).toContainText('Waiting for your client', { timeout: 30000 });
+    const boot = owner;
+    await invoke('open_settings');
+    await expect.poll(() => app.windows().some(p => p.url().endsWith('settings.html'))).toBe(true);
+    const page = app.windows().find(p => p.url().endsWith('settings.html'));
+    // The game page loses privileged IPC once it navigates. Keep owner actions
+    // in Settings and complete the actual setup Continue handler instead of
+    // starting services behind an abandoned "Waiting for your client" page.
+    owner = page;
+    await expect.poll(() => app.windows().some(p => p.url().endsWith('setup.html'))).toBe(true);
+    const setup = app.windows().find(p => p.url().endsWith('setup.html'));
+    await app.evaluate(({ dialog }) => { globalThis.roOriginalOpenDialog = dialog.showOpenDialog; });
+    try {
+      for (const key of ['data_grf', 'rdata_grf', 'official_grf', 'bgm_dir']) {
+        if (!selected[key]) continue;
+        // Stub only the OS file picker; real setup selection, validation,
+        // save, boot reload, readiness and navigation all run unchanged.
+        await app.evaluate(({ dialog }, chosen) => {
+          dialog.showOpenDialog = async () => ({ canceled: false, filePaths: [chosen] });
+        }, selected[key]);
+        await setup.locator(`[data-pick="${key}"]`).click();
+        await expect(setup.locator('#p-' + key)).toHaveText(selected[key]);
+      }
+    } finally {
+      await app.evaluate(({ dialog }) => {
+        dialog.showOpenDialog = globalThis.roOriginalOpenDialog;
+        delete globalThis.roOriginalOpenDialog;
+      });
+    }
+    await setup.getByRole('button', { name: 'Continue', exact: true }).click();
+    await expect(boot).toHaveURL(/^http:\/\/127\.0\.0\.1:3338\//, { timeout: 240000 });
+    // The desktop skin uses the native WinLogin inputs; accessible Account
+    // labels belong to the mobile adapter exercised separately below.
+    await expect(boot.locator('#WinLogin .user')).toBeVisible({ timeout: 90000 });
+    await verifyWorld();
+    await boot.screenshot({ path: path.join(out, 'setup-completed-login.png') });
+    report.screens.push('setup-completed-login.png');
+    report.setupCompletedToNativeLogin = true;
+    console.log('Real setup Continue reached the owned desktop login screen.');
+    await app.evaluate(({ BrowserWindow }) => {
+      for (const win of BrowserWindow.getAllWindows()) {
+        win.setTitle('Ragnarok Offline — disposable acceptance test');
+      }
+    });
+    page.setDefaultTimeout(240000);
+    browser = await chromium.launch({ headless: true });
+    report.browser = browser.version();
+    report.requestedImage = process.env.RAGNAROKMAC_IMAGE || 'normal runtime image';
+    const context = await browser.newContext({ viewport: { width: 1440, height: 900 } });
+    const game = await context.newPage();
+    game.setDefaultTimeout(60000);
+    game.on('pageerror', error => report.pageErrors.push(error.message));
+    const cycles = Number(process.env.RO_E2E_STRESS_CYCLES || 5);
+    if (!Number.isInteger(cycles) || cycles < 1 || cycles > 100) throw Error('Invalid stress cycle count');
+    async function login(era) {
+      await game.goto('http://127.0.0.1:3338/');
+      await game.locator('#WinLogin .user').fill(credentials[era].account);
+      await game.locator('#WinLogin .pass').fill(credentials[era].password);
+      await game.locator('#WinLogin .connect').click();
+      await game.locator('#slot0').dblclick();
+      await expect.poll(async () => (await snapshot(game)).input.canMove, { timeout: 90000 }).toBe(true);
+    }
+    async function command(value, acknowledgement) {
+      await game.keyboard.press('Enter');
+      const chat = game.locator('.input-chatbox');
+      await chat.fill(value);
+      await game.keyboard.press('Enter');
+      if (acknowledgement) await expect(game.locator('#ChatBox')).toContainText(acknowledgement, { timeout: 60000 });
+      await game.locator('.input-chatbox').blur();
+    }
+    async function healthy() {
+      for (const service of ['ragnarok-map', 'ragnarok-char', 'ragnarok-login']) {
+        const result = docker(['inspect', service]);
+        if (result.status !== 0) throw Error('Game container inspection failed');
+        const meta = JSON.parse(result.stdout)[0];
+        const log = docker(['logs', '--tail', '150', service]);
+        const text = log.stdout + log.stderr;
+        if (meta.State.Status !== 'running' || /AddressSanitizer|runtime error:|Received a crash signal/.test(text)) {
+          fs.writeFileSync(path.join(out, service + '-fault.log'), redact(text), { mode: 0o600 });
+          report.fault = { service, container: meta.Id, image: meta.Image, state: meta.State };
+          throw Error('Real game fault detected; original evidence retained');
+        }
+      }
+    }
+    for (const era of ['prerenewal', 'renewal']) {
+      await game.goto('about:blank');
+      await page.locator(era === 'renewal' ? '#era-re' : '#era-pre').click();
+      await expect(page.locator('#era-status')).toContainText(`Switched to ${era === 'renewal' ? 'renewal' : 'pre-renewal'} in`, { timeout: 240000 });
+      await invoke('db_backup', { path: path.join(out, `before-${era}.sql`) });
+      for (const population of [false, true]) {
+        await game.goto('about:blank');
+        await invoke('save_settings', { settings: { hosting_scope: 'local', population_enable: population } });
+        await verifyWorld();
+        const meta = JSON.parse(docker(['inspect', 'ragnarok-map']).stdout)[0];
+        const row = { era, population, image: meta.Image, startedAt: new Date().toISOString(), completed: 0, events: [] };
+        report.checks.push(row);
+        for (let cycle = 0; cycle < cycles; cycle++) {
+          await login(era);
+          await healthy();
+          await command('@warp prontera 150 180');
+          await expect.poll(async () => (await snapshot(game)).map, { timeout: 60000 }).toMatch(/^prontera/);
+          await expect.poll(async () => (await snapshot(game)).input.canMove).toBe(true);
+          if (population) {
+            await command('@populate stats', 'Active / created / errors');
+            row.populationStats = await game.locator('#ChatBox').evaluate(host => host.shadowRoot?.textContent || host.textContent);
+            if (!/Active \/ created \/ errors\s*:\s*[1-9]/.test(row.populationStats)) throw Error('Population did not actually spawn');
+          }
+          await command('@reloadscript', 'Scripts have been reloaded.');
+          await healthy();
+          if (cycle % 2 === 0) {
+            await game.keyboard.press('Escape');
+            await game.locator('#Escape .charselect').click();
+            await expect(game.locator('#slot0')).toBeVisible();
+            row.events.push('native character-select logout');
+          } else {
+            await game.goto('about:blank');
+            row.events.push('abrupt page disconnect');
+          }
+          await healthy();
+          row.completed++;
+          row.finishedAt = new Date().toISOString();
+          fs.writeFileSync(path.join(out, 'report.json'), JSON.stringify(report, null, 2), { mode: 0o600 });
+          console.log('Completed real reload/logout cycle:', era, 'population=' + population, cycle + 1);
+        }
+      }
+    }
+    await game.goto('about:blank');
+  } catch (error) {
+    failure = error;
+    report.failure = redact(error);
+    console.error('Acceptance failed:', report.failure);
+    // Capture the failing UI before cleanup can close it. Mask form fields;
+    // no account or connector secrets should enter screenshots.
+    for (const [index, page] of app.windows().entries()) {
+      if (page.isClosed()) continue;
+      await page.screenshot({ path: path.join(out, `failure-${index}.png`),
+        mask: [page.locator('input, textarea')] }).catch(() => {});
+    }
+  } finally {
+    if (browser) await browser.close().catch(() => {});
+    // Use the owning shell to stop its assets before restoring selection files.
+    // If teardown fails, retain the files so a later launch sees the true state.
+    let stopped = false;
+    try {
+      if (owner && !owner.isClosed()) {
+        await invoke('assets_stop'); await invoke('stack_down');
+        await freePorts(); stopped = true;
+      }
+    } catch (error) {
+      report.cleanupFailure = redact(error);
+    }
+    finally {
+      if (stopped) await app.evaluate(({ app }) => app.exit(0)).catch(() => {});
+      else {
+        // Request the app's normal graceful teardown, never bypass it with
+        // app.exit after a failed owner IPC call. Verify ports before restore.
+        await app.close().catch(() => {});
+        try { await freePorts(); stopped = true; } catch {}
+      }
+      if (stopped) {
+        fs.rmSync(clientPath);
+        if (settings) fs.writeFileSync(settingsPath, settings); else fs.rmSync(settingsPath, { force: true });
+        fs.rmSync(path.join(state, 'prerenewal'), { force: true });
+      }
+      report.finishedAt = new Date().toISOString();
+      fs.writeFileSync(path.join(out, 'report.json'), JSON.stringify(report, null, 2));
+    }
+    if (!stopped && !failure) failure = Error('Owned teardown did not free all ports; selection files retained');
+  }
+  if (failure) throw failure;
+}
+main().catch(error => {
+  console.error(redact(error)); process.exitCode = 1;
+});

--- a/tests/e2e/sanitizer-guest.cjs
+++ b/tests/e2e/sanitizer-guest.cjs
@@ -1,0 +1,105 @@
+// Validate the diagnostic runtime in the real guest, without starting SQL or
+// rAthena. Only an explicitly marked, stopped disposable world is accepted.
+'use strict';
+const fs = require('node:fs');
+const path = require('node:path');
+const net = require('node:net');
+const crypto = require('node:crypto');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+for (const key of ['RO_E2E_WORLD', 'RO_E2E_SANITIZER_ARCHIVE', 'RO_E2E_SANITIZER_SHA256', 'RO_E2E_SANITIZER_IMAGE'])
+  if (!process.env[key]) throw Error(`Missing ${key}`);
+const world = fs.realpathSync(process.env.RO_E2E_WORLD);
+assert.equal(JSON.parse(fs.readFileSync(path.join(world, '.ragnarok-e2e.json'))).disposable, true);
+const archive = fs.realpathSync(process.env.RO_E2E_SANITIZER_ARCHIVE);
+const image = process.env.RO_E2E_SANITIZER_IMAGE;
+assert.match(image, /^ragnarokmac\/rathena-diagnostics:[a-f0-9]{40}$/);
+assert.match(process.env.RO_E2E_SANITIZER_SHA256, /^[a-f0-9]{64}$/);
+const suffix = process.platform === 'win32' ? '.exe' : '';
+const bin = path.join(world, 'runtime/bin');
+const env = { ...process.env, NEBULA_HOME: path.join(world, 'nebula') };
+const out = path.join(world, 'account-tests', 'sanitizer-guest-' + Date.now());
+fs.mkdirSync(out, { recursive: true, mode: 0o700 });
+const report = { image, checks: [], startedAt: new Date().toISOString() };
+const call = (name, args, timeout = 30000) => spawnSync(path.join(bin, name + suffix), args,
+  { env, encoding: 'utf8', timeout, maxBuffer: 2 * 1024 * 1024 });
+const dk = (args, timeout) => call('docker-slim', args, timeout);
+const pause = ms => new Promise(resolve => setTimeout(resolve, ms));
+async function freePorts() {
+  for (const port of [3338, 6900, 6121, 5121, 7462]) await new Promise((resolve, reject) => {
+    const socket = net.connect(port, '127.0.0.1');
+    socket.once('connect', () => { socket.destroy(); reject(Error(`Occupied host port ${port}`)); });
+    socket.once('error', e => e.code === 'ECONNREFUSED' ? resolve() : reject(e));
+    socket.setTimeout(5000, () => { socket.destroy(); reject(Error(`Unknown host port ${port}`)); });
+  });
+}
+async function main() {
+  const hash = crypto.createHash('sha256');
+  for await (const bytes of fs.createReadStream(archive)) hash.update(bytes);
+  report.archiveSha256 = hash.digest('hex');
+  assert.equal(report.archiveSha256, process.env.RO_E2E_SANITIZER_SHA256, 'Archive checksum mismatch');
+  await freePorts();
+  let started = false, created = false, failure;
+  const name = 'ragnarok-sanitizer-fixture';
+  try {
+    started = true;
+    assert.equal(call('nebula', ['up'], 120000).status, 0, 'Disposable VM did not start');
+    const socket = path.join(world, 'nebula/run/docker.sock');
+    env.DOCKER_HOST = process.platform === 'win32'
+      ? 'tcp://127.0.0.1:' + fs.readFileSync(socket, 'utf8').trim() : 'unix://' + socket;
+    let ready = false;
+    for (let n = 0; n < 60; n++) {
+      if (dk(['ps', '-aq']).status === 0) { ready = true; break; }
+      await pause(250);
+    }
+    assert.equal(ready, true, 'Disposable engine not ready');
+    const existing = dk(['ps', '-aq']);
+    assert.equal(existing.status, 0);
+    assert.equal(existing.stdout.trim(), '', 'Refusing a world with existing containers');
+    assert.equal(dk(['load', '-i', archive], 300000).status, 0, 'Diagnostic image import failed');
+    const createdResult = dk(['run', '-d', '--name', name, image, 'sh', '/diagnostics/verify.sh', '/tmp/fixture-evidence']);
+    assert.equal(createdResult.status, 0, 'Diagnostic fixture could not start');
+    created = true;
+    let meta;
+    for (let n = 0; n < 120; n++) {
+      const result = dk(['inspect', name]);
+      assert.equal(result.status, 0);
+      meta = JSON.parse(result.stdout)[0];
+      if (meta.State.Status === 'exited') break;
+      await pause(500);
+    }
+    const logs = dk(['logs', '--tail', '300', name]);
+    const text = logs.stdout + logs.stderr;
+    fs.writeFileSync(path.join(out, 'synthetic-faults.log'), text, { mode: 0o600 });
+    report.container = meta.Id;
+    report.imageId = meta.Image;
+    report.exitCode = meta.State.ExitCode;
+    assert.equal(meta.State.Status, 'exited', 'Fixture did not finish');
+    assert.equal(meta.State.ExitCode, 0, 'Sanitizer validation failed; see private synthetic-faults.log');
+    assert.match(text, /ASan use-after-free, UBSan overflow and original SIGSEGV source lookup passed/);
+    report.checks.push('archive checksum matched', 'real guest ASan and UBSan faults symbolized',
+      'legacy handler did not replace sanitizer SIGSEGV capture', 'no SQL or rAthena process started');
+  } catch (error) {
+    failure = error;
+    report.failure = error.message;
+  } finally {
+    if (created) {
+      const result = dk(['rm', '-f', name]);
+      if (result.status !== 0) report.cleanupFailure = 'Could not remove the owned synthetic fixture';
+    }
+    if (started && call('nebula', ['down'], 120000).status !== 0)
+      report.cleanupFailure = 'Could not stop the owned disposable VM';
+    for (let attempt = 0; attempt < 60; attempt++) {
+      try { await freePorts(); break; } catch (error) {
+        if (attempt === 59) report.cleanupFailure = error.message;
+        else await pause(250);
+      }
+    }
+    report.finishedAt = new Date().toISOString();
+    fs.writeFileSync(path.join(out, 'report.json'), JSON.stringify(report, null, 2), { mode: 0o600 });
+  }
+  if (failure) throw failure;
+  if (report.cleanupFailure) throw Error(report.cleanupFailure);
+  console.log('Real guest sanitizer validation passed. Evidence:', out);
+}
+main().catch(error => { console.error(error.message); process.exitCode = 1; });

--- a/third-party/server-fixes/0001-language-mask.patch
+++ b/third-party/server-fixes/0001-language-mask.patch
@@ -1,0 +1,17 @@
+--- a/src/common/msg_conf.cpp
++++ b/src/common/msg_conf.cpp
+@@ -130,9 +130,11 @@
+  * -2 : disable
+  */
+ int32 msg_checklangtype(int32 lang, bool display){
+-	uint16 test= (1<<(lang-1));
+-	if(!lang) return 1; //default english
+-	else if(lang < 0 || test > LANG_MAX) return -1; //false range
++	if(!lang) return 1; //default english; do not shift by -1
++	// RAGNAROKMAC: validate before shifting or narrowing the language mask.
++	if(lang < 0 || lang > 16) return -1;
++	uint16 test = static_cast<uint16>(1u << (lang - 1));
++	if(test > LANG_MAX) return -1; //false range
+ 	else if (LANG_ENABLE&test) return 1;
+ 	else if(display) {
+ 		ShowDebug("Unsupported langtype '%d'.\n",lang);

--- a/third-party/server-fixes/0002-base-sp-range.patch
+++ b/third-party/server-fixes/0002-base-sp-range.patch
@@ -1,0 +1,13 @@
+--- a/src/map/pc.cpp
++++ b/src/map/pc.cpp
+@@ -13819,6 +13819,10 @@
+ 		base_sp += floor( ( base_sp / 2 ) + 0.5 );
+ 	}
+ 
++	// RAGNAROKMAC: incomplete job tables can produce negative base SP;
++	// clamp while still floating point, before converting to unsigned.
++	if( base_sp <= 0. ) return 0;
++	if( base_sp >= static_cast<double>( UINT_MAX ) ) return UINT_MAX;
+ 	return static_cast<uint32>( base_sp );
+ }
+ 

--- a/third-party/server-fixes/0003-unlearned-skill-level.patch
+++ b/third-party/server-fixes/0003-unlearned-skill-level.patch
@@ -1,0 +1,13 @@
+--- a/src/map/skill.cpp
++++ b/src/map/skill.cpp
+@@ -160,8 +160,9 @@
+ 	return var;\
+ } while(0)
+ 
++// RAGNAROKMAC: unlearned skills have level zero; never index before the array.
+ #define skill_get_lv(id, lv, arrvar) do {\
+-	if (!skill_check(id))\
++	if (!skill_check(id) || (lv) == 0)\
+ 		return 0;\
+ 	int32 lv_idx = min(lv, MAX_SKILL_LEVEL) - 1;\
+ 	if (lv > MAX_SKILL_LEVEL && arrvar[lv_idx] > 1 && lv_idx > 1) {\

--- a/third-party/server-fixes/0004-weapon-bonus-bounds.patch
+++ b/third-party/server-fixes/0004-weapon-bonus-bounds.patch
@@ -1,0 +1,121 @@
+--- a/src/map/pc.hpp
++++ b/src/map/pc.hpp
+@@ -26,6 +26,44 @@
+ #include "status.hpp" // unit_data
+ #include "unit.hpp" // unit_data
+ #include "vending.hpp" // struct s_vending
++
++// RAGNAROKMAC: size indexed bonuses from the complete weapon enum.
++enum weapon_type : uint8 {
++	W_FIST,	//Bare hands
++	W_DAGGER,	//1
++	W_1HSWORD,	//2
++	W_2HSWORD,	//3
++	W_1HSPEAR,	//4
++	W_2HSPEAR,	//5
++	W_1HAXE,	//6
++	W_2HAXE,	//7
++	W_MACE,	//8
++	W_2HMACE,	//9 (unused)
++	W_STAFF,	//10
++	W_BOW,	//11
++	W_KNUCKLE,	//12
++	W_MUSICAL,	//13
++	W_WHIP,	//14
++	W_BOOK,	//15
++	W_KATAR,	//16
++	W_REVOLVER,	//17
++	W_RIFLE,	//18
++	W_GATLING,	//19
++	W_SHOTGUN,	//20
++	W_GRENADE,	//21
++	W_HUUMA,	//22
++	W_2HSTAFF,	//23
++	MAX_WEAPON_TYPE,
++	// dual-wield constants
++	W_DOUBLE_DD, // 2 daggers
++	W_DOUBLE_SS, // 2 swords
++	W_DOUBLE_AA, // 2 axes
++	W_DOUBLE_DS, // dagger + sword
++	W_DOUBLE_DA, // dagger + axe
++	W_DOUBLE_SA, // sword + axe
++	MAX_WEAPON_TYPE_ALL,
++	W_SHIELD = MAX_WEAPON_TYPE,
++};
+ 
+ enum AtCommandType : uint8;
+ enum e_instance_mode : uint8;
+@@ -573,8 +611,8 @@
+ 		int16 weapon_coma_ele[ELE_MAX];
+ 		int16 weapon_coma_race[RC_MAX];
+ 		int16 weapon_coma_class[CLASS_MAX];
+-		int32 weapon_atk[16];
+-		int32 weapon_damage_rate[16];
++		int32 weapon_atk[MAX_WEAPON_TYPE];
++		int32 weapon_damage_rate[MAX_WEAPON_TYPE];
+ 		int32 arrow_addele[ELE_MAX];
+ 		int32 arrow_addrace[RC_MAX];
+ 		int32 arrow_addclass[CLASS_MAX];
+@@ -956,42 +994,7 @@
+ /* Global Expiration Timer ID */
+ extern int32 pc_expiration_tid;
+ 
+-enum weapon_type : uint8 {
+-	W_FIST,	//Bare hands
+-	W_DAGGER,	//1
+-	W_1HSWORD,	//2
+-	W_2HSWORD,	//3
+-	W_1HSPEAR,	//4
+-	W_2HSPEAR,	//5
+-	W_1HAXE,	//6
+-	W_2HAXE,	//7
+-	W_MACE,	//8
+-	W_2HMACE,	//9 (unused)
+-	W_STAFF,	//10
+-	W_BOW,	//11
+-	W_KNUCKLE,	//12
+-	W_MUSICAL,	//13
+-	W_WHIP,	//14
+-	W_BOOK,	//15
+-	W_KATAR,	//16
+-	W_REVOLVER,	//17
+-	W_RIFLE,	//18
+-	W_GATLING,	//19
+-	W_SHOTGUN,	//20
+-	W_GRENADE,	//21
+-	W_HUUMA,	//22
+-	W_2HSTAFF,	//23
+-	MAX_WEAPON_TYPE,
+-	// dual-wield constants
+-	W_DOUBLE_DD, // 2 daggers
+-	W_DOUBLE_SS, // 2 swords
+-	W_DOUBLE_AA, // 2 axes
+-	W_DOUBLE_DS, // dagger + sword
+-	W_DOUBLE_DA, // dagger + axe
+-	W_DOUBLE_SA, // sword + axe
+-	MAX_WEAPON_TYPE_ALL,
+-	W_SHIELD = MAX_WEAPON_TYPE,
+-};
++
+ 
+ #define WEAPON_TYPE_ALL ((1<<MAX_WEAPON_TYPE)-1)
+ 
+--- a/src/map/pc.cpp
++++ b/src/map/pc.cpp
+@@ -4699,10 +4699,16 @@
+ 		sd->special_state.bonus_coma = 1;
+ 		break;
+ 	case SP_WEAPON_ATK: // bonus2 bWeaponAtk,w,n;
++		// RAGNAROKMAC: item scripts cannot index beyond the weapon table.
++		if (type2 < 0 || type2 >= MAX_WEAPON_TYPE)
++			break;
+ 		if (sd->state.lr_flag != LR_FLAG_ARROW)
+ 			sd->indexed_bonus.weapon_atk[type2]+=val;
+ 		break;
+ 	case SP_WEAPON_DAMAGE_RATE: // bonus2 bWeaponDamageRate,w,n;
++		// RAGNAROKMAC: item scripts cannot index beyond the weapon table.
++		if (type2 < 0 || type2 >= MAX_WEAPON_TYPE)
++			break;
+ 		if (sd->state.lr_flag != LR_FLAG_ARROW)
+ 			sd->indexed_bonus.weapon_damage_rate[type2]+=val;
+ 		break;

--- a/third-party/server-fixes/README.md
+++ b/third-party/server-fixes/README.md
@@ -9,3 +9,9 @@ English index is zero, so the previous operation shifted by -1 before reaching
 its English early return. Large indices could also shift out of range or wrap
 the 16-bit mask. Valid languages and the enabled-language policy are unchanged.
 This was caught during real diagnostic map-server startup, not during logout.
+
+`0002-base-sp-range.patch` clamps calculated base SP before converting the
+floating-point result to unsigned. Default coefficients for a Ninja-mapped job
+produce -2 at level 10; converting that to `uint32` is undefined. Normal
+nonnegative values are unchanged, and overflow saturates at the return type's
+maximum. The actual function has a separate UBSan reduction covering both bounds.

--- a/third-party/server-fixes/README.md
+++ b/third-party/server-fixes/README.md
@@ -15,3 +15,8 @@ floating-point result to unsigned. Default coefficients for a Ninja-mapped job
 produce -2 at level 10; converting that to `uint32` is undefined. Normal
 nonnegative values are unchanged, and overflow saturates at the return type's
 maximum. The actual function has a separate UBSan reduction covering both bounds.
+
+`0003-unlearned-skill-level.patch` returns zero for an unlearned skill before the
+shared accessor indexes a level table. Native character login asks for SP at
+level zero while constructing the skill list; the previous macro read index -1.
+Stored and extrapolated learned levels retain their existing behavior.

--- a/third-party/server-fixes/README.md
+++ b/third-party/server-fixes/README.md
@@ -20,3 +20,11 @@ maximum. The actual function has a separate UBSan reduction covering both bounds
 shared accessor indexes a level table. Native character login asks for SP at
 level zero while constructing the skill list; the previous macro read index -1.
 Stored and extrapolated learned levels retain their existing behavior.
+
+`0004-weapon-bonus-bounds.patch` sizes both weapon bonus arrays from the existing
+weapon enum (moved before the player structure) and checks item-script indices.
+The fixed diagnostic image reached a real Pre-Renewal population spawn, where
+equipping a Katar read index 16 from the old 16-element array. Later weapon types
+also exceeded that array, including the damage bonus used by combat.
+`verify-weapon-bounds.py` reproduces the actual declaration/setter/status-read
+fault and checks every weapon type plus invalid script indices after patching.

--- a/third-party/server-fixes/README.md
+++ b/third-party/server-fixes/README.md
@@ -1,0 +1,11 @@
+# Pinned rAthena corrections
+
+These small patches apply to the pinned rAthena sources through
+`scripts/apply-server-mods.sh`, in both normal and diagnostic builds. They retain
+rAthena's GPL license; changes are marked `RAGNAROKMAC` where applicable.
+
+`0001-language-mask.patch` validates the language index before shifting. The
+English index is zero, so the previous operation shifted by -1 before reaching
+its English early return. Large indices could also shift out of range or wrap
+the 16-bit mask. Valid languages and the enabled-language policy are unchanged.
+This was caught during real diagnostic map-server startup, not during logout.


### PR DESCRIPTION
A stopped game server now brings the owning app to a recovery screen with saved reports and an explicit Retry. Old container logs no longer create duplicate reports, and retained reports include bounded population/mod context without copying credentials or all settings.

Actual sanitizer gameplay exposed four reproducible defects in the pinned rAthena source. This PR fixes them in ordinary and diagnostic builds:
- English language selection shifted by -1 before its early return.
- Default Ninja base-SP coefficients produced a negative value before an unsigned conversion.
- Building an unlearned skill list indexed the skill array at -1 for level zero.
- Equipping a population shell with a Katar accessed index 16 of a 16-element weapon bonus array. Attack/damage arrays now cover the complete weapon enum, with guarded script writes.

Each source-derived reduction fails on the original under UBSan and passes ordinary/boundary cases after patching. The patches apply idempotently. Diagnostic builds exclude only the pinned packet macros' pervasive alignment check; ASan and other UBSan checks remain fatal.

Validation:
- 66 supervisor and 60 Node tests passed with compiled binaries and zero skips. All five [final CI jobs](https://github.com/Flux159/ragnarokoffline.app/actions/runs/34168537923) passed, including fresh pinned source reductions.
- A real injected map-server SIGSEGV produced the recovery screen; Retry returned to native login.
- The final four-fix source dd39509 passed both architectures in [diagnostic](https://github.com/Flux159/ragnarokoffline.app/actions/runs/34160404547) and [ordinary](https://github.com/Flux159/ragnarokoffline.app/actions/runs/34160406889) image builds. The actual ARM64 guest first passed intentional ASan/UBSan/SIGSEGV symbolization.
- Both final ARM64 images then completed 20 real gameplay cycles each: five per era/population-off-or-on combination, with mods disabled. Events included login, map changes, positive population counts, stop/100-shell spawn requests, script reload, native character-select logout and abrupt disconnect. No server faults, browser errors or cleanup failures. Diagnostic exposure: 22:51:01–22:58:24 UTC; ordinary: 22:59:29–23:05:20 UTC.
- Earlier baseline runs also completed 20 cycles with mobile/keyboard mods enabled and 20 with mods disabled. The fixture now waits for the demand-driven population tick before requiring a positive count; a fast initial zero remains distinct from a real server fault.

The original intermittent logout crash in #16 still has no proven root cause. These are concrete startup/login/population fixes, not closure of that report or the full combat/long-duration/platform matrix. Original private evidence, image identities and backups are retained locally; docs/SANITIZER_INVESTIGATION.md records the investigation.

Stacked on #68; second of four continuation PRs. Nothing merged or released.
