### PR TITLE
Docs site polish, and pin libunwind by version rather than revision

### DIFF
--- a/containers/rathena/Dockerfile
+++ b/containers/rathena/Dockerfile
@@ -6,9 +6,16 @@
 
 FROM alpine:3.23 AS build
 
+# libunwind is pinned by upstream version, not by Alpine's package revision.
+# Alpine's repository carries only the current -rN for a branch: the moment
+# libunwind is rebuilt as -r1, an `=1.8.1-r0` pin stops resolving and the image
+# build fails outright -- on a release tag, most likely. `~1.8.1` keeps the
+# version deterministic while tolerating a repackage. The build-time -dev and
+# the runtime library must move together.
+
 RUN apk add --no-cache \
         bash git make cmake gcc g++ \
-        zlib-dev mariadb-dev linux-headers libunwind-dev=1.8.1-r0 binutils
+        zlib-dev mariadb-dev linux-headers libunwind-dev~1.8.1 binutils
 
 WORKDIR /rathena
 COPY . /rathena
@@ -85,7 +92,7 @@ COPY --from=build /symbols/ /
 
 FROM alpine:3.23
 
-RUN apk add --no-cache mariadb-connector-c zlib libstdc++ libgcc bash tzdata libunwind=1.8.1-r0 \
+RUN apk add --no-cache mariadb-connector-c zlib libstdc++ libgcc bash tzdata libunwind~1.8.1 \
     && adduser -D -h /rathena rathena
 
 WORKDIR /rathena

--- a/docs-site/docs/getting-started.mdx
+++ b/docs-site/docs/getting-started.mdx
@@ -23,6 +23,11 @@ Nothing is sent anywhere.
 1. **Install and open the app.**
 2. **Point it at your Ragnarok files** — the folder holding `data.grf`, and
    usually `rdata.grf` beside it.
+
+   **You need to find these yourself.** They are the client files from a
+   Ragnarok Online installation, and nothing copyrighted ships with this app.
+   **Please do not ask for links in the Discord** — we cannot help with that,
+   and posts asking for them will be removed.
 3. **Press play.** The first start takes a few minutes while it unpacks the
    server images; later starts take seconds.
 4. **Make an account** at the login screen by adding `_M` or `_F` to the
@@ -30,6 +35,13 @@ Nothing is sent anywhere.
 
 See [Installing](./installing) for the details, including where the app keeps
 its data on each platform.
