### PR TITLE
Open Settings first if you ask for it, and bring sharing back on a named tunnel

### DIFF
--- a/docs/ADVANCED_FEATURES.md
+++ b/docs/ADVANCED_FEATURES.md
@@ -148,6 +148,20 @@ You lose your characters, your rate settings, and the app's memory of where your
 GRFs are. You do not lose the GRFs themselves. This is also the reliable fix for
 an install that has got itself into a state no amount of restarting clears.
 
+## Opening Settings instead of the game
+
+Launching the app opens the game window, which starts the server for you. That
+is what almost everyone wants, and it is the default.
+
+If you spend more time changing settings than playing — switching era, testing a
+mod, moving rates around — turn on **Settings → General → Startup → At startup:
+open Settings instead of the game**. The next launch opens Settings and nothing
+else. No server starts on its own, so press **Start** and then **Open game**
+under **Server** when you actually want to play.
+
+Closing that window quits the app, the same as closing the game window does.
+Turn the option off to go back to the game opening first.
+
 ## Finding your way around
 
 Open **Navigation** in the game client to search every entry, or just NPCs, or

--- a/docs/FRIENDS_SHARING.md
+++ b/docs/FRIENDS_SHARING.md
@@ -62,6 +62,25 @@ or suspending the host also stops sharing. Start sharing again when ready.
 A failed/reconnecting link is shown as such; Copy is enabled only after the
 public HTTPS endpoint and a game WebSocket have verified against this host.
 
+**With your own domain connected, that last step happens by itself.** A named
+tunnel keeps its hostname, so once the server is up again — after applying a
+setting, a Repair, a crash you recovered from, or the next time you start the
+server — sharing comes back at the same address and the link your friends
+already have starts working again with nothing sent to anyone. There is nothing
+to turn on.
+
+Three things it will not do. It never acts on a server that has not been shared
+before: the saved hosting scope is the record of that, so a local or LAN server
+is never put on the internet by it, and an automatic start never changes how the
+game ports bind. It never resumes a temporary link, whose `trycloudflare.com`
+address changes every time — resuming one would open a tunnel at an address
+nobody holds, which is what connecting a domain is for. And it never overrides
+**Stop sharing**, which holds until you share again yourself or relaunch the
+app, so applying a setting a minute later does not undo it. To stop sharing for
+good, use **Forget saved Cloudflare connection**, or take the server off friends
+mode. An automatic start runs the same checks and reports in the same place as
+the button, and a failure leaves the panel saying why.
+
 Forgetting a connection removes its saved local credential. The stopped tunnel
 and DNS record remain in Cloudflare for the account owner to remove there.
 Open public registration, SMTP/reset services and ngrok are not provided.

