### PR TITLE
Fix status tooltip color formatting

### DIFF
--- a/patches/0014-stat-tooltip-color-formatting.md
+++ b/patches/0014-stat-tooltip-color-formatting.md
@@ -1,0 +1,22 @@
+# Status tooltip color formatting
+
+The V2 status window provides explanatory tooltips when hovering primary,
+secondary, and trait stats. Their localized messages contain Ragnarok color
+markers such as `^66cc33` and `^ffffff`, but the generic `data-text` renderer
+inserts every message as plain text. Consequently, those markers appeared
+literally in descriptions such as Strength and Power.
+
+This patch keeps the generic renderer unchanged and limits HTML formatting to
+WinStats description tooltips (`.desc .hover[data-text]`). Each localized
+message is escaped through a temporary DOM element before
+`DB.formatMsgToHtml` converts its color markers to spans. Regular translated
+labels and other components remain unaffected.
+
+## Verification
+
+The packaged Windows client was manually tested with both sections of the V2
+status window. Hovering the six primary stats and the expanded trait stats
+displayed their descriptions with colored stat names and no visible Ragnarok
+color markers. The resulting client bundle was also checked for the `DB`
+declaration, WinStats database initialization, both formatter methods, and
+JavaScript syntax.

--- a/scripts/patch-client.sh
+++ b/scripts/patch-client.sh
@@ -910,6 +910,35 @@ elif s.count(old) == 1:
 else:
     sys.exit("ItemCompare.css: description style no longer matches (%d hits); re-check the patch" % s.count(old))
 
+# 0014 - Render Ragnarok color markers in status-description tooltips.
+#
+# Generic data-text labels are deliberately inserted with textContent. The
+# WinStats descriptions are different: their localized messages contain
+# ^RRGGBB markers which should color the affected stat names.
+p = rb / "src/UI/Components/WinStats/WinStatsCommon.js"
+s = p.read_text()
+old = """		_root = this.getRoot();
+
+		// Base stat up buttons"""
+new = """		_root = this.getRoot();
+
+		// Stat descriptions use RO color codes (^RRGGBB), unlike regular UI labels.
+		// Keep data-text's safe text lookup, then only render formatting in tooltips.
+		_root.querySelectorAll('.desc .hover[data-text]').forEach(tooltip => {
+			const escaped = document.createElement('div');
+			escaped.textContent = DB.getMessage(tooltip.dataset.text, '');
+			tooltip.innerHTML = DB.formatMsgToHtml(escaped.innerHTML);
+		});
+
+		// Base stat up buttons"""
+if "tooltip.innerHTML = DB.formatMsgToHtml(escaped.innerHTML);" in s:
+    print("WinStatsCommon.js status tooltips already patched")
+elif s.count(old) == 1:
+    p.write_text(s.replace(old, new, 1))
+    print("patched WinStatsCommon.js (format status tooltip colors)")
+else:
+    sys.exit("WinStatsCommon.js: tooltip initialization no longer matches (%d hits); re-check the patch" % s.count(old))
+
 PY
 
 python3 "$ROOT/scripts/patch-client-controls.py" "$ROOT" "$RB"


### PR DESCRIPTION
## Summary

Fix the status window tooltips displaying Ragnarok color markers such as `^66cc33` and `^ffffff` as literal text.

## Problem

The explanatory messages shown when hovering primary, secondary, and trait stats such as Str, Agi, Vit, etc. contain Ragnarok color codes. The generic `data-text` renderer safely inserts localized messages as plain text, so these codes were displayed instead of being interpreted as colors.

## Solution

Limit formatted rendering to the status-description tooltips (`.desc .hover[data-text]`).

Each localized message is first escaped through a temporary DOM element and then passed to `DB.formatMsgToHtml`. This preserves safe text handling while converting only the Ragnarok color markers into styled spans. The generic translation renderer and other UI components remain unchanged.

## Verification

- Manually tested client with the status window.
- Verified the tooltips for primary and trait stats.
- Confirmed that color markers are no longer visible and highlighted stat names use their intended colors.
- Applied the complete client patch twice to a clean checkout of the pinned roBrowserLegacy revision to verify applicability and idempotency.
- Verified the generated bundle identifiers and JavaScript syntax.

## AI assistance

As always OpenAI Codex assisted with the investigation, implementation, cleanup and documentation of the fix.