+
+## Getting help
+
+**[Join the Discord](https://discord.gg/jUYC9dMbu5)** — for help getting set up,
+showing off a server, or reporting something odd. Bugs are also welcome as
+[GitHub issues](https://github.com/Flux159/ragnarokoffline.app/issues), and
+**Copy diagnostics** in the app gathers everything a report needs.
 
 ## Where to go next
 

--- a/docs-site/docs/installing.mdx
+++ b/docs-site/docs/installing.mdx
@@ -35,8 +35,8 @@ takes you straight there.
 | Platform | Path |
 |---|---|
 | macOS | `~/Library/Application Support/Ragnarok Offline` |
-| Windows | `%APPDATA%\Ragnarok Offline` |
-| Linux | `~/.config/Ragnarok Offline` |
+| Windows | `%APPDATA%\Ragnarok Offline` (that is `AppData\Roaming`, not `Local`) |
+| Linux | `~/.local/share/Ragnarok Offline` (or `$XDG_DATA_HOME/Ragnarok Offline`) |
 
 Inside it, `state/` holds your characters, settings and installed mods, and it
 deliberately sits outside the parts an app update replaces. Your GRF files are

--- a/docs-site/docs/settings-save-data.mdx
+++ b/docs-site/docs/settings-save-data.mdx
@@ -24,11 +24,30 @@ is worth the five minutes.
 
 ## Open data folder
 
-Opens the folder holding everything the app keeps: characters, settings, logs,
-crash reports and staged backups.
+Opens the folder holding everything the app generates: the microVM, its disks,
+the server runtime and your settings. Useful for attaching a log to a bug
+report, or copying a backup somewhere safe by hand.
 
-Useful for attaching a log to a bug report, or copying a backup somewhere safe
-by hand. See [Installing](./installing) for the path on each platform.
+| Platform | Location |
+|---|---|
+| macOS | `~/Library/Application Support/Ragnarok Offline` |
+| Windows | `%APPDATA%\Ragnarok Offline` (that is `AppData\Roaming`, not `Local`) |
+| Linux | `~/.local/share/Ragnarok Offline` (or `$XDG_DATA_HOME/Ragnarok Offline`) |
+
+Inside it:
+
+| Entry | What it is |
+|---|---|
+| `nebula/` | The microVM: guest kernel, container images, and the virtual disks. Nearly all of the size. |
+| `runtime/` | The server runtime — rAthena config, SQL schema, the client. Replaced wholesale by each app update. |
+| `state/` | Generated config, seeded schema, and staged backups. Deliberately outside `runtime/` so an update cannot wipe it. |
+| `state/mods` | Installed mods. Outside the asset tree on purpose, so rebuilding assets cannot destroy them. |
+| `state/crashes` | Preserved map-server crashes, including the symbolised stack a bug report wants. |
+| `client.json` | Which folder your GRFs are in, and whether you are hosting or joining. |
+
+**Your Ragnarok client is not in here.** The GRFs stay wherever you put them and
+are read in place, so a 3.5 GB client is never duplicated — and nothing on this
+page can put it at risk.
 
 ## Copying diagnostics
 

--- a/docs-site/src/pages/DocPage.tsx
+++ b/docs-site/src/pages/DocPage.tsx
@@ -146,6 +146,9 @@ export default function DocPage() {
           Ragnarok Offline
         </Link>
         <div className="navbar-links">
+          <a href="https://discord.gg/jUYC9dMbu5" target="_blank" rel="noopener">
+            Discord
+          </a>
           <Link to="/docs/getting-started">Docs</Link>
           <a href="https://github.com/Flux159/ragnarokoffline.app" target="_blank" rel="noopener">
             GitHub

--- a/docs-site/src/pages/HomePage.tsx
+++ b/docs-site/src/pages/HomePage.tsx
@@ -37,6 +37,9 @@ export default function HomePage() {
           Ragnarok Offline
         </Link>
         <div className="navbar-links">
+          <a href="https://discord.gg/jUYC9dMbu5" target="_blank" rel="noopener">
+            Discord
+          </a>
           <Link to="/docs/getting-started">Docs</Link>
           <a href="https://github.com/Flux159/ragnarokoffline.app" target="_blank" rel="noopener">
             GitHub
@@ -46,10 +49,13 @@ export default function HomePage() {
 
       <div style={{ marginTop: 'var(--navbar-height)' }}>
         <header className="hero">
+          <div className="hero-mark">
+            <AppMark size={96} />
+          </div>
           <h1>Your own Ragnarok Online server</h1>
           <p>
-            A single app for macOS, Windows and Linux. It carries the server, the database and the
-            client, so there is nothing to configure before you are standing in Prontera.
+            A single ragnarok app for MacOS, Windows, and Linux. Open the app, point to your client
+            files, and start playing in Midgard.
           </p>
           <div className="hero-buttons">
             <a
@@ -64,9 +70,6 @@ export default function HomePage() {
               Read the docs
             </Link>
           </div>
-          <p className="hero-note">
-            You supply your own Ragnarok client files. Nothing copyrighted ships with the app.
-          </p>
         </header>
 
         <section className="features">
@@ -79,6 +82,13 @@ export default function HomePage() {
         </section>
 
         <footer className="footer">
+          <p>
+            Stuck, or want to show off a server?{' '}
+            <a href="https://discord.gg/jUYC9dMbu5" target="_blank" rel="noopener">
+              Join the Discord
+            </a>
+            .
+          </p>
           <p>
             Built on <a href="https://github.com/rathena/rathena" target="_blank" rel="noopener">rAthena</a>,{' '}
             <a href="https://github.com/MrAntares/roBrowserLegacy" target="_blank" rel="noopener">roBrowserLegacy</a>{' '}

--- a/docs-site/src/styles.css
+++ b/docs-site/src/styles.css
@@ -571,3 +571,11 @@ a:hover {
   color: var(--text-secondary);
   font-size: 0.9rem;
 }
+
+/* The app icon above the title, so the home page leads with the mark rather
+   than repeating it only in the navbar. */
+.hero-mark {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 1.5rem;
+}


### PR DESCRIPTION
Follow-ups to the docs site, plus the one remaining item from the stack review.

**Site**
- New tagline; the app icon now sits above the title rather than only in the navbar; licence line dropped from the hero.
- Discord in the navbar (left of Docs), on the home page, and on Getting started — it was only in the README before.
- Getting started says the client files are yours to find, and asks people not to request links in the Discord.
- Save data documents the data folder: where it is per platform, and what each entry holds including `state/mods` and `state/crashes`. That table only existed in `ADVANCED_FEATURES.md`, which is not where somebody looking at the Save data tab will look.
- Corrected the Linux data path — I had written `~/.config` where the app uses `~/.local/share`.

**libunwind**

Alpine carries only the current `-rN`, so `=1.8.1-r0` stops resolving the moment the package is rebuilt and the image build fails outright. Verified against a real Alpine: `busybox=1.37.0-r0` is already refused exactly this way, while `busybox~1.37.0` resolves against the `-r30` that replaced it.

Docs verified by building and driving the site: tagline, icon, navbar order, the Discord links, and both Save data tables render with no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RguPr4pKY5v7Mp2RSfBG8W