### PR TITLE
Apply the drop rate sliders to bosses and MVPs, not just ordinary monsters

### DIFF
--- a/electron/battle-rates.js
+++ b/electron/battle-rates.js
@@ -1,0 +1,45 @@
+'use strict';
+//
+// Drop rate keys for the generated battle configuration.
+//
+// rAthena keeps three independent families of drop rate -- ordinary monsters,
+// bosses, and MVPs -- and reads a separate key per item category in each.
+// Only part of two families were ever written: bosses got common, equipment
+// and card but not healing or usable, and MVPs got nothing at all. A player
+// who raised the sliders saw them work on ordinary monsters and not on the
+// monsters they most wanted them for, which is what `@rates` reported.
+//
+// Generated from one table so a family cannot go half-covered again, and kept
+// in its own module because main.js exports nothing and so nothing here could
+// be tested -- which is the reason this went out wrong.
+
+// The five categories rAthena scales, and which slider each follows. Healing
+// and usable ride the item slider alongside common: the UI offers three
+// numbers, not five, and splitting them here would invent a setting.
+const CATEGORY_SLIDER = {
+	common: 'item_rate_common',
+	heal: 'item_rate_common',
+	use: 'item_rate_common',
+	equip: 'item_rate_equip',
+	card: 'item_rate_card',
+};
+
+// '' is ordinary monsters. rAthena spells the other two as key suffixes.
+const FAMILIES = ['', '_boss', '_mvp'];
+
+/**
+ * Every drop rate key, for every monster family, as battle-conf lines.
+ *
+ * Deliberately not included: `item_rate_mvp` is the MVP *reward* rather than a
+ * drop and `item_rate_treasure` is chest contents, both of which the caller
+ * sets from the item slider already; `item_rate_adddrop` scales drops granted
+ * by equipment scripts, which is not what any of these sliders describes.
+ */
+function dropRateConf(settings) {
+	return FAMILIES.flatMap(family =>
+		Object.entries(CATEGORY_SLIDER).map(
+			([category, slider]) => `item_rate_${category}${family}: ${settings[slider]}`))
+		.join('\n') + '\n';
+}
+
+module.exports = { dropRateConf, FAMILIES, CATEGORY_SLIDER };

