### PR TITLE
Say what the multiplayer modes do, and enlarge the home page icon

### DIFF
--- a/docs-site/docs/getting-started.mdx
+++ b/docs-site/docs/getting-started.mdx
@@ -9,11 +9,9 @@ app.
 
 ## What actually happens when you press play
 
-The app starts a small virtual machine, runs the Ragnarok server inside it, and
-opens the game in a window. That sounds heavy and mostly is not: it is a
-purpose-built microVM, not a desktop virtualisation product, and it exists so
-the Linux server the game needs can run the same way on all three platforms
-instead of being ported three times.
+The app starts a microVM, runs the Ragnarok server and its database inside it,
+and opens the game client in a window. The server is Linux-only, so the VM is
+how the same server runs on macOS, Windows and Linux without being ported.
 
 Your characters live on your machine, in a database only this app talks to.
 Nothing is sent anywhere.

--- a/docs-site/docs/settings-multiplayer.mdx
+++ b/docs-site/docs/settings-multiplayer.mdx
@@ -4,9 +4,15 @@ Playing with other people, on your network or over the internet.
 
 ## Mode
 
-**Host a server** runs the world on this machine. **Join a friend** runs
-nothing locally — no server, no virtual machine, no game files — and connects
-to someone else's, which is why joining starts in seconds.
+Multiplayer has two modes: you can host your own server, or join a friend.
+
+**Host a server** — runs the world on this machine. Requires client assets
+populated.
+
+**Join a friend** — joins a friend's world via their share link. LAN and WAN are
+both supported, depending on the host's settings. Note that you do not need
+ragnarokoffline.app to join a friend's server; you can simply join using a web
+browser.
 
 ## Allow LAN connections
 

--- a/docs-site/docs/settings-population.mdx
+++ b/docs-site/docs/settings-population.mdx
@@ -14,9 +14,9 @@ run, so a disabled engine costs nothing.
 
 ## Density
 
-How crowded a map feels, as a percentage of what the server's own spawn tables
-ask for. **This is the dial you actually want.** The world keeps the shape it
-was authored with; only its crowding changes.
+How crowded a map is, as a percentage of what the server's spawn tables ask
+for. The world keeps the shape it was authored with; only the number of
+characters on it changes.
 
 ## Limit
 

--- a/docs-site/src/pages/HomePage.tsx
+++ b/docs-site/src/pages/HomePage.tsx
@@ -50,7 +50,7 @@ export default function HomePage() {
       <div style={{ marginTop: 'var(--navbar-height)' }}>
         <header className="hero">
           <div className="hero-mark">
-            <AppMark size={96} />
+            <AppMark size={192} />
           </div>
           <h1>Your own Ragnarok Online server</h1>
           <p>


### PR DESCRIPTION
The Mode section explained itself rather than describing the options. It now states the two modes, what each needs, and the fact that was missing: joining does not require this app — a browser will do.

Two other passages had the same tic and were tightened: the microVM paragraph, and Population density.

Home page icon to 192px; the source is 1024px square so it stays sharp at 2x.

Verified by building and driving the site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RguPr4pKY5v7Mp2RSfBG8W