### PR TITLE
Drag and drop into the cart

### DIFF
--- a/patches/0016-cart-drag-and-drop.md
+++ b/patches/0016-cart-drag-and-drop.md
@@ -1,0 +1,49 @@
+# Drag and drop into the cart did nothing
+
+Dragging an item from the inventory or the storage onto the cart window was
+silently ignored. The drag started, the item lifted, and the drop went nowhere.
+Alt + right-clicking the item moved it, which is what made this look like a
+quirk of the cart rather than a bug.
+
+Same cause as [0010](0012-equipment-attachment-controls.md)'s neighbour, the
+equipment window, one component along. `CartItems.js` registers a drop handler
+and then a `dragover` handler that only stops propagation:
+
+```js
+this._host.addEventListener('drop', onDrop);
+this._host.addEventListener('dragover', e => e.stopImmediatePropagation());
+```
+
+Under the HTML5 drag-and-drop model an element becomes a drop target only if its
+`dragover` handler *cancels* the event. Without `preventDefault` the browser
+never fires `drop`, so `onDrop` below it — which accepts Storage and Inventory
+sources, asks for a quantity on a stack, and calls `reqMoveItemToCart` — had
+never once run.
+
+The cart is the only item window in the tree that does this. `Storage` and
+`Trade` both call `stopImmediatePropagation` and `preventDefault` on their host,
+and the inventory does the same behind its `hostDropPreventDefault` flag, which
+V2 and V3 set. That asymmetry is why cart → inventory already worked while
+inventory → cart did not, which is how it was reported.
+
+## Verification
+
+In a real game: a Merchant with `@cart 1`, an emptied cart, and twenty Red
+Potions. `@cartlist` is the assertion, so the result is the server's own answer
+rather than what the window happens to be drawing. The drag is Playwright's
+`dragTo`, which drives Chromium's own drag-and-drop model — a synthetic `drop`
+event dispatched from script would fire whether or not `dragover` cancelled,
+which is the whole bug.
+
+| | quantity prompt | `@cartlist` afterwards |
+|---|---|---|
+| before | never appears | `No item found in this player's cart` |
+| after | appears | `20 <Red Potion> (Red_Potion, id: 501)`, `1 cart slots` |
+
+The two runs are the same build, the same world and the same script, with only
+that one handler differing in the served bundle. Instrumenting the page
+separately confirms the mechanism: with the fix, `dragstart`, `dragenter`,
+`dragover` and `drop` all arrive, the last of them on the cart.
+
+`patch-client.sh` is idempotent across two runs, and the rebuilt bundle loads,
+logs in and enters the map.

--- a/scripts/patch-client.sh
+++ b/scripts/patch-client.sh
@@ -994,6 +994,54 @@ elif s.count(old) == 1:
 else:
     sys.exit("DBManager.js: msgstringtable loading no longer matches (%d hits); re-check the patch" % s.count(old))
 
+# 0016 - Drag and drop into the cart did nothing, the same way 0010 did.
+#
+# Dragging an item from the inventory or the storage onto the cart window was
+# silently ignored. Right-clicking the item and using the menu worked, which is
+# what made this look like a quirk of the cart rather than a bug.
+#
+# Identical cause to the equipment window in 0010, one window along. The cart
+# registers a drop handler and then a dragover handler that only stops
+# propagation:
+#
+#     this._host.addEventListener('drop', onDrop);
+#     this._host.addEventListener('dragover', e => e.stopImmediatePropagation());
+#
+# Under the HTML5 drag-and-drop model an element becomes a drop target only if
+# its dragover handler *cancels* the event. Without preventDefault the browser
+# never fires `drop`, so onDrop below it -- which handles Storage and Inventory
+# sources, asks for a quantity on a stack, and calls reqMoveItemToCart -- has
+# never once run.
+#
+# The cart is the only item window in the tree that does this. Storage and Trade
+# both call stopImmediatePropagation and preventDefault on their host, and the
+# inventory does the same behind its hostDropPreventDefault flag, which V2 and
+# V3 set. That asymmetry is why cart -> inventory already worked while
+# inventory -> cart did not, which is exactly how it was reported.
+#
+# Anchored on the pair of registrations, including the comment above them, so
+# this cannot silently land on some other dragover handler in the same file.
+p = rb / "src/UI/Components/CartItems/CartItems.js"
+s = p.read_text()
+old = """	// on drop item
+	this._host.addEventListener('drop', onDrop);
+	this._host.addEventListener('dragover', e => e.stopImmediatePropagation());"""
+new = """	// on drop item
+	this._host.addEventListener('drop', onDrop);
+	this._host.addEventListener('dragover', e => {
+		e.stopImmediatePropagation();
+		// A drop only fires on a target whose dragover cancelled the event.
+		// Without this the cart is never a drop target and onDrop never runs.
+		e.preventDefault();
+	});"""
+if "the cart is never a drop target" in s:
+    print("CartItems.js drag-and-drop already patched")
+elif s.count(old) == 1:
+    p.write_text(s.replace(old, new, 1))
+    print("patched CartItems.js (drag and drop into the cart)")
+else:
+    sys.exit("CartItems.js: the host drop registrations no longer match (%d hits); re-check the patch" % s.count(old))
+
 PY
 
 python3 "$ROOT/scripts/patch-client-controls.py" "$ROOT" "$RB"


### PR DESCRIPTION
Reported as "Drag and drop into carts (equipment was fixed, but carts need a fix)". It is the same bug as [0010](https://github.com/Flux159/ragnarokoffline.app/blob/main/scripts/patch-client.sh), one component along.

## The bug

Dragging an item from the inventory or the storage onto the cart window was silently ignored. Alt + right-clicking the item moved it, which is what made this look like a quirk of the cart rather than something broken.

`CartItems.js` registers a drop handler, and then a `dragover` handler that only stops propagation:

```js
this._host.addEventListener('drop', onDrop);
this._host.addEventListener('dragover', e => e.stopImmediatePropagation());
```

Under the HTML5 drag-and-drop model an element becomes a drop target only if its `dragover` handler **cancels** the event. Without `preventDefault` the browser never fires `drop`, so `onDrop` below it — which accepts Storage and Inventory sources, asks for a quantity on a stack, and calls `reqMoveItemToCart` — had never once run.

The cart is the only item window in the tree that does this. `Storage` and `Trade` both call `stopImmediatePropagation` and `preventDefault` on their host, and the inventory does the same behind its `hostDropPreventDefault` flag, which V2 and V3 set. That asymmetry is why cart → inventory already worked while inventory → cart did not, which is exactly how it came in.

## Verification

In a real game, not a unit test: a Merchant with `@cart 1`, an emptied cart and twenty Red Potions. `@cartlist` is the assertion, so the result is the server's own answer rather than whatever the window happens to be drawing.

The drag is Playwright's `dragTo`, which drives Chromium's own drag-and-drop model. A synthetic `drop` event dispatched from script would fire whether or not `dragover` cancelled, which is the whole bug, so the test has to go through the browser.

| | quantity prompt | `@cartlist` afterwards |
|---|---|---|
| before | never appears | `No item found in this player's cart` |
| after | appears | `20 <Red Potion> (Red_Potion, id: 501)`, `1 cart slots` |

Same build, same world, same script — only that one handler differs in the served bundle between the two runs. Instrumenting the page separately confirms the mechanism directly: with the fix, `dragstart`, `dragenter`, `dragover` and `drop` all arrive, the last of them on the cart.

`patch-client.sh` is idempotent across two runs, and the rebuilt bundle loads, logs in and enters the map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SvT1DAYsc7JnDNZJpvi5GW