### PR TITLE
Sharing: explain a blocked listener check, and stop hanging on the image loader

### DIFF
--- a/docs-site/docs/friends.mdx
+++ b/docs-site/docs/friends.mdx
@@ -18,10 +18,12 @@ forwarded and nothing on your network is exposed** — the tunnel carries only t
 game, and only to people holding a current invitation.
 
 1. **Settings → Multiplayer**, turn on **Set up sharing over the internet**.
-   This turns on LAN connections too.
+   This only reveals the controls; it changes no hosting setting on its own.
 2. **Share with friends.** The first time, it secures the server's internal
    credentials — it backs up the database first and keeps every account and
-   character.
+   character. It also restarts the game services once, and unticks **Allow LAN
+   connections**: while sharing, the invitation is the only way in, so the game
+   ports stop listening on your network.
 3. Click **Your link — over the internet** to copy the whole invitation.
 
 Your friend opens it, and either logs in with a game account, creates one from

--- a/docs-site/docs/settings-accounts.mdx
+++ b/docs-site/docs/settings-accounts.mdx
@@ -56,10 +56,25 @@ match, so the prompt rejects every answer — including the `000000` and
 those accounts the same 1 January 2000 and leaves any account that already has
 one alone. It is safe to press twice.
 
-The full deletion is three steps, because the server holds a character for a
-day before it will remove it: choose Delete, wait out the countdown shown on
-the character slot, then choose the final delete and enter the birthday. A
+Deletion is three steps by default: choose Delete, wait out the countdown shown
+on the character slot, then choose the final delete and enter the birthday. A
 character still in a party or guild cannot be deleted at all.
+
+## Character deletion
+
+**A day after it is requested** is Ragnarok's own behaviour and the default
+here. Choosing Delete queues the character and starts a countdown on the slot;
+until that runs out, the deletion can be cancelled. That is what protects a
+character from someone else who can reach the game, so keep it if you share
+your server with friends.
+
+**As soon as the birthday is entered** removes the wait, and the two clicks run
+back to back. On a server only you can reach there is nobody to cancel a
+deletion against, and the day only costs you time.
+
+Either way the birthday is still asked for, a character in a party or guild is
+still refused, and the deletion is permanent once it goes through. Applying
+restarts game services.
 
 ## Character names
 

--- a/docs-site/docs/settings-accounts.mdx
+++ b/docs-site/docs/settings-accounts.mdx
@@ -42,6 +42,25 @@ If a change is refused, the reason appears in red under the buttons.
 entered above. Use 4–23 letters, numbers, underscores or hyphens, without an
 `_M` or `_F` suffix.
 
+## Deleting a character: the birthday prompt
+
+The game asks for the **account's birthday** before it deletes a character, and
+refuses the deletion if the answer does not match what the server has stored.
+
+Every account this app creates is given **1 January 2000**. Type it as
+`20000101` when the game asks.
+
+Accounts created before the app started storing a birthday have nothing to
+match, so the prompt rejects every answer — including the `000000` and
+`00-00-00` suggested on rAthena forums. **Set missing account birthdays** gives
+those accounts the same 1 January 2000 and leaves any account that already has
+one alone. It is safe to press twice.
+
+The full deletion is three steps, because the server holds a character for a
+day before it will remove it: choose Delete, wait out the countdown shown on
+the character slot, then choose the final delete and enter the birthday. A
+character still in a party or guild cannot be deleted at all.
+
 ## Character names
 
 Not a setting, but the rule that surprises people: character names need **at

--- a/docs-site/docs/settings-multiplayer.mdx
+++ b/docs-site/docs/settings-multiplayer.mdx
@@ -35,9 +35,22 @@ part of an elided link by hand is how people end up sending half of one.
 
 ## Set up sharing over the internet
 
-Off until you ask for it, so a local or LAN game stays uncluttered. Turning it
-on also turns on LAN connections, since the people you are about to send a link
-to are by definition not on this machine.
+Off until you ask for it, so a local or LAN game stays uncluttered. The
+checkbox only reveals the controls; it changes no hosting setting on its own.
+
+### Sharing turns LAN connections off
+
+**Allow LAN connections** unticks itself when sharing starts, and that is the
+app closing ports rather than discarding your setting.
+
+Friends hosting and LAN are deliberately exclusive. While sharing, the game
+ports listen on this machine only and the invitation link is the single way in.
+LAN hosting would put those same ports on every network interface, where anyone
+who can reach your computer could connect without an invitation — past the gate
+that makes sharing safe to hand out.
+
+Turn LAN back on when you want players on your own network again. It applies at
+the next **Restart server**.
 
 ### Temporary links change every time
 

--- a/docs-site/docs/troubleshooting.mdx
+++ b/docs-site/docs/troubleshooting.mdx
@@ -57,8 +57,12 @@ stored refuses every answer. Open **Settings → Accounts** and choose **Set
 missing account birthdays**, then answer `20000101`.
 
 Answers such as `000000` or `00-00-00`, suggested for other rAthena servers,
-never work here. Deletion also waits out a day-long countdown on the slot, and
-is refused outright while the character is in a party or guild.
+never work here.
+
+If the birthday is accepted and the deletion is still refused, the character is
+waiting out its countdown. Deletion is queued for a day by default, and the
+same panel has **Character deletion** to make it immediate. A character in a
+party or guild is refused whichever you choose.
 
 ## Accounts and passwords
 

--- a/docs-site/docs/troubleshooting.mdx
+++ b/docs-site/docs/troubleshooting.mdx
@@ -50,6 +50,16 @@ Character names need **at least 4 characters**, and only letters, numbers and
 spaces. The server returns the same generic refusal for several different
 problems, so the app checks the length before sending.
 
+## A character will not delete, and the birthday is refused
+
+The game checks the birthday against the account, and an account with none
+stored refuses every answer. Open **Settings → Accounts** and choose **Set
+missing account birthdays**, then answer `20000101`.
+
+Answers such as `000000` or `00-00-00`, suggested for other rAthena servers,
+never work here. Deletion also waits out a day-long countdown on the slot, and
+is refused outright while the character is in a party or guild.
+
 ## Accounts and passwords
 
 Passwords are **8–23 printable ASCII characters** and cannot be the account

--- a/docs/FRIENDS_SHARING.md
+++ b/docs/FRIENDS_SHARING.md
@@ -91,7 +91,10 @@ Custom SSO/Han login modes and non-ASCII account names are not supported here.
 The Rust supervisor checks the actual running era, managed credentials, GM
 password policy, suffix signup policy, container port bindings and the pinned
 base command/permission files. Mods replacing command/permission imports are
-refused for friends mode. The app checks current LAN listeners as well. A
+refused for friends mode. The app probes the current LAN listeners as a second
+opinion: a port that answers refuses sharing outright, while a probe a firewall
+drops is reported to the player rather than treated as a failure, since the
+supervisor has already verified the bindings from the inside. A
 separate owner page retains privileged Electron IPC; public pages have none.
 
 The access boundary is implemented in the shell's gateway rather than changing