--- a/electron/main.js
+++ b/electron/main.js
@@ -974,14 +974,7 @@ function toBattleConf(s) {
 		// it feeds the same two bars, so a raised quest rate is discarded on
 		// turn-in the same way.
 		`multi_level_up: ${expRatesRaised(s) ? 'yes' : 'no'}\n` +
-		`item_rate_common: ${s.item_rate_common}\n` +
-		`item_rate_common_boss: ${s.item_rate_common}\n` +
-		`item_rate_equip: ${s.item_rate_equip}\n` +
-		`item_rate_equip_boss: ${s.item_rate_equip}\n` +
-		`item_rate_card: ${s.item_rate_card}\n` +
-		`item_rate_card_boss: ${s.item_rate_card}\n` +
-		`item_rate_heal: ${s.item_rate_common}\n` +
-		`item_rate_use: ${s.item_rate_common}\n` +
+		require('./battle-rates').dropRateConf(s) +
 		`item_rate_mvp: ${s.item_rate_common}\n` +
 		`item_rate_treasure: ${s.item_rate_common}\n` +
 		`zeny_from_mobs: ${s.zeny_from_mobs ? 'yes' : 'no'}\n` +

--- a/tests/battle-rates.test.cjs
+++ b/tests/battle-rates.test.cjs
@@ -1,0 +1,58 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { dropRateConf } = require('../electron/battle-rates');
+
+const settings = { item_rate_common: 400, item_rate_equip: 1000, item_rate_card: 1500 };
+const parse = text => Object.fromEntries(
+	text.trim().split('\n').map(line => line.split(': ').map(part => part.trim())));
+
+// The reported bug: sliders worked on ordinary monsters, half-worked on bosses
+// and did nothing at all on MVPs, because those are three separate key
+// families in rAthena and only part of two were written.
+test('every category is set for ordinary monsters, bosses and MVPs', () => {
+	const conf = parse(dropRateConf(settings));
+	for (const family of ['', '_boss', '_mvp']) {
+		assert.equal(conf[`item_rate_common${family}`], '400', `common${family}`);
+		assert.equal(conf[`item_rate_heal${family}`], '400', `heal${family}`);
+		assert.equal(conf[`item_rate_use${family}`], '400', `use${family}`);
+		assert.equal(conf[`item_rate_equip${family}`], '1000', `equip${family}`);
+		assert.equal(conf[`item_rate_card${family}`], '1500', `card${family}`);
+	}
+	assert.equal(Object.keys(conf).length, 15, 'five categories across three families');
+});
+
+// Each of the three sliders reaches every family. A slider that only moved
+// ordinary monsters is the shape of the original bug.
+test('each slider moves independently and reaches all three families', () => {
+	const conf = parse(dropRateConf({ item_rate_common: 100, item_rate_equip: 2500, item_rate_card: 700 }));
+	const at = rate => Object.entries(conf).filter(([, v]) => v === rate).map(([k]) => k).sort();
+	assert.deepEqual(at('2500'), ['item_rate_equip', 'item_rate_equip_boss', 'item_rate_equip_mvp']);
+	assert.deepEqual(at('700'), ['item_rate_card', 'item_rate_card_boss', 'item_rate_card_mvp']);
+	assert.equal(at('100').length, 9, 'common, heal and use across three families');
+});
+
+// These are set by the caller from the item slider, or not at all. Emitting
+// them here would write each one twice into the same generated file.
+test('the reward, treasure and equip-granted keys are left to the caller', () => {
+	const conf = dropRateConf(settings);
+	for (const key of ['item_rate_mvp:', 'item_rate_treasure:', 'item_rate_adddrop:']) {
+		assert.equal(conf.includes(key), false, `${key} must not be emitted here`);
+	}
+});
+
+// `item_rate_mvp` is a real key, so a naive "starts with" check would collide
+// with the MVP family and silently drop it back to the default.
+test('the MVP family is suffixed, never confused with the MVP reward key', () => {
+	const conf = parse(dropRateConf(settings));
+	assert.equal('item_rate_mvp' in conf, false);
+	assert.equal(conf.item_rate_common_mvp, '400');
+});
+
+test('output is one key per line and parses as battle conf', () => {
+	const text = dropRateConf(settings);
+	assert.ok(text.endsWith('\n'), 'trailing newline, so the caller can concatenate');
+	for (const line of text.trim().split('\n')) {
+		assert.match(line, /^item_rate_[a-z]+(_boss|_mvp)?: \d+$/);
+	}
+});


### PR DESCRIPTION
Fixes #91.

## The bug

rAthena keeps **three independent families of drop rate** and reads a separate
key per item category in each. We wrote part of two:

| Family | Before | After |
|---|---|---|
| Ordinary monsters | all five categories | unchanged |
| Bosses | common, equipment, card | all five |
| MVPs | **nothing** | all five |

So MVP drops stayed at 1x however high the sliders went, and boss healing and
usable items did too. That matches the report exactly: `@rates` listed normal
drops at the configured 4x, 10x and 15x, boss drops mixed, and MVP drops flat
at 1.00x across every category, on a server whose sliders were plainly not at
1x.

The keys `@rates` reads are in `atcommand.cpp`, and there are fifteen of them:
`item_rate_{common,heal,use,equip,card}` with no suffix, `_boss`, and `_mvp`.

## The fix

All fifteen are generated from one table, so a family cannot go half-covered
again. The three sliders cover five categories: healing and usable follow the
item drop slider alongside common, because the UI offers three numbers and
splitting them here would invent a setting nobody chose.

**Left alone deliberately.** `item_rate_mvp` is the MVP *reward* rather than a
drop, and `item_rate_treasure` is chest contents; both are already set beside
this from the item slider. `item_rate_adddrop` scales drops granted by
equipment scripts, which is not what any of these sliders describes, so tying
it to the card slider would be wrong.

## Why it moved to its own module

`main.js` exports nothing, so nothing in it could be asserted, and that is why
five missing keys and a sixth that only half worked shipped unnoticed. The
generation now sits in `electron/battle-rates.js` beside `settings-store.js`
and `hosting-policy.js`, which follow the same pattern.

The test pins all three families, that each slider reaches all of them, and
that the `_mvp` family is not confused with the similarly named
`item_rate_mvp` reward key -- a naive prefix check would collide with it and
silently drop MVP rates back to default.

## Testing

`npm test` 95 passing, `cargo test` 74 passing.

In game: raise the sliders, restart the server, then `@rates`. All three lines
should show the configured multipliers rather than 1.00x. Rates apply at
server start, so the restart is required.