### PR TITLE
Keep @autoloot, @autoloottype and @showexp across a logout

### DIFF
--- a/third-party/server-fixes/0005-persist-loot-preferences.patch
+++ b/third-party/server-fixes/0005-persist-loot-preferences.patch
@@ -1,0 +1,111 @@
+diff --git a/src/map/atcommand.cpp b/src/map/atcommand.cpp
+index f367e9b..10aeccf 100644
+--- a/src/map/atcommand.cpp
++++ b/src/map/atcommand.cpp
+@@ -7003,6 +7003,7 @@ ACMD_FUNC(autoloot)
+ 	if (rate > 10000) rate = 10000;
+ 
+ 	sd->state.autoloot = rate;
++	pc_save_loot_prefs(sd); // RAGNAROKMAC: keep the setting across logins
+ 	if (sd->state.autoloot) {
+ 		snprintf(atcmd_output, sizeof atcmd_output, msg_txt(sd,1187),((double)sd->state.autoloot)/100.); // Autolooting items with drop rates of %0.02f%% and below.
+ 		clif_displaymessage(fd, atcmd_output);
+@@ -7186,6 +7187,7 @@ ACMD_FUNC(autoloottype)
+ 				return -1;
+ 			}
+ 			sd->state.autoloottype |= (1<<type); // Stores the type
++			pc_save_loot_prefs(sd); // RAGNAROKMAC: keep the setting across logins
+ 			sprintf(atcmd_output, msg_txt(sd,1483), itemdb_typename(type), type); // Autolooting item type: '%s' {%u}
+ 			clif_displaymessage(fd, atcmd_output);
+ 			break;
+@@ -7195,6 +7197,7 @@ ACMD_FUNC(autoloottype)
+ 				return -1;
+ 			}
+ 			sd->state.autoloottype &= ~(1<<type);
++			pc_save_loot_prefs(sd); // RAGNAROKMAC: keep the setting across logins
+ 			sprintf(atcmd_output, msg_txt(sd,1485), itemdb_typename(type), type); // Removed item type: '%s' {%u} from your autoloottype list.
+ 			clif_displaymessage(fd, atcmd_output);
+ 			break;
+@@ -7218,6 +7221,7 @@ ACMD_FUNC(autoloottype)
+ 			break;
+ 		case 4:
+ 			sd->state.autoloottype = 0;
++			pc_save_loot_prefs(sd); // RAGNAROKMAC: keep the setting across logins
+ 			clif_displaymessage(fd, msg_txt(sd,1491)); // Your autoloottype list has been reset.
+ 			break;
+ 	}
+@@ -9167,11 +9171,13 @@ ACMD_FUNC(showexp)
+ {
+ 	if (sd->state.showexp) {
+ 		sd->state.showexp = 0;
++		pc_save_loot_prefs(sd); // RAGNAROKMAC: keep the setting across logins
+ 		clif_displaymessage(fd, msg_txt(sd,1316)); // Gained exp will not be shown.
+ 		return 0;
+ 	}
+ 
+ 	sd->state.showexp = 1;
++	pc_save_loot_prefs(sd); // RAGNAROKMAC: keep the setting across logins
+ 	clif_displaymessage(fd, msg_txt(sd,1317)); // Gained exp is now shown.
+ 	return 0;
+ }
+diff --git a/src/map/pc.cpp b/src/map/pc.cpp
+index eceefa9..b51e4c6 100755
+--- a/src/map/pc.cpp
++++ b/src/map/pc.cpp
+@@ -2351,6 +2351,17 @@ bool pc_set_hate_mob(map_session_data *sd, int32 pos, block_list *bl)
+  * We didn't receive item information at this point so DO NOT attempt to do item operations here.
+  * See intif_parse_StorageReceived() for item operations [lighta]
+  *------------------------------------------*/
++// RAGNAROKMAC: persist the loot and exp display preferences. Called from the
++// commands that change them, so a value survives a crash as well as a logout.
++void pc_save_loot_prefs(map_session_data *sd)
++{
++	nullpo_retv(sd);
++
++	pc_setglobalreg(sd, add_str(AUTOLOOT_RATE_VAR), sd->state.autoloot);
++	pc_setglobalreg(sd, add_str(AUTOLOOT_TYPE_VAR), sd->state.autoloottype);
++	pc_setglobalreg(sd, add_str(SHOWEXP_VAR), sd->state.showexp);
++}
++
+ void pc_reg_received(map_session_data *sd)
+ {
+ 	uint8 i;
+@@ -2362,6 +2373,13 @@ void pc_reg_received(map_session_data *sd)
+ 	sd->change_level_4th = static_cast<unsigned char>(pc_readglobalreg(sd, add_str(JOBCHANGE4TH_VAR)));
+ 	sd->die_counter = static_cast<int32>(pc_readglobalreg(sd, add_str(PCDIECOUNTER_VAR)));
+ 
++	// RAGNAROKMAC: @autoloot, @autoloottype and @showexp were session-only, so
++	// every login began by retyping them. They are read here rather than at
++	// pc_authok because character variables have only arrived by this point.
++	sd->state.autoloot = static_cast<uint16>(cap_value(pc_readglobalreg(sd, add_str(AUTOLOOT_RATE_VAR)), 0, 10000));
++	sd->state.autoloottype = static_cast<uint16>(cap_value(pc_readglobalreg(sd, add_str(AUTOLOOT_TYPE_VAR)), 0, UINT16_MAX));
++	sd->state.showexp = pc_readglobalreg(sd, add_str(SHOWEXP_VAR)) ? 1 : 0;
++
+ 	sd->langtype = static_cast<int32>(pc_readaccountreg(sd, add_str(LANGTYPE_VAR)));
+ 	if (msg_checklangtype(sd->langtype,true) < 0)
+ 		sd->langtype = 0; //invalid langtype reset to default
+diff --git a/src/map/pc.hpp b/src/map/pc.hpp
+index 4cb5e93..c53a6a4 100644
+--- a/src/map/pc.hpp
++++ b/src/map/pc.hpp
+@@ -55,6 +55,11 @@ class MapGuild;
+ #define ROULETTE_SILVER_VAR "RouletteSilver"
+ #define ROULETTE_GOLD_VAR "RouletteGold"
+ #define COOKMASTERY_VAR "COOK_MASTERY"
++// RAGNAROKMAC: per-character loot and exp display preferences. Stored as
++// ordinary character variables so they persist without a schema change.
++#define AUTOLOOT_RATE_VAR "AUTOLOOT_RATE"
++#define AUTOLOOT_TYPE_VAR "AUTOLOOT_TYPE"
++#define SHOWEXP_VAR "SHOWEXP"
+ #define PCDIECOUNTER_VAR "PC_DIE_COUNTER"
+ #define JOBCHANGE2ND_VAR "jobchange_level"
+ #define JOBCHANGE3RD_VAR "jobchange_level_3rd"
+@@ -1694,6 +1699,8 @@ void pc_inventory_rental_add(map_session_data *sd, uint32 seconds);
+ int32 pc_read_motd(void); // [Valaris]
+ int32 pc_disguise(map_session_data *sd, int32 class_);
+ bool pc_isautolooting(map_session_data *sd, t_itemid nameid);
++// RAGNAROKMAC: write the current loot/exp preferences to character variables.
++void pc_save_loot_prefs(map_session_data *sd);
+ 
+ void pc_overheat(map_session_data &sd, int16 heat);
+ 

--- a/third-party/server-fixes/README.md
+++ b/third-party/server-fixes/README.md
@@ -28,3 +28,13 @@ equipping a Katar read index 16 from the old 16-element array. Later weapon type
 also exceeded that array, including the damage bonus used by combat.
 `verify-weapon-bounds.py` reproduces the actual declaration/setter/status-read
 fault and checks every weapon type plus invalid script indices after patching.
+
+`0005-persist-loot-preferences.patch` keeps `@autoloot`, `@autoloottype` and
+`@showexp` across a logout. All three lived only in the session, so every login
+began by retyping them, and players were writing login scripts to do it for
+them. The values are stored as ordinary per-character variables, which needs no
+schema change and no migration, written by the commands that set them so a
+crash loses nothing, and read back in `pc_reg_received` because that is the
+first point at which character variables have arrived. A stored rate is clamped
+to rAthena's own range on the way in, so a hand-edited variable cannot put the
+session into a state the command itself could not produce.


### PR DESCRIPTION
Fixes #81.

All three settings lived only in the session, so every login began by retyping
them. A player had already worked around it with a hand-written mod that fires
the commands from `OnPCLoginEvent`, which is the clearest possible signal that
this is state the server should just keep.

## How

They are stored as ordinary per-character variables, the same mechanism
rAthena already uses for the die counter and job change levels. No schema
change, no migration, nothing to enable, and it works for existing characters
the first time they set a preference.

- **Written by the commands that set them**, not at logout, so a crash loses
  nothing.
- **Read back in `pc_reg_received`**, not `pc_authok`, because that is the
  first point at which character variables have actually arrived.
- **The stored rate is clamped** to rAthena's own 0-10000 range on the way in,
  so a hand-edited variable cannot put a session into a state the command
  itself could not produce.

Six write sites: `@autoloottype` changes its mask in three places and
`@showexp` toggles in two. Saving in six places and restoring in one is the
shape that survives someone adding a seventh path later, because a missed save
is a setting that does not stick, where a missed restore would be silent.

## Where it goes

`third-party/server-fixes/`, which is the existing mechanism for small pinned
rAthena corrections and already holds four. rAthena itself is never forked.

## Verification

Applied the whole server-mod set to a pristine checkout of the pinned rAthena
(`e985006`) and ran it twice. It applies alongside the population engine and
the four existing fixes, and reports `already applied` on the second run.

Symbols used are all already in scope in the files they are added to:
`cap_value` is a macro in `common/utils.hpp`, `nullpo_retv` and `UINT16_MAX`
are used throughout `pc.cpp`, and `atcommand.cpp` already includes `pc.hpp`.

**Not yet compiled.** The server image is built in CI, so the compile happens
in `images.yml` on merge.

## Sequencing note for whoever releases this

A change under `third-party/**` triggers `images.yml`, which republishes the
rolling `images` release that `build.yml` downloads. So after merging, let the
image build finish on main **before** tagging, or the app build will package
the previous server image and the fix will appear not to work.

## Testing in game

Set `@autoloot 100`, add a type with `@autoloottype +0`, turn on `@showexp`,
then log out and back in. All three should survive. `@autoloottype reset` and
turning `@showexp` off should also persist, since the off state is saved the
same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012agyW3Xz5AjXUjNkAE2y2y