### PR TITLE
Define rostack on every platform the app runs on

### DIFF
--- a/docs-site/docs/database.mdx
+++ b/docs-site/docs/database.mdx
@@ -20,9 +20,22 @@ path, or make an alias for it.
 | Windows | `%APPDATA%\Ragnarok Offline\runtime\bin\ragnarok-stack.exe` |
 
 ```sh
+# macOS
 alias rostack="$HOME/Library/Application Support/Ragnarok Offline/runtime/bin/ragnarok-stack"
 
+# Linux
+alias rostack="$HOME/.local/share/Ragnarok Offline/runtime/bin/ragnarok-stack"
+
 rostack sql "SELECT char_id, name, base_level FROM \`char\`"
+```
+
+On Windows, in PowerShell. Single quotes rather than double, because PowerShell
+reads the backquote that `char` needs as its own escape character:
+
+```powershell
+Set-Alias rostack "$env:APPDATA\Ragnarok Offline\runtime\bin\ragnarok-stack.exe"
+
+rostack sql 'SELECT char_id, name, base_level FROM `char`'
 ```
 
 **The server has to be running.** The database lives inside the virtual machine

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -25,13 +25,39 @@ runs. It is not on your `PATH`; give the full path, or alias it.
 | Linux | `~/.local/share/Ragnarok Offline/runtime/bin/ragnarok-stack` |
 | Windows | `%APPDATA%\Ragnarok Offline\runtime\bin\ragnarok-stack.exe` |
 
+A shortcut, so the rest of this page can say `rostack`:
+
 ```sh
+# macOS
 alias rostack="$HOME/Library/Application Support/Ragnarok Offline/runtime/bin/ragnarok-stack"
+
+# Linux
+alias rostack="$HOME/.local/share/Ragnarok Offline/runtime/bin/ragnarok-stack"
+```
+
+```powershell
+# Windows, in PowerShell
+Set-Alias rostack "$env:APPDATA\Ragnarok Offline\runtime\bin\ragnarok-stack.exe"
+```
+
+```
 rostack status
 ```
 
 It needs no arguments and no environment. It finds the engine, the database and
 the app's state from its own location.
+
+**The examples below are written for a POSIX shell**, where `` \` `` escapes the
+backquotes that `char` needs. PowerShell uses the backquote as its own escape
+character, so quote those statements with single quotes instead and nothing
+needs escaping:
+
+```powershell
+rostack sql 'SELECT char_id, name, homun_id FROM `char`'
+```
+
+Heredocs are POSIX-only as well. On PowerShell, put a multi-statement script in
+a file and pass `--file`.
 
 **The server has to be running.** The database lives in a container, inside the
 microVM, on a network that publishes no port to your machine, which is why

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -221,8 +221,15 @@ The server's database can be read and repaired from a terminal with the
 supervisor the app already ships:
 
 ```sh
+# macOS; on Linux the app's folder is ~/.local/share/Ragnarok Offline
 "$HOME/Library/Application Support/Ragnarok Offline/runtime/bin/ragnarok-stack" \
   sql "SELECT char_id, name, homun_id FROM \`char\`"
+```
+
+```powershell
+# Windows, in PowerShell
+& "$env:APPDATA\Ragnarok Offline\runtime\bin\ragnarok-stack.exe" `
+  sql 'SELECT char_id, name, homun_id FROM `char`'
 ```
 
 **[docs/DATABASE.md](DATABASE.md)** has the paths for each platform, what is in


### PR DESCRIPTION
The database page listed the supervisor's path for macOS, Linux and Windows, then aliased only the macOS one — and `rostack` is what every example below it uses. A Linux reader had to translate each line by hand; a Windows reader had no `alias` command at all.

## What changed

`docs/DATABASE.md` and its docs-site copy now define the shortcut three ways:

```sh
# macOS
alias rostack="$HOME/Library/Application Support/Ragnarok Offline/runtime/bin/ragnarok-stack"

# Linux
alias rostack="$HOME/.local/share/Ragnarok Offline/runtime/bin/ragnarok-stack"
```

```powershell
# Windows, in PowerShell
Set-Alias rostack "$env:APPDATA\Ragnarok Offline\runtime\bin\ragnarok-stack.exe"
```

Two things would have bitten a Windows reader who worked it out anyway, so both are named rather than left to be discovered:

- **Quoting.** `char` is a type name in SQL and has to be written `` `char` ``. The POSIX examples escape those backquotes; PowerShell reads the backquote as *its own* escape character, so the statements need single quotes there and no escaping.
- **Heredocs.** POSIX-only. `--file` is named as the way to run a multi-statement script instead.

`docs/TROUBLESHOOTING.md` keeps its full path, because it is one standalone command for someone who has set nothing up, but it now says where the folder is on Linux and carries a PowerShell form beside it.

## Checks

`docs-site` builds. Documentation only — no code, no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SvT1DAYsc7JnDNZJpvi5GW