--- a/electron/main.js
+++ b/electron/main.js
@@ -899,6 +899,13 @@ const SETTINGS_DEFAULTS = {
 	// countdown on the slot is what lets a player undo a deletion somebody else
 	// started, which matters the moment friends can reach the server.
 	instant_character_deletion: false,
+	// Which window a launch opens. Off means the game, which is what anyone
+	// who has not asked for this gets; on means the Settings window and no
+	// game window at all. The only shell-side preference in this file -- it is
+	// here because settings.json is where the app's preferences live and the
+	// window already reads it, and it is deliberately ignored by
+	// writeSettingsFiles: the server knows nothing about it.
+	open_settings_first: false,
 	// Pre-renewal is a different rAthena build, not a runtime option, so this
 	// selects which of the two the supervisor starts. Each mode keeps its own
 	// characters -- see db_volume() in stack/src/cmds.rs for why sharing them
@@ -908,6 +915,25 @@ const SETTINGS_DEFAULTS = {
 
 function getSettings() {
 	return require('./settings-store').read(path.join(stateDir(), 'settings.json'), SETTINGS_DEFAULTS);
+}
+
+// Keys in settings.json that the app acts on rather than the server, and the
+// only names set_app_preference will write. Everything else in that file
+// changes how the server runs and has to go through Apply.
+const APP_PREFERENCES = new Set(['open_settings_first']);
+
+// Whether this launch opens Settings instead of the game.
+//
+// Guarded, and answering false on anything it cannot read: a settings.json the
+// store refuses is already reported everywhere it matters, and the one thing it
+// must not do is leave a launch with no window at all. The game window is the
+// safe answer because it is the one nobody has to have asked for.
+function openSettingsFirst() {
+	try {
+		return getSettings().open_settings_first === true;
+	} catch {
+		return false;
+	}
 }
 
 // rAthena has no zeny multiplier: whether monsters drop zeny at all is a
@@ -1472,6 +1498,122 @@ async function installModFrom(src) {
 }
 
 // ---------------------------------------------------------------------------
+// Sharing, and putting it back
+// ---------------------------------------------------------------------------
+
+// Set when the player stops sharing themselves, cleared when they start it by
+// hand again. Since a connected domain resumes without being asked, this is
+// what makes Stop mean stopped -- see auto-share.
+let sharingStoppedByHand = false;
+
+// The whole of "Share with friends", so that an automatic resume runs the same
+// sequence as the button rather than a second, thinner version of it that
+// drifts.
+//
+// `applyScope` is the only difference between the two callers. The button may
+// be arriving from a server that is local-only or on the LAN, so it writes
+// friends mode and cycles the stack to pick it up. A resume is already in
+// friends mode -- that is one of the conditions for resuming at all -- and the
+// stack it would cycle is the one that just came up.
+async function shareWithFriends({ useDomain, applyScope }) {
+	const request = ++sharingStartRequest;
+	if (getClientPaths().mode !== 'host') throw Error('Start your own server before sharing.');
+	const saved = useDomain ? getSharingSecrets().load() : null;
+	if (useDomain && !saved) throw Error('Connect your Cloudflare domain first, or use a temporary session link.');
+	// Securing this era's internal credentials is mechanical: it backs the
+	// database up first and preserves every account and character. Refusing
+	// here and telling the player to go find a button in another section is
+	// what made "share with friends" feel like a maze, so just do it. Safe
+	// to run from here -- sharing has not started, so runStack's stop-first
+	// rule for this verb has nothing to interrupt.
+	const era = getSettings().prerenewal ? 'prerenewal' : 'renewal';
+	if (!fs.existsSync(path.join(stateDir(), 'private/service-credentials', era, 'credentials.json'))) {
+		appLog('sharing: securing this era\u2019s internal service credentials (one time; the database is backed up first)');
+		await runStack(['secure-services']);
+	}
+	// Account safeguards stay in force, but the signup policy is the
+	// owner's to set. Sharing used to force it off and then hide the
+	// resulting check failure, which made _M/_F unreachable over a link
+	// even though the tunnel only carries invited friends.
+	const policy = JSON.parse(await runStack(['hosting-check']));
+	const missing = policy.checks.filter(check => !check.passed);
+	if (missing.length) throw Error(missing.map(check => check.detail).join(' '));
+	if (applyScope) await saveSettings({ hosting_scope: 'friends' });
+	await assetsStart();
+	if (request !== sharingStartRequest) return getSharing().status();
+	await getSharing().start(saved);
+	return getSharing().status();
+}
+
+// Put sharing back on after something stopped it. The conditions are in
+// sharing/auto-share.js; this is the plumbing around them.
+//
+// Queued and not awaited, on purpose. The operation that just finished is what
+// the player is waiting on, and a tunnel takes tens of seconds to come up, so
+// this chains itself behind that operation and then reports through the sharing
+// panel exactly like a manual start -- because it is one. Nothing about the
+// triggering operation succeeds or fails on the strength of it.
+//
+// The generation is read now and checked again when the turn comes: a Stop, a
+// crash, a suspend or a share started by hand in between all move it, and each
+// of those is a reason to drop a resume that was decided before it happened.
+function resumeSharing(reason) {
+	const generation = sharingStartRequest;
+	// Asked at both ends rather than once: the mode, the scope and a
+	// Stop can all have happened by the time the queue reaches this, and the
+	// answer that matters is the one at that moment.
+	const assess = () => {
+		const client = getClientPaths();
+		// The secure store is opened only once the cheap conditions agree.
+		// This runs after every server operation, and asking the operating
+		// system to unlock a credential to answer a question already settled is
+		// both slow and a source of failures that have nothing to do with
+		// sharing. The repeated conditions are a guard on that lookup, not a
+		// second opinion: auto-share still decides.
+		let configured = false;
+		if (client.mode === 'host' && client.hosting_scope === 'friends') {
+			try {
+				configured = !!getSharingSecrets().load();
+			} catch (error) {
+				// A domain is configured but its credential cannot be
+				// unlocked. Carrying on with `configured: false` would read as
+				// "no domain", which is a quiet refusal -- and this is worth
+				// saying, because the host is expecting their link to be up.
+				return { share: false, reason: error.message };
+			}
+		}
+		return require('./sharing/auto-share').decide({
+			mode: client.mode,
+			scope: client.hosting_scope,
+			state: sharing ? sharing.state : 'stopped',
+			configured,
+			stoppedByHand: sharingStoppedByHand,
+			quitting: tearingDown,
+		});
+	};
+	let decision;
+	// A settings.json or client.json the store refuses is reported by every
+	// other path that reads them; this one just does nothing about it.
+	try { decision = assess(); } catch (error) { return appLog(`sharing: automatic resume skipped: ${error.message}`); }
+	if (!decision.share) {
+		// Silent on the installs that were never going to share, which is most
+		// of them: a line after every server operation saying that nothing
+		// happened is a line nobody can read past.
+		if (!decision.quiet) appLog(`sharing: not resuming automatically (${decision.reason})`);
+		return;
+	}
+	appLog(`sharing: resuming automatically ${reason} (${decision.reason})`);
+	queueServerOperation(() => {
+		if (generation !== sharingStartRequest) {
+			return appLog('sharing: automatic resume dropped; sharing changed while it waited');
+		}
+		const now = assess();
+		if (!now.share) return appLog(`sharing: automatic resume dropped (${now.reason})`);
+		return shareWithFriends({ useDomain: now.useDomain, applyScope: false });
+	}).catch(error => appLog(`sharing: automatic resume failed: ${error.message}`));
+}
+
+// ---------------------------------------------------------------------------
 // IPC — every name the pages can call, reached via window.__ELECTRON__.core
 // ---------------------------------------------------------------------------
 
@@ -1873,36 +2015,15 @@ const handlers = {
         }
         return { hostname: saved.hostname };
     },
+    // Starting by hand also withdraws any earlier Stop: the player has said
+    // what they want twice now, and an automatic resume may act again.
     sharing_start: async ({ useDomain = false } = {}) => {
-        const request = ++sharingStartRequest;
-        if (getClientPaths().mode !== 'host') throw Error('Start your own server before sharing.');
-        const saved = useDomain ? getSharingSecrets().load() : null;
-        if (useDomain && !saved) throw Error('Connect your Cloudflare domain first, or use a temporary session link.');
-        // Securing this era's internal credentials is mechanical: it backs the
-        // database up first and preserves every account and character. Refusing
-        // here and telling the player to go find a button in another section is
-        // what made "share with friends" feel like a maze, so just do it. Safe
-        // to run from here -- sharing has not started, so runStack's stop-first
-        // rule for this verb has nothing to interrupt.
-        const era = getSettings().prerenewal ? 'prerenewal' : 'renewal';
-        if (!fs.existsSync(path.join(stateDir(), 'private/service-credentials', era, 'credentials.json'))) {
-            appLog('sharing: securing this era\u2019s internal service credentials (one time; the database is backed up first)');
-            await runStack(['secure-services']);
-        }
-        // Account safeguards stay in force, but the signup policy is the
-        // owner's to set. Sharing used to force it off and then hide the
-        // resulting check failure, which made _M/_F unreachable over a link
-        // even though the tunnel only carries invited friends.
-        const policy = JSON.parse(await runStack(['hosting-check']));
-        const missing = policy.checks.filter(check => !check.passed);
-        if (missing.length) throw Error(missing.map(check => check.detail).join(' '));
-        await saveSettings({ hosting_scope: 'friends' });
-        await assetsStart();
-        if (request !== sharingStartRequest) return getSharing().status();
-        await getSharing().start(saved);
-        return getSharing().status();
+        sharingStoppedByHand = false;
+        return shareWithFriends({ useDomain, applyScope: true });
     },
-    sharing_stop: async () => { ++sharingStartRequest; await getSharing().stop(); return getSharing().status(); },
+    // Remembered, so that applying a setting a minute later does not undo it.
+    // Cleared by the next start, by hand or at the next launch.
+    sharing_stop: async () => { sharingStoppedByHand = true; ++sharingStartRequest; await getSharing().stop(); return getSharing().status(); },
     sharing_copy: () => {
         clipboard.writeText(getSharing().invitation());
         // Say the figure actually in force rather than a number baked into the
@@ -1919,7 +2040,7 @@ const handlers = {
         getSharing().replaceInvitation();
         return 'New link created. The previous link stopped working and friends using it were disconnected.';
     },
-    sharing_forget: async () => { await getSharing().stop(); getSharingSecrets().forget(); return 'Saved credentials removed. The hostname and stopped tunnel remain in your Cloudflare account for you to remove there.'; },
+    sharing_forget: async () => { sharingStoppedByHand = true; await getSharing().stop(); getSharingSecrets().forget(); return 'Saved credentials removed. The hostname and stopped tunnel remain in your Cloudflare account for you to remove there.'; },
 	hosting_check: async () => {
 		if (getClientPaths().mode !== 'host') throw new Error('Hosting checks belong to your own server.');
 		return JSON.parse(await runStack(['hosting-check']));
@@ -2076,6 +2197,21 @@ const handlers = {
 		return next.vm_ram_mib;
 	},
 	save_settings: ({ settings }) => saveSettings(settings),
+	// The preferences the app acts on itself. Written straight to
+	// settings.json, and deliberately not server operations: nothing the
+	// supervisor reads is involved, and going the usual way would restart the
+	// whole stack to record which window opens next launch.
+	//
+	// The allowlist is the point. Every other key in settings.json changes how
+	// the server runs and has to go through Apply, which regenerates its config
+	// and restarts it; a setter that took any name would be a way around that.
+	set_app_preference: ({ key, value }) => {
+		if (!APP_PREFERENCES.has(key)) throw new Error(`${key} is not an app preference`);
+		const on = !!value;
+		require('./settings-store').write(path.join(stateDir(), 'settings.json'),
+			{ [key]: on }, SETTINGS_DEFAULTS);
+		return on;
+	},
 
 	copy_text: ({ text }) => clipboard.writeText(String(text || '')),
 
@@ -2231,6 +2367,11 @@ const GAME_PAGE_HANDLERS = new Set([]);
 // not change halfway through an account operation. Read-only status stays live.
 const SERVER_OPERATIONS = new Set(['sharing_connect', 'sharing_start', 'sharing_forget', 'accounts', 'hosting_check', 'save_settings', 'set_mode', 'set_client_paths', 'start_stack',
 	'stack_up', 'stack_down', 'stack_repair', 'secure_services', 'db_backup', 'db_restore']);
+// The operations that must never be followed by an automatic resume. Sharing's
+// own verbs answer for themselves, and `stack_down` is a server the player has
+// just taken offline on purpose. Everything else in the set above leaves a
+// running server behind it.
+const NEVER_RESUMES_SHARING = new Set(['sharing_connect', 'sharing_start', 'sharing_forget', 'stack_down']);
 let serverOperationQueue = Promise.resolve();
 function queueServerOperation(operation) {
 	if (tearingDown) return Promise.reject(new Error('The app is quitting; wait until the next launch.'));
@@ -2263,10 +2404,18 @@ ipcMain.handle('invoke', async (event, name, args) => {
 	if (!fn) throw new Error(`unknown command: ${name}`);
 	try {
 		if (SERVER_OPERATIONS.has(name)) {
-			return await queueServerOperation(async () => {
+			const result = await queueServerOperation(async () => {
                 if (sharing && ((name === 'accounts' && args?.action !== 'list') || ['set_mode', 'set_client_paths', 'save_settings', 'stack_repair', 'secure_services', 'db_restore'].includes(name))) await sharing.stop();
                 return fn(args || {});
             });
+			// Every operation above either stops sharing on the way in or
+			// cycles the stack underneath it, and the server is back up by the
+			// time one returns. This is the single place that offers it back,
+			// rather than a call at the end of each handler that the next
+			// handler forgets to copy. Only on success: a failed start is not
+			// a server to share.
+			if (!NEVER_RESUMES_SHARING.has(name)) resumeSharing(`after ${name}`);
+			return result;
 		}
 		return await fn(args || {});
 	} catch (e) {
@@ -2453,7 +2602,14 @@ app.whenReady().then(() => {
 	// would notice the host being down -- Electron would just render its own
 	// "cannot be reached" page, which says nothing about which host or why.
 	const c = getClientPaths();
-	if (c.mode === 'join' && c.join_host) {
+	// Asked for by people who are in Settings more often than in the game. The
+	// game window is not opened behind it -- opening both would defeat the
+	// point, and Settings already has "Open game", which runs the same boot
+	// page. Nothing is prepared here either, in either mode: the boot page owns
+	// starting the server and reaching a host, whenever it is finally opened.
+	if (openSettingsFirst()) {
+		openSettings();
+	} else if (c.mode === 'join' && c.join_host) {
 		queueServerOperation(() => prepareJoin(c))
 			.then(() => openGame())
 			.catch(err => {
@@ -2484,8 +2640,12 @@ app.whenReady().then(() => {
 		openGame();
 	}
 
+	// Clicking the Dock icon with every window closed is the same question as
+	// launching the app, so it gets the same answer.
 	app.on('activate', () => {
-		if (BrowserWindow.getAllWindows().length === 0) openGame();
+		if (BrowserWindow.getAllWindows().length) return;
+		if (openSettingsFirst()) openSettings();
+		else openGame();
 	});
 });
 

--- a/electron/sharing/auto-share.js
+++ b/electron/sharing/auto-share.js
@@ -1,0 +1,54 @@
+'use strict';
+
+// Whether the app should put sharing back on by itself.
+//
+// Sharing does not survive the server restarting. Every verb that cycles the
+// stack stops it first -- applying settings, switching era, Repair, a backup,
+// an account change -- and a map-server crash stops it too. Coming back was a
+// button the host had to notice and press, and until they did, the link their
+// friends were holding answered nothing. That is the whole of issue #100.
+//
+// A connected domain is what makes the answer obvious enough not to ask. Its
+// hostname does not change, so resuming restores the very link the friends
+// already have: there is no new address to send and nothing for anyone to
+// decide, which is why this is the behaviour rather than a setting. A temporary
+// link is never resumed -- Cloudflare hands out a new trycloudflare.com address
+// every time, so the most it could do is open a tunnel nobody can reach and
+// leave the host to notice and send a new link anyway.
+//
+// The conditions live here rather than inline at the call site because "should
+// this machine open a tunnel to the internet without being asked" deserves to
+// be readable in one place, and testable without an Electron window. Refusing
+// is the default: every reason to share has to be present at once.
+//
+// `state` is the sharing controller's own state; `configured` is whether a
+// named tunnel is saved; `scope` is the effective hosting scope.
+//
+// `quiet` marks the refusals that mean "this was never going to share": not
+// hosting, never shared, no domain. The caller runs after every server
+// operation, and those three would otherwise fill the log of every install that
+// has only ever played alone. A refusal that would have shared but for
+// something passing is never quiet; that one is worth a line.
+function decide({ mode, scope, state, configured, stoppedByHand, quitting } = {}) {
+  const no = reason => ({ share: false, useDomain: false, reason });
+  const nothingToSay = reason => ({ ...no(reason), quiet: true });
+  if (quitting) return nothingToSay('the app is quitting');
+  if (mode !== 'host') return nothingToSay('this copy is joining someone else’s server');
+  // Whether sharing was ever turned on at all. Nothing but a successful share
+  // leaves the scope on `friends`, which makes it the only durable record of
+  // that -- and the reason a server whose owner has only ever played alone is
+  // never put on the internet by this. It is also what keeps an automatic start
+  // from changing the server it found: friends mode is already in force, so
+  // resuming alters nothing about how the game ports bind.
+  if (scope !== 'friends') return nothingToSay('this server is not set up for friends');
+  if (!configured) return nothingToSay('no connected domain; a temporary link changes address and is not resumed');
+  // Stopping sharing is an instruction, and an Apply two minutes later is not
+  // permission to undo it. It holds until sharing is started by hand again or
+  // the app is relaunched -- a relaunch being the point at which "bring the
+  // server up" plainly includes the address it is normally reachable at.
+  if (stoppedByHand) return no('sharing was stopped by hand');
+  if (!['stopped', 'failed'].includes(state)) return no(`sharing is already ${state}`);
+  return { share: true, useDomain: true, reason: 'the connected domain keeps its address' };
+}
+
+module.exports = { decide };

--- a/src/settings.html
+++ b/src/settings.html
@@ -161,6 +161,21 @@
        or fourth jobs. Switching restarts the server.</p>
   </div>
 
+  <h2>Startup</h2>
+  <div class="panel">
+    <label>
+      <span>At startup</span>
+      <input type="checkbox" id="open_settings_first" style="accent-color: var(--accent); flex: none" />
+      <span class="val" style="width:auto; color: var(--dim)">open Settings instead of the game</span>
+    </label>
+    <p class="note" id="startup-status" hidden style="margin:8px 0 0; color: var(--text)"></p>
+    <p class="note">For anyone who changes settings more often than they play. With
+       this on, launching opens Settings and nothing else &mdash; the server does not
+       start on its own, so press <b>Start</b> and then <b>Open game</b> under
+       <b>Server</b> when you want to play. Leave it off and launching goes straight
+       to the game, which starts the server itself.</p>
+  </div>
+
   <h2>Server</h2>
   <div class="panel">
     <div class="row"><span class="name">Assets &amp; client (:3338)</span><span class="state" id="s-assets">—</span></div>
@@ -305,6 +320,10 @@
       <p id="sharing-state" class="note" role="status" aria-live="polite">Sharing is off.</p>
       <p id="sharing-notice" class="note" role="status" aria-live="polite" hidden></p>
       <p id="sharing-feedback" class="note" role="status" aria-live="polite"></p>
+      <!-- Written by refreshSharing: what happens after a restart depends on
+           whether a domain is connected, and a fixed sentence would be wrong
+           half the time. -->
+      <p class="note" id="share-auto-note"></p>
       <p class="note" id="sharing-lifetime-note">An invitation lets up to 32 friend browsers connect. Invited friends can create an ordinary game account. Stop sharing disconnects friends without stopping your local game. Starting sharing applies the protected account policy and restarts game services once.</p>
       <details><summary>Manage invitations and connection</summary>
         <button id="sharing-replace" class="ghost" disabled>Disconnect friends and replace invitation</button>
@@ -1071,6 +1090,24 @@ function setNote(id, message, kind = '') {
   if (kind === 'bad') node.scrollIntoView({ block: 'nearest' });
 }
 
+// Saved the moment it is clicked. Nothing the server reads is involved, so
+// there is nothing to restart and nothing to confirm -- and Apply, which does
+// restart the server, would be the wrong place for it. The box goes back if the
+// write fails: one left ticked over a settings.json that never took it is worse
+// than the failure. The element id is the settings key, and main.js will write
+// no name that is not on its own list.
+$('open_settings_first').onchange = async () => {
+  const on = $('open_settings_first').checked;
+  try {
+    await invoke('set_app_preference', { key: 'open_settings_first', value: on });
+    setNote('startup-status', on ? 'Next launch opens this window.' : 'Next launch opens the game.');
+  } catch (error) {
+    $('open_settings_first').checked = !on;
+    setNote('startup-status', `Could not save that: ${error.message || String(error)}`, 'bad');
+  }
+  $('startup-status').hidden = false;
+};
+
 // Mod names, descriptions and refusal reasons are written by whoever made the
 // mod, and land in innerHTML. Nothing about a mod folder is trusted markup.
 function esc(s) {
@@ -1149,6 +1186,16 @@ async function refreshSharing() {
     // What the pre-flight checks could not confirm on a start that worked.
     setNote('sharing-notice', state.notice || '');
     $('sharing-notice').hidden = !state.notice;
+    // What happens the next time the server restarts, which is different with
+    // a domain connected and is the main thing connecting one buys you.
+    setNote('share-auto-note', state.configured
+      ? 'Your hostname does not change, so sharing comes back by itself once the server is up again '
+        + '— after applying a setting, a Repair, a crash you recovered from, or the next time you start '
+        + 'the server — and the link your friends already have starts working again with nothing sent to '
+        + 'anyone. Stop sharing still means stopped: that holds until you share again or relaunch.'
+      : 'A temporary link gets a new address every time, so anything that restarts the server — applying '
+        + 'a setting, a Repair, a crash, quitting — ends the session and the next one needs a new link. '
+        + 'Connect your own domain below and sharing comes back by itself, at the same address.');
     if (state.state === 'sharing') {
       const expiry = Number.isFinite(state.expires)
         ? ` Invitation expires ${new Date(state.expires).toLocaleString()}.`
@@ -1307,6 +1354,7 @@ invoke('get_settings').then(s => {
   $('delete-delay').value = s.instant_character_deletion ? 'instant' : 'delayed';
   setEra(!!s.prerenewal);
   $('zeny_from_mobs').checked = !!s.zeny_from_mobs;
+  $('open_settings_first').checked = !!s.open_settings_first;
   $('population_enable').checked = !!s.population_enable;
   $('population_max').value = s.population_max;
   $('population_density').value = s.population_density;

--- a/tests/auto-share.test.cjs
+++ b/tests/auto-share.test.cjs
@@ -1,0 +1,86 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { decide } = require('../electron/sharing/auto-share');
+
+// The one state in which resuming is the right answer. Every test below takes
+// this and breaks one thing. There is no preference in it: a connected domain
+// keeps its address, which is what makes resuming the plain answer rather than
+// a question to put to the host.
+const shared = { mode: 'host', scope: 'friends', state: 'stopped', configured: true, stoppedByHand: false, quitting: false };
+
+test('a server already shared through its own domain is shared again once it is back', () => {
+  assert.deepEqual(decide(shared),
+                   { share: true, useDomain: true, reason: 'the connected domain keeps its address' });
+  // A failed attempt is a state worth retrying from; the server coming back is
+  // new information.
+  assert.equal(decide({ ...shared, state: 'failed' }).share, true);
+});
+
+// The reason it stops at a named tunnel: that address survives the restart, so
+// the link the friends are already holding starts working again with nothing
+// sent to anyone. A temporary one would come back somewhere else.
+test('a temporary link is never resumed, because its address does not survive', () => {
+  const decision = decide({ ...shared, configured: false });
+  assert.equal(decision.share, false);
+  assert.equal(decision.useDomain, false);
+  assert.match(decision.reason, /not resumed/);
+});
+
+test('nothing is shared that the player has not already shared themselves', () => {
+  // The heart of it: hosting scope is the only durable record that sharing was
+  // ever turned on, so a local or LAN server stays off the internet, and an
+  // automatic start never changes how the server it found binds its ports.
+  for (const scope of ['local', 'lan', 'public', undefined, '']) {
+    const decision = decide({ ...shared, scope });
+    assert.equal(decision.share, false, scope);
+    assert.match(decision.reason, /not set up for friends/);
+  }
+  // Joining someone else's server shares nothing of ours.
+  for (const mode of ['join', undefined]) assert.equal(decide({ ...shared, mode }).share, false);
+  assert.equal(decide({}).share, false);
+  assert.equal(decide().share, false);
+});
+
+test('Stop sharing is an instruction, not a state to be corrected', () => {
+  const decision = decide({ ...shared, stoppedByHand: true });
+  assert.equal(decision.share, false);
+  assert.match(decision.reason, /stopped by hand/);
+});
+
+test('a quit in progress and a session already under way are both left alone', () => {
+  assert.equal(decide({ ...shared, quitting: true }).share, false);
+  // Quitting outranks everything, including a setup that says share.
+  assert.match(decide({ ...shared, quitting: true }).reason, /quitting/);
+  for (const state of ['preparing', 'connecting', 'sharing', 'reconnecting', 'stopping']) {
+    const decision = decide({ ...shared, state });
+    assert.equal(decision.share, false, state);
+    assert.equal(decision.reason, `sharing is already ${state}`);
+  }
+});
+
+// The caller logs one line per server operation, so the refusals that mean
+// "this install was never going to share" have to be silent, and the ones that
+// mean "it would have, but" have to not be.
+test('only the refusals worth reading are worth logging', () => {
+  for (const quiet of [{ mode: 'join' }, { scope: 'local' }, { configured: false }, { quitting: true }]) {
+    assert.equal(decide({ ...shared, ...quiet }).quiet, true, JSON.stringify(quiet));
+  }
+  for (const loud of [{ stoppedByHand: true }, { state: 'sharing' }]) {
+    assert.notEqual(decide({ ...shared, ...loud }).quiet, true, JSON.stringify(loud));
+  }
+});
+
+// A refusal must never carry a domain with it: the caller reads useDomain
+// without re-checking share, and a stray true would mean "share the fixed
+// hostname" on an answer that said not to share at all.
+test('every refusal is inert', () => {
+  for (const broken of [{ mode: 'join' }, { scope: 'local' }, { stoppedByHand: true },
+                        { quitting: true }, { state: 'sharing' }, { configured: false }]) {
+    const decision = decide({ ...shared, ...broken });
+    assert.equal(decision.share, false, JSON.stringify(broken));
+    assert.equal(decision.useDomain, false, JSON.stringify(broken));
+    assert.equal(typeof decision.reason, 'string');
+    assert.ok(decision.reason.length, 'a refusal says why, for the log');
+  }
+});


### PR DESCRIPTION
Two things about what happens when the app, or the server, starts.

## Settings can be the window a launch opens

**Settings → General → Startup → At startup: open Settings instead of the game.**
Off by default, because the game window is what almost everyone wants and it is
the thing that starts the server.

On, a launch opens Settings and nothing else. No game window behind it, since
opening both defeats the point, and nothing starts on its own, so **Start** and
then **Open game** are the two presses that get you playing. This is for the
people who spend more time switching era, testing a mod and moving rates around
than playing, which is why it is a switch rather than a change of behaviour.
Clicking the Dock icon with every window closed now gets the same answer as a
launch.

It is written straight to `settings.json` through a setter with a one-name
allowlist, not through `save_settings`: every other key in that file changes how
the server runs and restarts the whole stack on Apply, and restarting a virtual
machine to record which window opens next launch would be absurd. The startup
path reads it defensively, because a settings file the store refuses must not be
able to leave a launch with no window at all.

## Sharing comes back by itself where the address survives

Fixes #100.

Every verb that cycles the stack stops sharing first — applying a setting,
switching era, Repair, a backup, an account change — and a map-server crash
stops it too. Coming back was a button the host had to notice and press, and
until they did, the link their friends were holding answered nothing.

With a Cloudflare domain connected the answer needs no asking: a named tunnel
keeps its hostname, so resuming restores the very link the friends already have,
with no new address to send and nothing for anyone to decide. So it is the
behaviour, not a setting.

Three refusals, each a fact rather than a preference:

- **A temporary link is never resumed.** Its `trycloudflare.com` address changes
  every time, so the tunnel would come back somewhere nobody can reach — which
  is what connecting a domain is for. The sharing panel now says this in both
  states, since it is the main thing a domain buys you.
- **A server never shared is never shared.** The saved hosting scope is the only
  durable record of that, so a local or LAN server cannot be put on the internet
  by this, and an automatic start never changes how the game ports bind.
- **Stop sharing still means stopped.** It holds until sharing is started by
  hand again or the app is relaunched, so applying a setting a minute later does
  not undo it. For a durable off, forget the saved connection or take the server
  off friends mode.

### How it is wired

The conditions live in `electron/sharing/auto-share.js` rather than inline,
because "should this machine open a tunnel to the internet without being asked"
deserves to be readable in one place and testable without an Electron window.

The plumbing hangs off one call in the IPC dispatcher, after any server
operation that succeeded, instead of a line at the end of each handler for the
next handler to forget. Sharing's own verbs and `stack_down` are excluded. It
queues itself behind the operation that triggered it and is never awaited, so
Apply does not wait on a tunnel, and it reports through the sharing panel
exactly like a manual start — because it is one. The whole of "Share with
friends" moved into one function so the resume runs the same sequence as the
button rather than a thinner copy that drifts. A Stop, a crash, a suspend or a
share started by hand between scheduling and running drops it.

Refusals that mean "this install was never going to share" are marked quiet: the
check runs after every server operation and would otherwise fill the log of
everyone who only ever plays alone.

## Testing

- `npm test` — 102 passing, 6 skipped. Seven of those are new, covering every
  condition on the resume decision and which refusals are worth logging.
- The startup option was verified in the running app: with it on, one window
  titled `Ragnarok Offline — settings` and the server left stopped; with it off,
  the game window as before. Clicking the box wrote the value and printed its
  confirmation line. The section moved above **Server** after the first run,
  because at the end of the tab it sat on the window's bottom edge with its
  confirmation below the fold.
- `node --check` on the shell and the settings page's inline script.

Not verified here: a real tunnel coming back, which needs a Cloudflare domain.
`tests/e2e/friends-sharing.cjs` is where that belongs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TmBcqE8s3p6r1LRezRizd8