--- a/electron/accounts.js
+++ b/electron/accounts.js
@@ -6,9 +6,15 @@ const { spawn } = require("node:child_process");
 function runAccounts(binary, options, request) {
   if (
     !request ||
-    !["list", "create", "invite-create", "password", "disable", "enable"].includes(
-      request.action,
-    ) ||
+    ![
+      "list",
+      "create",
+      "invite-create",
+      "password",
+      "disable",
+      "enable",
+      "birthdates",
+    ].includes(request.action) ||
     !["renewal", "prerenewal"].includes(request.era)
   ) {
     return Promise.reject(new Error("Invalid account request"));

--- a/electron/listener-probe.js
+++ b/electron/listener-probe.js
@@ -1,0 +1,130 @@
+'use strict';
+const net = require('node:net');
+const os = require('node:os');
+
+// Ports the app publishes: the asset server, then rAthena's login, char and
+// map. All four are bound to 127.0.0.1 when hosting is anything but `lan`.
+const GAME_PORTS = [3338, 6900, 6121, 5121];
+
+// What a single connection attempt proved, worst first. `open` is the only
+// outcome that says a port is exposed; every other one says it is not, and
+// they differ only in how much we are entitled to claim about why.
+//
+// The distinction that matters is `closed` versus `filtered`. A refused
+// connection is the stack telling us nothing is listening. A dropped one is a
+// packet filter telling us nothing, and Windows drops by default: its inbound
+// policy discards unsolicited SYNs without a reset, so a probe to this
+// machine's own LAN address times out on a healthy install rather than being
+// refused. Treating that silence as a failure made sharing impossible there.
+const OUTCOMES = {
+  open: 'reachable',
+  closed: 'refused, so nothing is listening',
+  unreachable: 'no route to that address',
+  filtered: 'no answer, so a packet filter dropped it',
+  error: 'the probe itself failed',
+};
+
+function classify(error) {
+  switch (error.code) {
+    case 'ECONNREFUSED': case 'ECONNRESET': return 'closed';
+    case 'EHOSTUNREACH': case 'ENETUNREACH': case 'ENETDOWN': case 'EHOSTDOWN':
+    case 'EADDRNOTAVAIL': case 'EACCES': case 'EPERM': return 'unreachable';
+    case 'ETIMEDOUT': return 'filtered';
+    default: return 'error';
+  }
+}
+
+// Every IPv4 address this machine answers on, minus loopback. Virtual adapters
+// are deliberately included: a Hyper-V or WSL bridge is still an address a
+// listener could bind, and excluding them by name would be a guess that ages
+// badly as the platform adds more of them.
+function localAddresses() {
+  return Object.values(os.networkInterfaces()).flat()
+    .filter(info => info && !info.internal && info.family === 'IPv4')
+    .map(info => info.address);
+}
+
+function probeOne(address, port, timeoutMs) {
+  return new Promise(resolve => {
+    let settled = false;
+    const socket = new net.Socket();
+    const finish = outcome => {
+      if (settled) return;
+      settled = true;
+      socket.destroy();
+      resolve({ address, port, outcome });
+    };
+    socket.setTimeout(timeoutMs, () => finish('filtered'));
+    socket.once('connect', () => finish('open'));
+    socket.once('error', error => finish(classify(error)));
+    // connect() throws rather than emitting for a malformed port or address.
+    // Left uncaught it rejects this promise, takes Promise.all with it and
+    // surfaces as exactly the unexplained sharing failure this module exists
+    // to replace. An unprobeable address is a result, not an exception.
+    try {
+      socket.connect({ host: address, port });
+    } catch {
+      finish('error');
+    }
+  });
+}
+
+// Every address against every port, at once. Serially this was one timeout per
+// probe, and a machine with several virtual adapters spent half a minute in a
+// check that is meant to be instant.
+async function probeListeners({ timeoutMs = 1000, ports = GAME_PORTS, addresses = localAddresses() } = {}) {
+  const results = await Promise.all(addresses.flatMap(address => ports.map(port => probeOne(address, port, timeoutMs))));
+  const exposed = results.filter(result => result.outcome === 'open');
+  const filtered = results.filter(result => result.outcome === 'filtered');
+  return { results, exposed, filtered, addresses };
+}
+
+// A machine with several virtual adapters produces one result per adapter per
+// port, and naming all two dozen turns the sentence into a wall. Name a few and
+// count the rest; the diagnostics section carries the full list.
+function where(results, limit = 4) {
+  const named = results.slice(0, limit).map(result => `${result.address}:${result.port}`).join(', ');
+  const rest = results.length - limit;
+  return rest > 0 ? `${named} and ${rest} more` : named;
+}
+
+// Which addresses were affected, regardless of port -- the useful unit when a
+// whole interface was dropped, which is the usual shape of a firewall result.
+function whichAddresses(results, limit = 4) {
+  const unique = [...new Set(results.map(result => result.address))];
+  const rest = unique.length - limit;
+  return rest > 0 ? `${unique.slice(0, limit).join(', ')} and ${rest} more` : unique.join(', ');
+}
+
+// One line per probe, for the log and for a bug report. Without this the only
+// evidence of a failure was the word "listeners" and no address.
+function describe({ results }) {
+  if (!results.length) return 'no non-loopback IPv4 address on this machine';
+  return results.map(result => `${result.address}:${result.port} ${result.outcome} (${OUTCOMES[result.outcome]})`).join('\n');
+}
+
+// The sentence a player sees. Only an actually reachable port is a refusal:
+// the authoritative checks already ran in the supervisor, which reads the
+// container port bindings and the engine's publication flag rather than
+// guessing from outside. This probe is the second opinion, so it may say "I
+// could not tell" without stopping anything.
+function verdict(report) {
+  if (report.exposed.length) {
+    return {
+      shareable: false,
+      message: `A game port is reachable on your network at ${where(report.exposed)}. `
+        + 'Turn off "Allow LAN connections" in Settings → Multiplayer, restart the server, then share again.',
+    };
+  }
+  if (report.filtered.length) {
+    return {
+      shareable: true,
+      message: `Your firewall dropped the check on ${whichAddresses(report.filtered)} instead of refusing it, `
+        + 'so those ports could not be confirmed closed from outside. The server’s own settings were '
+        + 'verified separately and are private, so sharing continued. This is normal on Windows.',
+    };
+  }
+  return { shareable: true, message: '' };
+}
+
+module.exports = { probeListeners, describe, verdict, localAddresses, GAME_PORTS };

--- a/electron/main.js
+++ b/electron/main.js
@@ -25,6 +25,10 @@ const { JoinSession } = require('./join-session');
 const joinSession = new JoinSession();
 let sharing, sharingSecrets;
 let sharingStartRequest = 0;
+// Kept for the diagnostics bundle. A sharing failure used to arrive as one
+// sentence with no address in it, and the report carried no way to work out
+// which interface the check had objected to.
+let lastListenerReport = null;
 function getSharingSecrets() {
     return sharingSecrets ||= new (require('./sharing/secrets').SharingSecrets)(path.join(dataRoot(), 'sharing'), safeStorage);
 }
@@ -62,18 +66,23 @@ function getSharing() {
             if (client.mode !== 'host' || client.hosting_scope !== 'friends' || client.lan || !assetServer.running || !(await assetsReady())) throw Error('Start your own server in friends mode before sharing.');
             const checked = JSON.parse(await runStack(['sharing-check']));
             if (!checked.backendReady) throw Error('The server is not ready for friends.');
-            // Configuration checks above verify each published container port.
-            // Also reject a reachable listener on any current LAN interface.
-            const net = require('node:net');
-            const addresses = Object.values(os.networkInterfaces()).flat().filter(info => info && !info.internal && info.family === 'IPv4');
-            for (const info of addresses) for (const port of [3338, 6900, 6121, 5121]) {
-                await new Promise((resolve, reject) => {
-                    const socket = net.connect({ host: info.address, port });
-                    socket.once('connect', () => { socket.destroy(); reject(Error('A game or management port is reachable on the LAN. Turn off LAN hosting and restart before sharing.')); });
-                    socket.once('error', error => ['ECONNREFUSED', 'EHOSTUNREACH', 'ENETUNREACH', 'EACCES'].includes(error.code) ? resolve() : reject(Error('Could not verify private game listeners.')));
-                    socket.setTimeout(1000, () => { socket.destroy(); reject(Error('Could not verify private game listeners.')); });
-                });
-            }
+            // Configuration checks above verify each published container port
+            // from the inside -- the container bindings and the engine's
+            // publication flag. This is the outside second opinion: nothing of
+            // ours should answer on a LAN address. It reports what it found
+            // rather than refusing whenever it cannot tell, because a firewall
+            // that drops the probe is the ordinary case on Windows and used to
+            // fail here with a sentence naming neither an address nor a port.
+            const probe = require('./listener-probe');
+            lastListenerReport = await probe.probeListeners();
+            appLog(`sharing: listener check\n${probe.describe(lastListenerReport)}`);
+            const decided = probe.verdict(lastListenerReport);
+            if (!decided.shareable) throw Error(decided.message);
+            if (decided.message) appLog(`sharing: ${decided.message}`);
+            // Returned, not just logged: the controller shows it beside the
+            // sharing state so the player reads it without opening a log or
+            // asking on Discord.
+            return decided.message;
         },
         register: (request, stillInvited) => queueServerOperation(async () => {
             if (!stillInvited() || !sharing?.gateway || !['sharing', 'connecting', 'reconnecting'].includes(sharing.state)) throw Error('Sharing stopped');
@@ -1617,6 +1626,24 @@ const handlers = {
 			state: sharing?.state || 'stopped',
 			helper: require('./sharing/helper').helperDiagnostics(path.join(dataRoot(), 'sharing/helpers')),
 		}, null, 2));
+
+		// The addresses the listener check runs against, and what it last
+		// found. Diagnostics carried neither, so a report saying the check had
+		// failed gave no way to tell which interface it objected to -- and on
+		// a machine with virtual adapters that is most of the question.
+		try {
+			const probe = require('./listener-probe');
+			add('network', [
+				`interfaces  ${probe.localAddresses().join(', ') || 'none (loopback only)'}`,
+				`ports       ${probe.GAME_PORTS.join(', ')}`,
+				'',
+				lastListenerReport
+					? probe.describe(lastListenerReport)
+					: 'listener check has not run in this session',
+			].join('\n'));
+		} catch (e) {
+			add('network', `could not read: ${e.message}`);
+		}
 
 		// What sharing actually did, including the helper download and
 		// cloudflared's own output. The status block above says the current

--- a/electron/main.js
+++ b/electron/main.js
@@ -894,6 +894,11 @@ const SETTINGS_DEFAULTS = {
 	// spawn tables ask for. This is the dial players actually want; the limit
 	// above is only a safety net.
 	population_density: 100,
+	// Whether deleting a character takes effect at once or a day after it is
+	// queued. rAthena's default is the day, and it stays the default here: the
+	// countdown on the slot is what lets a player undo a deletion somebody else
+	// started, which matters the moment friends can reach the server.
+	instant_character_deletion: false,
 	// Pre-renewal is a different rAthena build, not a runtime option, so this
 	// selects which of the two the supervisor starts. Each mode keeps its own
 	// characters -- see db_volume() in stack/src/cmds.rs for why sharing them

--- a/electron/settings-store.js
+++ b/electron/settings-store.js
@@ -14,6 +14,13 @@ function validate(settings) {
   if (Object.hasOwn(settings, 'hosting_scope') && !['local', 'lan', 'friends', 'public'].includes(settings.hosting_scope)) {
     throw new Error('Invalid hosting scope. Choose local, lan, friends or public before starting.');
   }
+  // Checked here as well as in the supervisor: the supervisor refuses to start
+  // on a damaged value, and a refusal is a much worse way to learn about it
+  // than a rejected Apply.
+  if (Object.hasOwn(settings, 'instant_character_deletion') &&
+      typeof settings.instant_character_deletion !== 'boolean') {
+    throw new Error('Cannot read the character deletion setting. Repair settings.json before starting the server; the deletion delay was left in place.');
+  }
   return settings;
 }
 

--- a/electron/sharing/controller.js
+++ b/electron/sharing/controller.js
@@ -75,14 +75,21 @@ class SharingController {
   constructor({ directory, register, guard, onChange = () => {}, lifetime = () => 8 * 60 * 60 * 1000, invite = () => null, onInvite = () => {}, log = () => {} }, { helper = ensureHelper, launch = spawn, health = publicHealth, websocket = publicSocket, Gateway = FriendGateway } = {}) {
     Object.assign(this, { directory, register, guard, onChange, lifetime, invite, onInvite, log, helper, launch, health, websocket, Gateway }); this.state = 'stopped'; this.generation = 0;
   }
-  status() { return { state: this.state, message: this.message || '', hostname: this.hostname || '', expires: this.gateway?.expires || null, connectedFriends: this.gateway ? [...this.gateway.sessions.values()].filter(entry => entry.sockets.size > 0).length : 0 }; }
+  // `notice` is what the pre-flight checks could not confirm, on a start that
+  // succeeded anyway. It is deliberately separate from `message`, which is the
+  // current state: a player who shared successfully should still be told that
+  // their firewall hid the listener check, without that reading as a failure.
+  status() { return { state: this.state, message: this.message || '', notice: this.notice || '', hostname: this.hostname || '', expires: this.gateway?.expires || null, connectedFriends: this.gateway ? [...this.gateway.sessions.values()].filter(entry => entry.sockets.size > 0).length : 0 }; }
   update(state, message = '') { this.state = state; this.message = message; this.onChange(this.status()); }
   async start(saved) {
     if (this.state !== 'stopped' && this.state !== 'failed') throw Error('Sharing is already starting or running.');
     const generation = ++this.generation;
-    this.hostname = saved?.hostname || ''; this.update('preparing', 'Checking your server and preparing Cloudflare…');
+    this.hostname = saved?.hostname || ''; this.notice = ''; this.update('preparing', 'Checking your server and preparing Cloudflare…');
     try {
-      await this.guard();
+      // A guard that passes may still have something to say. Anything it
+      // could not verify is carried to the player rather than to the log
+      // alone, which is where it used to stop.
+      this.notice = (await this.guard()) || '';
       if (generation !== this.generation) return;
       const executable = await this.helper(path.join(this.directory, 'helpers'), message => {
         this.log(`helper: ${message}`);

--- a/electron/sharing/controller.js
+++ b/electron/sharing/controller.js
@@ -183,7 +183,9 @@ class SharingController {
     try { await this.stopping; } finally { this.stopping = null; }
   }
   async stopOwned() {
-    ++this.generation; clearInterval(this.monitor); this.monitor = null;
+    // The advisory described a session that is ending. Left in place it read
+    // as "sharing continued" under a panel saying sharing was off.
+    ++this.generation; clearInterval(this.monitor); this.monitor = null; this.notice = '';
     this.update('stopping', 'Stopping sharing…');
     const gateway = this.gateway; this.gateway = null;
     if (gateway) await gateway.stop();

--- a/sql/03-account.sql
+++ b/sql/03-account.sql
@@ -18,6 +18,16 @@
 -- Guarded with NOT EXISTS rather than INSERT IGNORE: rAthena indexes userid
 -- with a plain KEY, not a UNIQUE one, so IGNORE has no conflict to suppress and
 -- happily inserts a second 'ragnarok' every startup.
-INSERT INTO `login` (`userid`, `user_pass`, `sex`, `email`, `group_id`)
-SELECT 'ragnarok', 'ragnarok', 'M', 'ragnarok@localhost', 99 FROM DUAL
+--
+-- The birthdate is 2000-01-01 rather than the NULL the schema defaults to,
+-- because it is what lets a player delete a character. rAthena asks the client
+-- for the account's birthday and compares it to this column
+-- (chclif_delchar_check in src/char/char_clif.cpp), and nothing else in this
+-- app ever writes it. A NULL one cannot be matched: the sole value that would
+-- pass is an empty birthday, and roBrowser's input box will not submit an empty
+-- field, so the delete prompt refuses everything the player can type. The same
+-- date is written by account creation in stack/src/accounts.rs, and by the
+-- Accounts panel's migration for databases seeded before this line existed.
+INSERT INTO `login` (`userid`, `user_pass`, `sex`, `email`, `group_id`, `birthdate`)
+SELECT 'ragnarok', 'ragnarok', 'M', 'ragnarok@localhost', 99, '2000-01-01' FROM DUAL
  WHERE NOT EXISTS (SELECT 1 FROM `login` WHERE `userid` = 'ragnarok');

--- a/src/accounts-settings.js
+++ b/src/accounts-settings.js
@@ -7,14 +7,20 @@
   // A refusal has to look like one. Every message used to land in the same
   // dim note style as "Loading accounts…", so a rejected password change was
   // indistinguishable from progress and read as the button doing nothing.
-  const status = (message, kind = "") => {
-    const node = element("accounts-status");
+  const report = (id, message, kind = "") => {
+    const node = element(id);
     node.classList.remove("bad", "good");
     if (kind) node.classList.add(kind);
     node.textContent = message;
     // A refusal that scrolls off-screen is a refusal nobody reads.
     if (kind === "bad") node.scrollIntoView({ block: "nearest" });
   };
+  const status = (message, kind = "") => report("accounts-status", message, kind);
+  // The birthday migration answers beside its own button rather than in the
+  // shared line, which sits with the password and enable/disable buttons well
+  // above it.
+  const replyTo = (action) =>
+    action === "birthdates" ? "account-birthdate-status" : "accounts-status";
   const selected = () =>
     snapshot?.accounts.find(
       (account) => account.id === element("account-select").value,
@@ -110,7 +116,13 @@
     }
     busy = true;
     paint();
-    status("Updating the account and restarting game services…");
+    const reply = replyTo(action);
+    report(
+      reply,
+      action === "birthdates"
+        ? "Giving accounts a birthday and restarting game services…"
+        : "Updating the account and restarting game services…",
+    );
     let message;
     let failed = true;
     try {
@@ -137,7 +149,7 @@
       busy = false;
     }
     await refresh();
-    status(message, failed ? "bad" : "good");
+    report(reply, message, failed ? "bad" : "good");
   }
   element("accounts-refresh").onclick = refresh;
   element("account-select").onchange = paint;

--- a/src/accounts-settings.js
+++ b/src/accounts-settings.js
@@ -19,8 +19,20 @@
     snapshot?.accounts.find(
       (account) => account.id === element("account-select").value,
     );
+  // Accounts the game will never let delete a character, because it checks its
+  // birthday prompt against a column nothing used to write.
+  const birthdayless = () =>
+    snapshot?.accounts.filter((account) => account.needsBirthdate).length ?? 0;
+  const plural = (count, one, many) => `${count} ${count === 1 ? one : many}`;
   function paint() {
     const account = selected();
+    const missing = birthdayless();
+    element("account-birthdates").disabled = busy || !snapshot || !missing;
+    element("account-birthdate-detail").textContent = !snapshot
+      ? "Character deletion needs a birthday on the account."
+      : missing
+        ? `${plural(missing, "account has", "accounts have")} no birthday, so characters on ${missing === 1 ? "it" : "them"} cannot be deleted in the game.`
+        : "Every account has a birthday. Enter 20000101 when the game asks for it.";
     element("account-select").disabled = busy || !snapshot;
     for (const id of [
       "accounts-refresh",
@@ -86,9 +98,12 @@
     const request = { action, era: snapshot.era };
     if (action === "create")
       request.username = element("account-username").value;
-    else if (account)
+    // The birthday migration names no account: it fills in whichever rows are
+    // missing one, so the selection in the list above is irrelevant to it.
+    else if (action !== "birthdates") {
+      if (!account) return;
       Object.assign(request, { id: account.id, username: account.username });
-    else return;
+    }
     if (action === "password" || action === "create") {
       request.password = element("account-password").value;
       request.confirmation = element("account-confirmation").value;
@@ -102,7 +117,14 @@
       const result = await invoke("accounts", request);
       if (!result.updated)
         throw new Error("The account update was not confirmed");
-      message = `Account updated in ${result.era === "prerenewal" ? "pre-renewal" : "renewal"}. Log in again.`;
+      // Zero rows is success here rather than a refusal: it means every
+      // account already had a birthday. Say which of the two happened,
+      // because they leave the panel looking identical.
+      const filled = Number(result.changed) || 0;
+      message =
+        action === "birthdates"
+          ? `${filled ? `${plural(filled, "account", "accounts")} given a birthday` : "Every account already had a birthday"}. Enter 20000101 when the game asks for it, and log in again.`
+          : `Account updated in ${result.era === "prerenewal" ? "pre-renewal" : "renewal"}. Log in again.`;
       failed = false;
     } catch (error) {
       message = error.message || "Account update failed";
@@ -123,4 +145,5 @@
   element("account-disable").onclick = () => change("disable");
   element("account-enable").onclick = () => change("enable");
   element("account-create").onclick = () => change("create");
+  element("account-birthdates").onclick = () => change("birthdates");
 })();

--- a/src/settings.html
+++ b/src/settings.html
@@ -303,6 +303,7 @@
         <button id="sharing-stop" class="ghost" disabled>Stop sharing</button>
       </div>
       <p id="sharing-state" class="note" role="status" aria-live="polite">Sharing is off.</p>
+      <p id="sharing-notice" class="note" role="status" aria-live="polite" hidden></p>
       <p id="sharing-feedback" class="note" role="status" aria-live="polite"></p>
       <p class="note" id="sharing-lifetime-note">An invitation lets up to 32 friend browsers connect. Invited friends can create an ordinary game account. Stop sharing disconnects friends without stopping your local game. Starting sharing applies the protected account policy and restarts game services once.</p>
       <details><summary>Manage invitations and connection</summary>
@@ -1113,6 +1114,9 @@ async function refreshSharing() {
     $('sharing-replace').disabled = !['sharing', 'reconnecting'].includes(state.state);
     $('sharing-forget').disabled = sharingBusy || (!state.configured && !state.configurationError);
     setNote('sharing-state', state.message || 'Sharing is off.');
+    // What the pre-flight checks could not confirm on a start that worked.
+    setNote('sharing-notice', state.notice || '');
+    $('sharing-notice').hidden = !state.notice;
     if (state.state === 'sharing') {
       const expiry = Number.isFinite(state.expires)
         ? ` Invitation expires ${new Date(state.expires).toLocaleString()}.`

--- a/src/settings.html
+++ b/src/settings.html
@@ -361,23 +361,38 @@
       <button id="account-disable" class="ghost" disabled>Disable account</button>
       <button id="account-enable" class="ghost" disabled>Enable account</button>
     </div>
+    <!-- Beside the buttons, not at the top of the panel. The reply to a click
+         used to render six elements above it, in the same grey as the rules
+         note sitting right next to the button -- so a refusal read as the
+         button doing nothing at all. The character-deletion controls below
+         each carry their own reply for that reason. -->
+    <p class="note" id="accounts-status" role="status" aria-live="polite"></p>
     <!-- Account-wide rather than part of the row above: a birthday is a fixed
          value the game needs present, not a per-account preference, and the
          delete prompt never says which account is missing one. -->
     <p class="note" id="account-birthdate-detail">Character deletion needs a birthday on the account.</p>
-    <button id="account-birthdates" class="ghost" disabled>Set missing account birthdays</button>
     <p class="note">The game asks for the account's birthday before it will delete a character.
       Accounts created before this app started storing one have nothing to match, so the
       prompt refuses every answer that can be typed. This writes 1 January 2000 to those
       accounts and leaves any that already have a birthday alone. Enter it as
       <strong>20000101</strong> when the game asks. To delete a character: choose Delete,
-      wait out the countdown the server puts on the slot, then choose the final delete and
-      enter the birthday.</p>
-    <!-- Beside the buttons, not at the top of the panel. The reply to a click
-         used to render six elements above it, in the same grey as the rules
-         note sitting right next to the button -- so a refusal read as the
-         button doing nothing at all. -->
-    <p class="note" id="accounts-status" role="status" aria-live="polite"></p>
+      wait out any countdown on the slot, then choose the final delete and enter the
+      birthday.</p>
+    <button id="account-birthdates" class="ghost" disabled>Set missing account birthdays</button>
+    <p class="note" id="account-birthdate-status" role="status" aria-live="polite"></p>
+    <label><span>Character deletion</span><select id="delete-delay">
+      <option value="delayed">A day after it is requested</option>
+      <option value="instant">As soon as the birthday is entered</option>
+    </select></label>
+    <p class="note">Choosing Delete does not remove the character. It queues it and starts
+      a countdown on the slot, and only the final delete after that countdown removes it.
+      <b>A day after it is requested</b> is Ragnarok's own behaviour, and the countdown is
+      what lets you cancel a deletion you did not start — keep it if friends can reach your
+      server. <b>As soon as the birthday is entered</b> removes the wait, so the two clicks
+      run back to back. Either way the birthday is still asked for, and a character in a
+      party or guild is still refused. Applying restarts game services.</p>
+    <button id="delete-delay-save" class="ghost">Apply character deletion and restart</button>
+    <p class="note" id="delete-delay-status" role="status" aria-live="polite"></p>
     <label style="margin-top:12px"><span>New friend account</span><input id="account-username" type="text" autocomplete="off" /></label>
     <p class="note">Create an ordinary player account with the password entered above.
       Use 4–23 letters, numbers, underscores or hyphens, without an _M or _F suffix.</p>
@@ -1223,6 +1238,30 @@ $('registration-save').onclick = async () => {
   }
 };
 
+$('delete-delay-save').onclick = async () => {
+  const button = $('delete-delay-save');
+  const status = $('delete-delay-status');
+  button.disabled = true;
+  status.textContent = 'Saving character deletion and restarting…';
+  try {
+    // One preference at a time, for the same reason as the policy above: the
+    // owner operation is serialized, and a whole-settings write from an older
+    // snapshot of this window would take a concurrent change with it.
+    const instant = $('delete-delay').value === 'instant';
+    await invoke('save_settings', { settings: { instant_character_deletion: instant } });
+    const mode = await invoke('get_mode');
+    status.textContent = mode.mode === 'join'
+      ? 'Saved for your own server. It will apply when you next host.'
+      : instant
+        ? 'Characters are deleted as soon as the birthday is entered.'
+        : 'Characters are deleted a day after they are requested, and can be cancelled until then.';
+  } catch (error) {
+    status.textContent = `Could not apply character deletion: ${String(error)}. Start the server to retry.`;
+  } finally {
+    button.disabled = false;
+  }
+};
+
 $('save').onclick = async () => {
   const settings = await invoke('get_settings');
   for (const k of RATES) settings[k] = rateOf(k);
@@ -1230,6 +1269,7 @@ $('save').onclick = async () => {
   settings.max_parameter = Number($('max_parameter').value) || 99;
   settings.free_kafra_warp = $('free_kafra_warp').checked;
   settings.open_registration = $('open-registration').value === 'open';
+  settings.instant_character_deletion = $('delete-delay').value === 'instant';
   settings.sharing_invite_days = inviteDays($('sharing_invite_days').value);
   settings.prerenewal = eraIsPre;
   settings.zeny_from_mobs = $('zeny_from_mobs').checked;
@@ -1264,6 +1304,7 @@ invoke('get_settings').then(s => {
   $('max_parameter').value = s.max_parameter ?? 99;
   $('free_kafra_warp').checked = !!s.free_kafra_warp;
   paintRegistration(s);
+  $('delete-delay').value = s.instant_character_deletion ? 'instant' : 'delayed';
   setEra(!!s.prerenewal);
   $('zeny_from_mobs').checked = !!s.zeny_from_mobs;
   $('population_enable').checked = !!s.population_enable;

--- a/src/settings.html
+++ b/src/settings.html
@@ -361,6 +361,18 @@
       <button id="account-disable" class="ghost" disabled>Disable account</button>
       <button id="account-enable" class="ghost" disabled>Enable account</button>
     </div>
+    <!-- Account-wide rather than part of the row above: a birthday is a fixed
+         value the game needs present, not a per-account preference, and the
+         delete prompt never says which account is missing one. -->
+    <p class="note" id="account-birthdate-detail">Character deletion needs a birthday on the account.</p>
+    <button id="account-birthdates" class="ghost" disabled>Set missing account birthdays</button>
+    <p class="note">The game asks for the account's birthday before it will delete a character.
+      Accounts created before this app started storing one have nothing to match, so the
+      prompt refuses every answer that can be typed. This writes 1 January 2000 to those
+      accounts and leaves any that already have a birthday alone. Enter it as
+      <strong>20000101</strong> when the game asks. To delete a character: choose Delete,
+      wait out the countdown the server puts on the slot, then choose the final delete and
+      enter the birthday.</p>
     <!-- Beside the buttons, not at the top of the panel. The reply to a click
          used to render six elements above it, in the same grey as the rules
          note sitting right next to the button -- so a refusal read as the
@@ -530,19 +542,20 @@ function paintInternetSetup(mode = $('mp-mode').value) {
   $('mp-internet-setup').setAttribute('aria-expanded', String(visible));
   $('internet-hosting').hidden = !visible;
 }
-$('mp-internet-setup').onchange = async () => {
+$('mp-internet-setup').onchange = () => {
   internetSetup = $('mp-internet-setup').checked;
   try { localStorage.setItem('internet-sharing-setup', String(internetSetup)); } catch {}
   paintInternetSetup();
-  // Sharing over the internet with LAN off is a combination nobody wants: the
-  // people you hand a link to are, by definition, not on this machine. Turn it
-  // on as a default when the disclosure is opened -- never off, and never
-  // again once it has been unticked deliberately.
-  if (internetSetup && !$('mp-lan').checked) {
-    await invoke('set_mode', { lan: true });
-    await refreshMode();
-    log('LAN connections turned on for internet sharing. Restart server to apply.');
-  }
+  // Revealing the controls must not change hosting, which is what the comment
+  // on paintInternetSetup already says and what this used to contradict: it
+  // turned LAN on, and then Share with friends turned it straight back off.
+  //
+  // Friends hosting and LAN are mutually exclusive on purpose. In friends
+  // scope the game ports bind loopback only and the invitation is the single
+  // way in; LAN would bind them to every interface and let anyone on the
+  // network past the gate that makes sharing safe. So the box unticking
+  // itself when sharing starts is the app closing those ports, not undoing
+  // the setting.
   refreshSharing();
 };
 
@@ -1024,7 +1037,11 @@ function paintInviteLifetime(days) {
     : `An invitation lasts ${span} day${span === 1 ? '' : 's'} and lets up to 32 friend browsers connect.`)
     + ' Invited friends can create an ordinary game account. Stop sharing disconnects friends'
     + ' without stopping your local game. Starting sharing applies the protected account policy'
-    + ' and restarts game services once.';
+    + ' and restarts game services once.'
+    // Said here because the checkbox visibly unticks itself a moment later,
+    // which reads as the app undoing your setting rather than closing a door.
+    + ' It also turns off Allow LAN connections: friends reach you through the'
+    + ' invitation only, so the game ports stop listening on your network.';
 }
 
 // Status lines that answer a button. A failure has to look like one: these all

--- a/stack/src/accounts.rs
+++ b/stack/src/accounts.rs
@@ -7,6 +7,30 @@ use crate::{
 };
 use std::io::{self, Read};
 
+/// The birthday every account this app creates is given, and the one the
+/// Accounts panel writes over accounts that have none.
+///
+/// It exists because character deletion asks for it. rAthena will not delete a
+/// character until the client echoes back the account's birthday
+/// (`chclif_delchar_check`, `vendor/rathena/src/char/char_clif.cpp`), and the
+/// login server stores an empty one for every account it creates. An empty
+/// birthday is unmatchable in practice: the only input that satisfies the check
+/// is an empty one, and roBrowser's prompt refuses to submit an empty field.
+///
+/// A literal rather than the player's own date of birth: this is a single-player
+/// server whose owner is the only person who can reach this column, so the value
+/// is a formality that has to be *known*, and one date everyone can be told
+/// beats a birthday nobody recorded. Digits and dashes only, so it can be
+/// inlined into SQL alongside the hex-encoded literals below.
+///
+/// Typed into the game's delete prompt as `20000101`: the client sends the last
+/// six digits and the char server compares those.
+const DEFAULT_BIRTHDATE: &str = "2000-01-01";
+
+/// Accounts whose birthday the migration has to write. NULL is what rAthena
+/// leaves; the zero date is what a permissive `sql_mode` can turn it into.
+const MISSING_BIRTHDATE: &str = "(birthdate IS NULL OR birthdate='0000-00-00')";
+
 fn field<'a>(request: &'a Value, key: &str) -> Result<&'a str, String> {
     request
         .str(key)
@@ -140,26 +164,27 @@ pub(crate) fn verify_era(cfg: &Config, dk: &Docker, era: &str) -> Result<(), Str
 }
 
 fn list(dk: &Docker, era: &str) -> Result<String, String> {
-    let output = dk.private_sql("SELECT account_id,HEX(userid),group_id,state,(BINARY user_pass=0x7261676e61726f6b) FROM login WHERE sex<>'S' ORDER BY account_id LIMIT 251;")?;
+    let output = dk.private_sql(&format!("SELECT account_id,HEX(userid),group_id,state,(BINARY user_pass=0x7261676e61726f6b),{MISSING_BIRTHDATE} FROM login WHERE sex<>'S' ORDER BY account_id LIMIT 251;"))?;
     let mut rows = Vec::new();
     for line in output.lines().filter(|l| !l.is_empty()) {
         let values: Vec<_> = line.split('\t').collect();
-        if values.len() != 5 {
+        if values.len() != 6 {
             return Err("Invalid account response".into());
         }
-        for index in [0, 2, 3, 4] {
+        for index in [0, 2, 3, 4, 5] {
             values[index]
                 .parse::<u32>()
                 .map_err(|_| "Invalid account response")?;
         }
         let name = unhex(values[1])?;
         rows.push(format!(
-            "{{\"id\":{},\"username\":{},\"group\":{},\"state\":{},\"defaultPassword\":{}}}",
+            "{{\"id\":{},\"username\":{},\"group\":{},\"state\":{},\"defaultPassword\":{},\"needsBirthdate\":{}}}",
             json::quote(values[0]),
             json::quote(&name),
             values[2],
             values[3],
-            values[4] == "1"
+            values[4] == "1",
+            values[5] == "1"
         ));
     }
     if rows.len() > 250 {
@@ -284,6 +309,45 @@ fn wait_for_restarted_maps(dk: &Docker, previous: Option<&str>) -> bool {
     false
 }
 
+/// The one statement an action runs, ending in `SELECT ROW_COUNT()` so the
+/// caller can tell a write that landed from one that matched nothing.
+///
+/// Separate from `run` so the SQL can be read in a test without a database:
+/// every value reaching it is either hex-encoded, parsed as a number, or a
+/// constant in this file, and that is a property worth pinning down.
+fn statement(action: &str, request: &Value) -> Result<String, String> {
+    Ok(match action {
+        "create" | "invite-create" => {
+            let name = field(request, "username")?;
+            username(name)?;
+            let pass = password(request)?;
+            format!("LOCK TABLES login WRITE, login AS existing READ; INSERT INTO login (userid,user_pass,sex,email,group_id,birthdate) SELECT {},{},'M','a@a.com',0,'{DEFAULT_BIRTHDATE}' FROM DUAL WHERE NOT EXISTS (SELECT 1 FROM login AS existing WHERE userid={}); SELECT ROW_COUNT(); UNLOCK TABLES;", hex(name), hex(pass), hex(name))
+        }
+        // Every account at once, not the selected one. A birthday is not a
+        // per-account preference here -- it is a fixed value the game needs
+        // present -- and a player who has hit the delete prompt has no way to
+        // tell which of their accounts is the one missing it. Accounts that
+        // already have one are left alone, so the button can be pressed twice.
+        "birthdates" => format!("UPDATE login SET birthdate='{DEFAULT_BIRTHDATE}' WHERE sex<>'S' AND {MISSING_BIRTHDATE}; SELECT ROW_COUNT();"),
+        "password" | "disable" | "enable" => {
+            let id = field(request, "id")?
+                .parse::<u32>()
+                .map_err(|_| "Invalid account ID")?;
+            let name = field(request, "username")?;
+            if id < 2000000 {
+                return Err("Service accounts cannot be edited here".into());
+            }
+            let assignment = match action {
+                "password" => format!("user_pass={}", hex(password(request)?)),
+                "disable" => "state=5".into(),
+                _ => "state=0".into(),
+            };
+            format!("UPDATE login SET {assignment} WHERE account_id={id} AND BINARY userid={} AND sex<>'S'; SELECT ROW_COUNT();", hex(name))
+        }
+        _ => return Err("Unknown account action".into()),
+    })
+}
+
 pub fn run(cfg: &Config, dk: &Docker) -> Result<(), String> {
     let mut input = String::new();
     io::stdin()
@@ -306,34 +370,20 @@ pub fn run(cfg: &Config, dk: &Docker) -> Result<(), String> {
     if action == "password" || action == "create" || action == "invite-create" {
         verify_password_format(cfg)?;
     }
-    let sql = match action {
-        "create" | "invite-create" => {
-            let name = field(&request, "username")?;
-            username(name)?;
-            let pass = password(&request)?;
-            format!("LOCK TABLES login WRITE, login AS existing READ; INSERT INTO login (userid,user_pass,sex,email,group_id) SELECT {},{},'M','a@a.com',0 FROM DUAL WHERE NOT EXISTS (SELECT 1 FROM login AS existing WHERE userid={}); SELECT ROW_COUNT(); UNLOCK TABLES;", hex(name), hex(pass), hex(name))
-        }
-        "password" | "disable" | "enable" => {
-            let id = field(&request, "id")?
-                .parse::<u32>()
-                .map_err(|_| "Invalid account ID")?;
-            let name = field(&request, "username")?;
-            if id < 2000000 {
-                return Err("Service accounts cannot be edited here".into());
-            }
-            let assignment = match action {
-                "password" => format!("user_pass={}", hex(password(&request)?)),
-                "disable" => "state=5".into(),
-                _ => "state=0".into(),
-            };
-            format!("UPDATE login SET {assignment} WHERE account_id={id} AND BINARY userid={} AND sex<>'S'; SELECT ROW_COUNT();", hex(name))
-        }
-        _ => return Err("Unknown account action".into()),
-    };
-    let update = || {
+    let sql = statement(action, &request)?;
+    let update = || -> Result<u32, String> {
         // Recheck immediately before touching any records.
         verify_era(cfg, dk, era)?;
         let output = dk.private_sql(&sql)?;
+        // A set operation, so any row count is a result rather than a refusal:
+        // zero means every account already had a birthday, which is the state
+        // the button exists to reach.
+        if action == "birthdates" {
+            return output
+                .trim()
+                .parse::<u32>()
+                .map_err(|_| "Invalid account response".into());
+        }
         if output.trim() != "1" {
             return Err(match action {
                 "password" => "The password was not changed: the account already uses this password. Choose a different one.",
@@ -342,9 +392,9 @@ pub fn run(cfg: &Config, dk: &Docker) -> Result<(), String> {
             }
             .into());
         }
-        Ok(())
+        Ok(1)
     };
-    if action == "invite-create" {
+    let changed = if action == "invite-create" {
         // The invited-player path only INSERTs a new group-0 row. It cannot
         // change a loaded account, so friends joining need not disconnect the
         // host or other players. Owner mutations retain their stop/save guard.
@@ -352,11 +402,14 @@ pub fn run(cfg: &Config, dk: &Docker) -> Result<(), String> {
             return Err("Invited accounts require internet friends mode".into());
         }
         crate::hosting::require_game_policy(cfg, dk)?;
-        update()?;
+        update()?
     } else {
-        with_servers_stopped(cfg, dk, update)?;
-    }
-    println!("{{\"era\":{},\"updated\":true}}", json::quote(era));
+        with_servers_stopped(cfg, dk, update)?
+    };
+    println!(
+        "{{\"era\":{},\"updated\":true,\"changed\":{changed}}}",
+        json::quote(era)
+    );
     Ok(())
 }
 
@@ -407,6 +460,47 @@ mod tests {
         let attack = "'; DROP TABLE login; --\\";
         assert_eq!(unhex(&hex(attack)[2..]).unwrap(), attack);
         assert!(hex(attack)[2..].bytes().all(|b| b.is_ascii_hexdigit()));
+    }
+    #[test]
+    fn every_account_this_app_creates_can_delete_a_character() {
+        // rAthena compares the delete prompt against login.birthdate, so an
+        // account created without one has characters that cannot be deleted
+        // from inside the game at all. Both creation paths write the date.
+        for action in ["create", "invite-create"] {
+            let request = json::parse(&format!(
+                "{{\"username\":\"friend-1\",\"password\":{},\"confirmation\":{}}}",
+                json::quote("a-test-only-secret"),
+                json::quote("a-test-only-secret")
+            ))
+            .unwrap();
+            let sql = statement(action, &request).unwrap();
+            assert!(sql.contains(&format!("'{DEFAULT_BIRTHDATE}'")));
+            assert!(sql.contains("group_id,birthdate"));
+        }
+    }
+    #[test]
+    fn the_birthdate_migration_only_fills_in_what_is_missing() {
+        let sql = statement("birthdates", &json::parse("{}").unwrap()).unwrap();
+        // Rows that already have a birthday keep it: the player may have set
+        // their own, and pressing the button twice must not rewrite it.
+        assert!(sql.contains(MISSING_BIRTHDATE));
+        // Service accounts are out of scope here exactly as they are in the
+        // listing and in every other write.
+        assert!(sql.contains("sex<>'S'"));
+        // No account is named, so no request field reaches the statement.
+        assert!(!sql.contains("account_id"));
+        assert!(sql.ends_with("SELECT ROW_COUNT();"));
+    }
+    #[test]
+    fn the_default_birthdate_is_safe_to_inline_and_matches_the_seeded_account() {
+        assert!(DEFAULT_BIRTHDATE
+            .bytes()
+            .all(|b| b.is_ascii_digit() || b == b'-'));
+        // The seed writes it into a fresh database; this file writes it into
+        // every account afterwards. They drift apart silently otherwise.
+        let seed = include_str!("../../sql/03-account.sql");
+        assert!(seed.contains(&format!("'{DEFAULT_BIRTHDATE}'")));
+        assert!(seed.contains("`birthdate`"));
     }
     #[test]
     fn ordinary_accounts_cannot_occupy_reserved_or_registration_names() {

--- a/stack/src/cmds.rs
+++ b/stack/src/cmds.rs
@@ -1755,9 +1755,11 @@ pub fn up(cfg: &Config, dk: &Docker, lan: bool, ram_mib: Option<u32>) -> Result<
     // reader takes the last assignment of a key: start_point in particular is
     // parsed by char_config_split_startpoint, which clears the array before
     // filling it, so the last line is the whole answer rather than an addition.
+    let instant_deletion = crate::registration::instant_character_deletion(&cfg.state)?;
     write_conf(&conf, "char_conf.txt",
-        &format!("login_ip: ragnarok-login\nchar_ip: {advertise}\npincode_enabled: no\n\
-                  {start_point}\n{}{}", conf_lines(&mods, "char_conf.txt"),
+        &format!("login_ip: ragnarok-login\nchar_ip: {advertise}\npincode_enabled: no\n{}\
+                  {start_point}\n{}{}", crate::registration::character_config(instant_deletion),
+                  conf_lines(&mods, "char_conf.txt"),
                   credentials.as_ref().map(|c| format!("userid: s1\npasswd: {}\n", c.interserver)).unwrap_or_default()))?;
 
     let product = if cfg!(target_os = "macos") { "RagnarokMac" }

--- a/stack/src/cmds.rs
+++ b/stack/src/cmds.rs
@@ -1196,7 +1196,7 @@ fn ensure_images(cfg: &Config, dk: &Docker) -> Result<(), String> {
     phase(cfg, "Loading the bundled server images…");
     // Always use Docker's owned-engine transport, including Windows' loopback
     // proxy. Existing fixed image tags are replaced when bundled bytes change.
-    dk.load_bundle(&bundle)?;
+    dk.load_bundle(&bundle, || dk.image_exists(&cfg.image) && dk.image_exists(&cfg.db_image))?;
     if !dk.image_exists(&cfg.image) || !dk.image_exists(&cfg.db_image) {
         return Err(format!("image load did not produce {} and {}", cfg.image, cfg.db_image));
     }

--- a/stack/src/crashes.rs
+++ b/stack/src/crashes.rs
@@ -281,6 +281,7 @@ pub fn capture(cfg: &Config, dk: &Docker, name: &str) -> Result<Option<String>, 
             "population_max",
             "population_density",
             "prerenewal",
+            "instant_character_deletion",
         ] {
             match settings.get(key) {
                 Some(Value::Bool(v)) => report.push_str(&format!("{key}: {v}\n")),

--- a/stack/src/docker.rs
+++ b/stack/src/docker.rs
@@ -161,13 +161,52 @@ impl Docker {
         }
     }
 
-    pub fn load_bundle(&self, bundle: &Path) -> Result<(), String> {
+    /// Load the bundled images, without trusting the loader to exit.
+    ///
+    /// This waited on the child forever. On Windows the loader has been seen
+    /// importing the bundle correctly and then never exiting, which hung the
+    /// first start of a fresh install with no output at all -- both streams go
+    /// to null -- and nothing to distinguish it from a slow import. Ten minutes
+    /// in, the process held 0.03s of CPU and killing it let startup continue
+    /// with the images already present.
+    ///
+    /// So `done` is the real completion test: the images the caller asked for
+    /// exist. A loader that exits first is still the fast path; one that hangs
+    /// after doing its work no longer costs anything. It is checked on a slower
+    /// cadence than the child is polled because each call runs a docker
+    /// command.
+    pub fn load_bundle(&self, bundle: &Path, done: impl Fn() -> bool) -> Result<(), String> {
         let file = fs::File::open(bundle).map_err(|_| "Cannot open the bundled server images")?;
-        let status = self.base().arg("load").stdin(Stdio::from(file))
-            .stdout(Stdio::null()).stderr(Stdio::null()).status()
+        let mut child = self.base().arg("load").stdin(Stdio::from(file))
+            .stdout(Stdio::null()).stderr(Stdio::null()).spawn()
             .map_err(|_| "Cannot run the bundled image loader")?;
-        if !status.success() { return Err("Could not load the bundled server images".into()); }
-        Ok(())
+        let deadline = Instant::now() + Duration::from_secs(900);
+        let mut next_check = Instant::now() + Duration::from_secs(5);
+        loop {
+            match child.try_wait() {
+                Ok(Some(status)) => {
+                    return if status.success() { Ok(()) }
+                    else { Err("Could not load the bundled server images".into()) };
+                }
+                Ok(None) => {}
+                Err(_) => return Err("Cannot run the bundled image loader".into()),
+            }
+            let now = Instant::now();
+            if now >= next_check {
+                if done() {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return Ok(());
+                }
+                next_check = now + Duration::from_secs(3);
+            }
+            if now >= deadline {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err("The bundled image loader did not finish in time".into());
+            }
+            sleep(Duration::from_millis(250));
+        }
     }
 
     pub fn image_exists(&self, image: &str) -> bool {

--- a/stack/src/registration.rs
+++ b/stack/src/registration.rs
@@ -1,6 +1,8 @@
-//! Persisted login registration policy, read on every startup/repair/era switch.
-//! Missing legacy settings retain local/LAN behavior; malformed settings never
-//! silently reopen registration. Internet-mode enforcement builds on this policy.
+//! Persisted account policy, read on every startup/repair/era switch: who may
+//! create a login, and how long a character survives after it is queued for
+//! deletion. Missing legacy settings retain local/LAN behavior; malformed
+//! settings never silently reopen registration or drop a safeguard.
+//! Internet-mode enforcement builds on this policy.
 use crate::json::{self, Value};
 use std::fs::File;
 use std::io::Read;
@@ -67,6 +69,49 @@ pub fn enabled(state: &Path) -> Result<bool, String> {
     Ok(requested)
 }
 
+/// rAthena's own delay before a queued character is actually removed, in
+/// seconds. Named here rather than left to the shipped config, because
+/// char_conf.txt is regenerated on every start and the key has to be written
+/// in both directions to mean anything.
+const DELETE_DELAY: u32 = 86400;
+
+const DELETE_ERROR: &str = "Cannot read the character deletion setting. Repair settings.json before starting the server; the deletion delay was left in place.";
+
+fn instant_deletion(settings: &Value) -> Result<bool, String> {
+    match settings.get("instant_character_deletion") {
+        // Absent is rAthena's own behaviour, which is also what every install
+        // predating this setting has been running.
+        None => Ok(false),
+        Some(Value::Bool(value)) => Ok(*value),
+        _ => Err(DELETE_ERROR.into()),
+    }
+}
+
+/// Whether a character goes the moment its birthday is accepted, or a day
+/// after it was queued.
+///
+/// The wait is worth having wherever someone else can reach the game: it is
+/// the countdown on the character slot, and the chance to cancel, that turn a
+/// malicious or mistaken deletion into something the player can still undo. On
+/// a loopback server with one player there is nobody to undo it against, and
+/// the day is only a day.
+///
+/// A damaged value keeps the wait rather than removing a safeguard nobody
+/// asked to remove.
+pub fn instant_character_deletion(state: &Path) -> Result<bool, String> {
+    instant_deletion(&settings(state)?)
+}
+
+/// The character-server line for that choice. Written either way, because a
+/// key left out of the regenerated config falls back to the shipped 86400 and
+/// the setting would appear to do nothing in one direction only.
+pub fn character_config(instant: bool) -> String {
+    format!(
+        "char_del_delay: {}\n",
+        if instant { 0 } else { DELETE_DELAY }
+    )
+}
+
 pub fn login_config(enabled: bool) -> String {
     format!(
         "new_account: {}\nacc_name_min_length: 4\npassword_min_length: 4\n",
@@ -84,6 +129,25 @@ mod tests {
         assert!(parse(r#"{"open_registration":true}"#).unwrap());
         assert!(parse(r#"{"prerenewal":false}"#).unwrap());
         assert!(login_config(false).starts_with("new_account: no\n"));
+    }
+
+    #[test]
+    fn deletion_stays_delayed_unless_the_owner_asked_for_otherwise() {
+        let read = |body: &str| instant_deletion(&json::parse(body).unwrap());
+        assert!(read(r#"{"instant_character_deletion":true}"#).unwrap());
+        assert!(!read(r#"{"instant_character_deletion":false}"#).unwrap());
+        // Every install predating the setting, and every one that has never
+        // opened it, keeps rAthena's day-long wait.
+        assert!(!read(r#"{"open_registration":false}"#).unwrap());
+        assert!(!read("{}").unwrap());
+        // A hand-edited value is refused rather than read as "no wait".
+        for value in ["\"true\"", "1", "null", "{}"] {
+            assert!(read(&format!("{{\"instant_character_deletion\":{value}}}")).is_err());
+        }
+        // Both directions are stated, so regenerating the config cannot leave
+        // the server on the shipped default while Settings says otherwise.
+        assert_eq!(character_config(true), "char_del_delay: 0\n");
+        assert_eq!(character_config(false), "char_del_delay: 86400\n");
     }
 
     #[test]

--- a/tests/accounts.test.cjs
+++ b/tests/accounts.test.cjs
@@ -70,6 +70,29 @@ test("structured errors redact the supplied password", async (t) => {
   );
 });
 
+test("the birthday migration carries no account and reports what it changed", async (t) => {
+  const cwd = fixture(
+    t,
+    `let input=''; process.stdin.on('data',c=>input+=c); process.stdin.on('end',()=>{
+        const request=JSON.parse(input);
+        require('node:fs').writeFileSync('request.json',input);
+        process.stdout.write(JSON.stringify({era:request.era,updated:true,changed:2}));
+    });`,
+  );
+  assert.deepEqual(
+    await runAccounts(
+      process.execPath,
+      { cwd },
+      { action: "birthdates", era: "renewal" },
+    ),
+    { era: "renewal", updated: true, changed: 2 },
+  );
+  // It fills in whichever accounts are missing a birthday, so a selected
+  // account travelling with it would be a bug rather than an extra field.
+  const sent = JSON.parse(fs.readFileSync(path.join(cwd, "request.json")));
+  assert.deepEqual(Object.keys(sent).sort(), ["action", "era"]);
+});
+
 test("unknown operations and oversized UTF-8 requests are rejected before spawning", async () => {
   await assert.rejects(
     runAccounts("/does-not-exist", {}, { ...request, action: "sql" }),

--- a/tests/cloudflare-sharing.test.cjs
+++ b/tests/cloudflare-sharing.test.cjs
@@ -98,8 +98,9 @@ test('a guard advisory reaches the player without failing the start', async t =>
   await f.instance.start(saved);
   assert.equal(f.instance.status().state, 'sharing');
   assert.match(f.instance.status().notice, /firewall dropped the check on 192\.168\.1\.5/);
-  // A later clean start must not keep showing the previous one's advisory.
+  // Stopping ends the session the advisory described.
   await f.instance.stop();
+  assert.equal(f.instance.status().notice, '', 'a stopped session shows no advisory');
   f.instance.guard = async () => '';
   await f.instance.start(saved);
   assert.equal(f.instance.status().notice, '');

--- a/tests/cloudflare-sharing.test.cjs
+++ b/tests/cloudflare-sharing.test.cjs
@@ -91,6 +91,19 @@ test('failed policy checks and cancellation cannot launch a connector later', as
   const pending = canceled.instance.start(saved); await canceled.instance.stop(); release(); await pending;
   assert.equal(canceled.launched(), undefined); assert.equal(canceled.instance.status().state, 'stopped');
 });
+// A check that could not confirm something is not a failure, but the player
+// still has to see it -- previously it reached the log and stopped there.
+test('a guard advisory reaches the player without failing the start', async t => {
+  const f = controller(t, { guard: async () => 'Your firewall dropped the check on 192.168.1.5.' });
+  await f.instance.start(saved);
+  assert.equal(f.instance.status().state, 'sharing');
+  assert.match(f.instance.status().notice, /firewall dropped the check on 192\.168\.1\.5/);
+  // A later clean start must not keep showing the previous one's advisory.
+  await f.instance.stop();
+  f.instance.guard = async () => '';
+  await f.instance.start(saved);
+  assert.equal(f.instance.status().notice, '');
+});
 test('connector exit removes the public gateway and reports a failed link', async t => {
   const f = controller(t); await f.instance.start(saved);
   f.child().exitCode = 1; f.child().emit('exit', 1, null);

--- a/tests/e2e/accounts-settings.cjs
+++ b/tests/e2e/accounts-settings.cjs
@@ -108,6 +108,19 @@ async function main() {
     );
     const friend = accounts.accounts.find((a) => a.username === username);
     if (!friend || friend.group !== 0) throw Error("Friend not ordinary");
+    // A new account has to be able to delete its characters: the game checks
+    // its delete prompt against a birthday the account must actually carry.
+    if (friend.needsBirthdate)
+      throw Error("A created account has no birthday and cannot delete a character");
+    // Worlds seeded before the birthday existed still have accounts without
+    // one, so the migration tracks the listing rather than a fixed state.
+    const migration = page.getByRole("button", {
+      name: "Set missing account birthdays",
+      exact: true,
+    });
+    if (accounts.accounts.some((account) => account.needsBirthdate))
+      await expect(migration).toBeEnabled();
+    else await expect(migration).toBeDisabled();
     await page.locator("#account-select").selectOption(friend.id);
     await page
       .getByRole("button", { name: "Disable account", exact: true })

--- a/tests/listener-probe.test.cjs
+++ b/tests/listener-probe.test.cjs
@@ -1,0 +1,90 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const net = require('node:net');
+const probe = require('../electron/listener-probe');
+
+// A listener on the loopback, and a port next to it with nothing on it. Real
+// sockets rather than mocks: the whole point of this module is what the local
+// TCP stack does with a connection, and a mock would be asserting the
+// classification table against itself.
+async function withListener(t, run) {
+  const server = net.createServer(socket => socket.destroy());
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+  t.after(() => new Promise(resolve => server.close(resolve)));
+  return run(server.address().port);
+}
+
+test('a reachable port is the one outcome that refuses sharing', async t => {
+  await withListener(t, async port => {
+    const report = await probe.probeListeners({ addresses: ['127.0.0.1'], ports: [port] });
+    assert.deepEqual(report.results.map(r => r.outcome), ['open']);
+    const decided = probe.verdict(report);
+    assert.equal(decided.shareable, false);
+    assert.match(decided.message, new RegExp(`127\\.0\\.0\\.1:${port}`));
+  });
+});
+
+test('a refused connection proves the port private and says nothing to the player', async () => {
+  // Bind to learn a free port, then release it, so the refusal is certain
+  // rather than a guess at a number nothing happens to be using.
+  const server = net.createServer();
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+  const free = server.address().port;
+  await new Promise(resolve => server.close(resolve));
+
+  const report = await probe.probeListeners({ addresses: ['127.0.0.1'], ports: [free] });
+  assert.deepEqual(report.results.map(r => r.outcome), ['closed']);
+  assert.deepEqual(probe.verdict(report), { shareable: true, message: '' });
+});
+
+// The shape that escaped the old inline check: connect() throws instead of
+// emitting, and an uncaught throw here is an unexplained sharing failure.
+test('an unprobeable address is a result rather than a thrown error', async () => {
+  const report = await probe.probeListeners({ addresses: ['127.0.0.1'], ports: [65536] });
+  assert.deepEqual(report.results.map(r => r.outcome), ['error']);
+  assert.equal(probe.verdict(report).shareable, true);
+});
+
+// The Windows default: unsolicited inbound is dropped without a reset, so the
+// probe times out on a machine whose ports are correctly private. This used to
+// be the failure that made sharing impossible there.
+test('a dropped probe explains itself and still allows sharing', async () => {
+  const report = await probe.probeListeners({ addresses: ['10.255.255.1'], ports: [6900], timeoutMs: 250 });
+  assert.deepEqual(report.results.map(r => r.outcome), ['filtered']);
+  const decided = probe.verdict(report);
+  assert.equal(decided.shareable, true);
+  assert.match(decided.message, /firewall dropped the check on 10\.255\.255\.1/);
+  assert.match(decided.message, /verified separately/);
+});
+
+test('every probe is named with its address, port and outcome', async () => {
+  const report = await probe.probeListeners({ addresses: ['10.255.255.1'], ports: [6900, 6121], timeoutMs: 250 });
+  assert.equal(probe.describe(report), [
+    '10.255.255.1:6900 filtered (no answer, so a packet filter dropped it)',
+    '10.255.255.1:6121 filtered (no answer, so a packet filter dropped it)',
+  ].join('\n'));
+});
+
+// A machine with a dozen virtual adapters would otherwise put every one of
+// them in a sentence a player is meant to read.
+test('many affected adapters are summarised, not listed in full', async () => {
+  const addresses = Array.from({ length: 6 }, (_, i) => `10.255.255.${i + 1}`);
+  const report = await probe.probeListeners({ addresses, ports: [6900], timeoutMs: 250 });
+  assert.equal(report.filtered.length, 6);
+  assert.match(probe.verdict(report).message, /10\.255\.255\.4 and 2 more/);
+});
+
+// Serial probing cost one timeout per address per port, which on the machine
+// this was reported from would have been the better part of a minute.
+test('probes run concurrently rather than one timeout after another', async () => {
+  const started = Date.now();
+  const addresses = Array.from({ length: 4 }, (_, i) => `10.255.255.${i + 1}`);
+  const report = await probe.probeListeners({ addresses, timeoutMs: 500 });
+  assert.equal(report.results.length, 16);
+  assert.ok(Date.now() - started < 2000, 'sixteen 500ms probes must not take eight seconds');
+});
+
+test('interface enumeration excludes loopback', () => {
+  assert.ok(!probe.localAddresses().includes('127.0.0.1'));
+});

--- a/tests/settings-store.test.cjs
+++ b/tests/settings-store.test.cjs
@@ -32,6 +32,22 @@ test('malformed saved policy fails closed and is never overwritten with defaults
   }
 });
 
+test('a damaged deletion setting is refused rather than read as no wait', t => {
+  const file = fixture(t);
+  store.write(file, { instant_character_deletion: true }, defaults);
+  assert.equal(store.read(file, defaults).instant_character_deletion, true);
+  const previous = fs.readFileSync(file, 'utf8');
+  for (const update of [{ instant_character_deletion: 'true' }, { instant_character_deletion: 1 }, { instant_character_deletion: null }]) {
+    assert.throws(() => store.write(file, update, defaults), /character deletion setting/);
+    assert.equal(fs.readFileSync(file, 'utf8'), previous);
+  }
+  // An install that has never opened the setting keeps rAthena's wait, and
+  // reading one must not rewrite the file to say so.
+  fs.writeFileSync(file, '{"max_aspd":190}');
+  assert.equal(store.read(file, defaults).instant_character_deletion, undefined);
+  assert.equal(fs.readFileSync(file, 'utf8'), '{"max_aspd":190}');
+});
+
 test('invalid updates cannot erase or reopen owner policy', t => {
   const file = fixture(t);
   store.write(file, { open_registration: false }, defaults);


### PR DESCRIPTION
Fixes two ways a Windows user gets stuck, plus the settings and docs around
them. Verified end to end on the Windows dev box: from a wiped data
directory, pressing Share with friends produced a working invitation link,
and a friend connected through it, made a character and played.

## Sharing refused on a correctly-private machine

Reported from the wild: **"Could not verify private game listeners."**

Before sharing, the app probes every LAN address on the four published ports
to prove nothing of ours answers there. It accepted only `ECONNREFUSED` as
proof. Windows discards unsolicited inbound without sending a reset, so on a
correctly-private install the probe times out, and the check failed with a
sentence naming neither an address nor a port.

A dropped probe now permits sharing and says what could not be confirmed.
Only a port that actually answers refuses. That is the property worth
enforcing and the one that was never broken; `sharing-check` already verifies
the container bindings and the engine's publication flag from the inside, so
this outside second opinion may report uncertainty without stopping anything.

Confirmed by a controlled comparison on the reporter's machine. With LAN
hosting on the ports bind the wildcard and the probe connects; in friends
scope they rebind to loopback and the same probe against the same firewall
times out. The only variable was the bind address.

Also fixed while there: probes ran serially, one timeout each, so a machine
with several virtual adapters spent up to 24 seconds in a check meant to be
instant; `net.connect` throws rather than emitting for a malformed address,
which was rejected through `Promise.all` as exactly the unexplained failure
being removed; and diagnostics carried no interface list, so a report of this
failure gave no way to tell which address the check objected to.

## First start hung on the image loader

On a wiped install, startup hung on "Loading the bundled server images…". The
loader had imported the bundle correctly and then never exited. It held 0.03s
of CPU after ten minutes; killing it let startup finish with nothing lost.

Nothing bounded that wait, and both of the loader's streams go to null, so
there was no output and no way to tell a hang from a slow import.

`load_bundle` now polls and treats "the images the caller asked for exist" as
completion, which the caller already verifies immediately afterwards.

**This is a workaround.** The bug is in nebula: the end of a streamed docker
response does not reach the client on Windows. It was seen again during
teardown on a different command, so it is not specific to `load`. Written up
separately for that repo. The bound stays here regardless, because a shipped
app should not hang forever on a bundled binary that will not exit, and it
cannot assume which nebula version a user has.

## Settings and docs

Allow LAN connections unticks itself when sharing starts, and nothing said
why. Opening the internet-sharing disclosure also used to turn LAN on, which
sharing then turned straight back off. The disclosure no longer changes
hosting, and the invitation note explains that sharing closes the LAN ports.
Three documents claiming the opposite are corrected.

## Testing

`npm test` 90 passing, `cargo test` 74 passing.

## Note on contents

This branch also carries the 1.1.0 release commit, earlier settings UI
tweaks, and another author's character-deletion work. My settings change
landed inside "Give every account a birthday" because the tree was shared
while it was uncommitted; the code is correct, only the attribution is off.

Still open before tagging 1.1.1: sharing intermittently fails its WebSocket
proof on the first press and succeeds on a retry, and the nebula fix needs to
land and be pinned here via `NEBULA_VERSION` and `config/NEBULA_MIN_VERSION`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012agyW3Xz5AjXUjNkAE2y2y