### PR TITLE
Fix item comparison description formatting

### DIFF
--- a/patches/0013-item-compare-description-formatting.md
+++ b/patches/0013-item-compare-description-formatting.md
@@ -1,0 +1,23 @@
+# Item comparison description formatting
+
+The inventory item comparison window displayed equipment descriptions
+differently from the regular item window. Ragnarok color markers such as
+`^0000CC` and `^000000` appeared as visible text instead of changing the text
+color. Once those markers were rendered as HTML, the browser also collapsed
+the description's line breaks, putting fields such as type, defense, weight,
+and armor level on the same line.
+
+`ItemInfo` already implements the intended behavior. This patch gives
+`ItemCompare` the same rendering path: escape the source description, pass it
+through `DB.formatMsgToHtml`, and preserve whitespace with `pre-wrap`.
+
+The escaping step remains in place before assigning `innerHTML`, so item data
+cannot introduce arbitrary markup.
+
+## Verification
+
+The packaged Windows client was manually tested with weapons and armor. After
+right-clicking comparable equipment in the inventory, color markers were no
+longer visible and the description fields retained their original line breaks.
+The fix was reapplied and retested after a clean installation of Ragnarok
+Offline 1.1.4.

--- a/scripts/patch-client.sh
+++ b/scripts/patch-client.sh
@@ -867,6 +867,49 @@ elif s.count(anchor) == 1:
 else:
     sys.exit("EquipmentV4.css: removeOption block no longer matches (%d hits); re-check the patch" % s.count(anchor))
 
+# 0013 - Render inventory comparison descriptions like the regular item window.
+#
+# ItemInfo escapes the description and passes it through formatMsgToHtml, which
+# interprets Ragnarok's ^RRGGBB color markers. ItemCompare assigned the same
+# description with textContent instead, exposing those markers as raw text.
+p = rb / "src/UI/Components/ItemCompare/ItemCompare.js"
+s = p.read_text()
+old = """	const descInner = root.querySelector('.description-inner');
+	if (descInner) {
+		descInner.textContent = item.IsIdentified ? it.identifiedDescriptionName : it.unidentifiedDescriptionName;
+	}"""
+new = """	const descInner = root.querySelector('.description-inner');
+	if (descInner) {
+		const rawDesc = item.IsIdentified ? it.identifiedDescriptionName : it.unidentifiedDescriptionName;
+		descInner.innerHTML = DB.formatMsgToHtml(_escapeHTML(rawDesc));
+	}"""
+if "descInner.innerHTML = DB.formatMsgToHtml(_escapeHTML(rawDesc));" in s:
+    print("ItemCompare.js description already patched")
+elif s.count(old) == 1:
+    p.write_text(s.replace(old, new, 1))
+    print("patched ItemCompare.js (format comparison description)")
+else:
+    sys.exit("ItemCompare.js: description renderer no longer matches (%d hits); re-check the patch" % s.count(old))
+
+# HTML rendering collapses newlines unless the comparison description opts
+# into preserving them. ItemInfo already has this rule; ItemCompare did not.
+p = rb / "src/UI/Components/ItemCompare/ItemCompare.css"
+s = p.read_text()
+old = """.ItemCompare .description .description-inner {
+	width: 150px;
+}"""
+new = """.ItemCompare .description .description-inner {
+	width: 150px;
+	white-space: pre-wrap;
+}"""
+if new in s:
+    print("ItemCompare.css line breaks already patched")
+elif s.count(old) == 1:
+    p.write_text(s.replace(old, new, 1))
+    print("patched ItemCompare.css (preserve description line breaks)")
+else:
+    sys.exit("ItemCompare.css: description style no longer matches (%d hits); re-check the patch" % s.count(old))
+
 PY
 
 python3 "$ROOT/scripts/patch-client-controls.py" "$ROOT" "$RB"


### PR DESCRIPTION
## Summary

Fix equipment descriptions in the inventory comparison window so they render like descriptions in the regular item window.

- interpret Ragnarok color markers instead of displaying them as raw text
- preserve the description's original line breaks
- keep the description HTML-escaped before formatting
- document the cause and manual verification

## Problem

Right-clicking a comparable equipment item in the inventory opened the comparison window, but that window assigned the description with `textContent`. As a result, color markers such as `^0000CC` and `^000000` appeared as visible text.

Rendering the description as formatted HTML fixes the color markers, but HTML collapses newline characters by default. This put fields such as type, defense, weight and armor level on the same line.

The regular `ItemInfo` component already handles both cases correctly.

## Implementation

The new idempotent `0013` client patch:

- uses the same escaped `DB.formatMsgToHtml(...)` rendering path as `ItemInfo`
- adds `white-space: pre-wrap` to the comparison description

## Testing

- reproduced with weapon and armor comparisons in the packaged Windows client
- manually verified that raw color markers no longer appear
- manually verified that description fields retain their intended line breaks
- reinstalled Ragnarok Offline 1.1.4, reproduced the original bug, reapplied the fix and verified it again
- applied the `0013` patch block twice to the pinned roBrowserLegacy commit; the second run correctly reported both changes as already applied
- syntax-checked the patched `Online.js`

## AI assistance

As always OpenAI Codex assisted with the investigation, implementation, cleanup and documentation of the fix.