### PR TITLE
Say in Settings when the server threw a mod's table away

### DIFF
--- a/docs/MODDING.md
+++ b/docs/MODDING.md
@@ -698,6 +698,26 @@ for a refusal instead:
 mods: my-island was not applied -- needs app >=1.0.7, and this is 1.0.6
 ```
 
+**Settings → Mods says when the server rejected one of your tables.** A `db/`
+file that the server could not read does not switch the mod off or refuse it:
+every other layer still applies, the box stays ticked, and only that one table
+is missing. So the mod is listed as on, with what the server said underneath:
+
+```
+Server could not read part of this mod — db/skill_db.yml: 1 entry offered,
+0 kept. Node "Id" cannot be parsed as t. (t is a whole number)
+Occurred in file 'db/import/skill_db.yml' on line 5 and column 4.
+```
+
+That is rAthena's own verdict, quoted, with the file and line it named. `t` is
+its name for a whole number, which is worth knowing because its message says
+only the letter — that one is a field wanting a number and given something
+else, such as a skill's `Id` written as `AM_CALLHOMUN` instead of `243`.
+
+It comes from the last time the server started, so start the server after
+installing a mod and then look. No line means the server did not complain, not
+that it has read anything.
+
 The server log is the next place to look. For a `db/` override:
 
 ```

--- a/electron/main.js
+++ b/electron/main.js
@@ -1638,7 +1638,7 @@ const handlers = {
 		// the app would not run it, and the difference is the whole point of
 		// having a reason to show.
 		return out.split('\n').filter(Boolean).map(l => {
-			const [state, name, description, reason, origin, version, author, grants, settings] = l.split('\t');
+			const [state, name, description, reason, origin, version, author, grants, settings, problems] = l.split('\t');
 			return {
 				name,
 				enabled: state === 'on',
@@ -1657,6 +1657,14 @@ const handlers = {
 				// older supervisor that does not write the field at all.
 				settings: (() => {
 					try { return JSON.parse(settings || '[]'); } catch { return []; }
+				})(),
+				// What the game server said about this mod's own tables the
+				// last time it started. A mod can be switched on, have every
+				// other layer in effect, and have had its db/ thrown away with
+				// only a line in a log nobody opens to say so -- which is the
+				// failure this carries out to Settings.
+				problems: (() => {
+					try { return JSON.parse(problems || '[]'); } catch { return []; }
 				})(),
 			};
 		});

--- a/patches/0016-cart-drag-and-drop.md
+++ b/patches/0016-cart-drag-and-drop.md
@@ -1,0 +1,49 @@
+# Drag and drop into the cart did nothing
+
+Dragging an item from the inventory or the storage onto the cart window was
+silently ignored. The drag started, the item lifted, and the drop went nowhere.
+Alt + right-clicking the item moved it, which is what made this look like a
+quirk of the cart rather than a bug.
+
+Same cause as [0010](0012-equipment-attachment-controls.md)'s neighbour, the
+equipment window, one component along. `CartItems.js` registers a drop handler
+and then a `dragover` handler that only stops propagation:
+
+```js
+this._host.addEventListener('drop', onDrop);
+this._host.addEventListener('dragover', e => e.stopImmediatePropagation());
+```
+
+Under the HTML5 drag-and-drop model an element becomes a drop target only if its
+`dragover` handler *cancels* the event. Without `preventDefault` the browser
+never fires `drop`, so `onDrop` below it — which accepts Storage and Inventory
+sources, asks for a quantity on a stack, and calls `reqMoveItemToCart` — had
+never once run.
+
+The cart is the only item window in the tree that does this. `Storage` and
+`Trade` both call `stopImmediatePropagation` and `preventDefault` on their host,
+and the inventory does the same behind its `hostDropPreventDefault` flag, which
+V2 and V3 set. That asymmetry is why cart → inventory already worked while
+inventory → cart did not, which is how it was reported.
+
+## Verification
+
+In a real game: a Merchant with `@cart 1`, an emptied cart, and twenty Red
+Potions. `@cartlist` is the assertion, so the result is the server's own answer
+rather than what the window happens to be drawing. The drag is Playwright's
+`dragTo`, which drives Chromium's own drag-and-drop model — a synthetic `drop`
+event dispatched from script would fire whether or not `dragover` cancelled,
+which is the whole bug.
+
+| | quantity prompt | `@cartlist` afterwards |
+|---|---|---|
+| before | never appears | `No item found in this player's cart` |
+| after | appears | `20 <Red Potion> (Red_Potion, id: 501)`, `1 cart slots` |
+
+The two runs are the same build, the same world and the same script, with only
+that one handler differing in the served bundle. Instrumenting the page
+separately confirms the mechanism: with the fix, `dragstart`, `dragenter`,
+`dragover` and `drop` all arrive, the last of them on the cart.
+
+`patch-client.sh` is idempotent across two runs, and the rebuilt bundle loads,
+logs in and enters the map.

--- a/scripts/patch-client.sh
+++ b/scripts/patch-client.sh
@@ -994,6 +994,54 @@ elif s.count(old) == 1:
 else:
     sys.exit("DBManager.js: msgstringtable loading no longer matches (%d hits); re-check the patch" % s.count(old))
 
+# 0016 - Drag and drop into the cart did nothing, the same way 0010 did.
+#
+# Dragging an item from the inventory or the storage onto the cart window was
+# silently ignored. Right-clicking the item and using the menu worked, which is
+# what made this look like a quirk of the cart rather than a bug.
+#
+# Identical cause to the equipment window in 0010, one window along. The cart
+# registers a drop handler and then a dragover handler that only stops
+# propagation:
+#
+#     this._host.addEventListener('drop', onDrop);
+#     this._host.addEventListener('dragover', e => e.stopImmediatePropagation());
+#
+# Under the HTML5 drag-and-drop model an element becomes a drop target only if
+# its dragover handler *cancels* the event. Without preventDefault the browser
+# never fires `drop`, so onDrop below it -- which handles Storage and Inventory
+# sources, asks for a quantity on a stack, and calls reqMoveItemToCart -- has
+# never once run.
+#
+# The cart is the only item window in the tree that does this. Storage and Trade
+# both call stopImmediatePropagation and preventDefault on their host, and the
+# inventory does the same behind its hostDropPreventDefault flag, which V2 and
+# V3 set. That asymmetry is why cart -> inventory already worked while
+# inventory -> cart did not, which is exactly how it was reported.
+#
+# Anchored on the pair of registrations, including the comment above them, so
+# this cannot silently land on some other dragover handler in the same file.
+p = rb / "src/UI/Components/CartItems/CartItems.js"
+s = p.read_text()
+old = """	// on drop item
+	this._host.addEventListener('drop', onDrop);
+	this._host.addEventListener('dragover', e => e.stopImmediatePropagation());"""
+new = """	// on drop item
+	this._host.addEventListener('drop', onDrop);
+	this._host.addEventListener('dragover', e => {
+		e.stopImmediatePropagation();
+		// A drop only fires on a target whose dragover cancelled the event.
+		// Without this the cart is never a drop target and onDrop never runs.
+		e.preventDefault();
+	});"""
+if "the cart is never a drop target" in s:
+    print("CartItems.js drag-and-drop already patched")
+elif s.count(old) == 1:
+    p.write_text(s.replace(old, new, 1))
+    print("patched CartItems.js (drag and drop into the cart)")
+else:
+    sys.exit("CartItems.js: the host drop registrations no longer match (%d hits); re-check the patch" % s.count(old))
+
 PY
 
 python3 "$ROOT/scripts/patch-client-controls.py" "$ROOT" "$RB"

--- a/src/settings.html
+++ b/src/settings.html
@@ -1024,7 +1024,13 @@ async function refreshMods() {
         : '')
       + (m.refused
         ? `<br><span style="color:var(--bad, #e5534b)">Not loaded — ${esc(m.reason)}</span>`
-        : '');
+        : '')
+      // The server's own words about this mod's tables, from the last start.
+      // Separate from `refused`: the mod is on and the rest of it is working,
+      // so this is a warning about one layer rather than a refusal.
+      + ((!m.refused && Array.isArray(m.problems) ? m.problems : [])
+        .map(p => `<br><span style="color:var(--warn, #d98)">Server could not read part of this mod — ${esc(p)}</span>`)
+        .join(''));
     row.append(cb, text);
     box.append(row);
     // Options the mod declared for itself. Built with DOM calls and

--- a/stack/src/cmds.rs
+++ b/stack/src/cmds.rs
@@ -1613,6 +1613,10 @@ pub fn up(cfg: &Config, dk: &Docker, lan: bool, ram_mib: Option<u32>) -> Result<
     run_server(cfg, dk, "ragnarok-map", 5121, &format!("/rathena/map-server{era}"), lan)?;
     phase(cfg, "Loading maps and NPCs…");
     wait_for_maps(dk)?;
+    // After the map server has read its tables and before anyone is told the
+    // world is ready: this is the only moment rAthena's verdict on the mods'
+    // own tables exists, and it exists in its log and nowhere else.
+    crate::mods::record_load_report(cfg, dk);
     phase(cfg, "Ready");
     println!("stack up");
     // The one string a host pastes to a friend. Printed rather than only

--- a/stack/src/mods.rs
+++ b/stack/src/mods.rs
@@ -825,6 +825,10 @@ pub fn assemble(cfg: &Config) -> Result<Assembled, String> {
             out.maps = maps.iter().map(|m| m.name.clone()).collect();
             out.map_lines = maps.iter().map(|m| format!("map: {}\n", m.name)).collect();
         }
+        // Kept beside the merged tree, because after this nothing about a file
+        // in it says which mod put it there -- and that is what a complaint
+        // from the server has to be attributed to.
+        write_owners(&dst, &owners);
         out.db = Some(dst);
     }
 
@@ -1081,8 +1085,298 @@ pub fn save_settings(cfg: &Config, name: &str, body: &str) -> Result<(), String>
     fs::rename(&temporary, &path).map_err(|e| format!("publishing mod settings: {e}"))
 }
 
-pub fn list(cfg: &Config) -> Vec<[String; 9]> {
+/// Where the last start's verdict on the mods' tables is kept.
+///
+/// Beside `mod-settings.json` rather than inside `modbuild`, which is deleted
+/// and rebuilt on every start: the report has to outlive the run that produced
+/// it, because Settings is usually read with the server stopped.
+fn report_path(state: &Path) -> PathBuf {
+    state.join("mod-load-report.json")
+}
+
+/// Which mod supplied each file under `db/import`, written where the next
+/// command can read it.
+///
+/// `assemble` is the only place that knows this -- afterwards the files are
+/// merged into one tree and nothing about them says where they came from.
+fn write_owners(dst: &Path, owners: &BTreeMap<String, String>) {
+    let mut body = String::new();
+    for (file, owner) in owners {
+        body.push_str(&format!("{}\t{}\n", one_line(file), one_line(owner)));
+    }
+    let _ = fs::write(dst.join(OWNERS_FILE), body);
+}
+
+fn read_owners(db: &Path) -> BTreeMap<String, String> {
+    let mut out = BTreeMap::new();
+    let Ok(body) = fs::read_to_string(db.join(OWNERS_FILE)) else {
+        return out;
+    };
+    for line in body.lines() {
+        if let Some((file, owner)) = line.split_once('\t') {
+            out.insert(file.to_string(), owner.to_string());
+        }
+    }
+    out
+}
+
+const OWNERS_FILE: &str = ".owners.tsv";
+
+/// One table a mod supplied, and what the server made of it.
+#[derive(Debug, PartialEq)]
+pub struct TableResult {
+    pub file: String,
+    pub offered: u32,
+    pub accepted: u32,
+    /// The server's own complaints, in the order it made them.
+    pub errors: Vec<String>,
+}
+
+/// Strip the colour codes and carriage returns rAthena writes between fields.
+///
+/// Its status lines are printed without newlines and overwritten in place, so
+/// several of them share one physical line with escape sequences in between.
+/// Scanning has to happen on the whole text, not line by line.
+fn plain(text: &str) -> String {
+    let bytes: Vec<char> = text.chars().collect();
+    let mut out = String::with_capacity(text.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == '\u{1b}' {
+            i += 1;
+            if i < bytes.len() && bytes[i] == '[' {
+                i += 1;
+                while i < bytes.len() && !bytes[i].is_ascii_alphabetic() {
+                    i += 1;
+                }
+                i += 1;
+            }
+            continue;
+        }
+        if bytes[i] == '\r' {
+            i += 1;
+            continue;
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    out
+}
+
+/// The text between `after` and the next `'`, starting the search at `from`.
+fn quoted_at(text: &str, from: usize) -> Option<(String, usize)> {
+    let rest = &text[from..];
+    let end = rest.find('\'')?;
+    Some((rest[..end].to_string(), from + end + 1))
+}
+
+/// Read the map server's account of loading `db/import`.
+///
+/// This is rAthena's verdict, not a second opinion: it owns the parser, and
+/// re-implementing enough of it here to predict the answer is exactly the kind
+/// of plausible-and-wrong that the real thing cannot be.
+///
+/// The shape it prints, once the escape codes are gone:
+///
+/// ```text
+/// Loading 'db/import/skill_db.yml'...Loading '1' entries in 'db/import/skill_db.yml'
+/// [Error]: Node "Id" cannot be parsed as t.
+/// [Error]: Occurred in file 'db/import/skill_db.yml' on line 5 and column 4.
+/// Done reading '0' entries in 'db/import/skill_db.yml'
+/// ```
+///
+/// One entry offered and none kept, with the reason in between. Only files
+/// under `db/import` are read, and only the errors between a file's own two
+/// markers, so the stub-not-found noise from an unpackaged tree and one
+/// table's failure never land on another.
+pub fn parse_table_results(log: &str) -> Vec<TableResult> {
+    const PREFIX: &str = "db/import/";
+    let text = plain(log);
+    let mut open: Vec<(String, u32, usize)> = Vec::new();
+    let mut out: Vec<TableResult> = Vec::new();
+    let mut at = 0usize;
+
+    while at < text.len() {
+        let Some(mark) = text[at..].find(" entries in '") else {
+            break;
+        };
+        let mark = at + mark;
+        // The count sits in quotes just before it: `Loading '1' entries in`.
+        let head = &text[..mark];
+        let Some(count_end) = head.rfind('\'') else {
+            at = mark + 1;
+            continue;
+        };
+        let Some(count_start) = head[..count_end].rfind('\'') else {
+            at = mark + 1;
+            continue;
+        };
+        let count: u32 = match head[count_start + 1..count_end].parse() {
+            Ok(count) => count,
+            Err(_) => {
+                at = mark + 1;
+                continue;
+            }
+        };
+        let done = head[..count_start].ends_with("Done reading ");
+        let Some((file, next)) = quoted_at(&text, mark + " entries in '".len()) else {
+            break;
+        };
+        at = next;
+
+        if !file.starts_with(PREFIX) {
+            continue;
+        }
+        let file = file[PREFIX.len()..].to_string();
+
+        if !done {
+            open.push((file, count, mark));
+            continue;
+        }
+        // A close with no open is a table this build never announced; skip it
+        // rather than invent an offered count for it.
+        let Some(index) = open.iter().rposition(|(name, _, _)| *name == file) else {
+            continue;
+        };
+        let (_, offered, from) = open.remove(index);
+        let mut errors = Vec::new();
+        for line in text[from..mark].lines() {
+            let line = line.trim();
+            for tag in ["[Error]:", "[Warning]:"] {
+                if let Some(rest) = line.find(tag) {
+                    let message = line[rest + tag.len()..].trim();
+                    if !message.is_empty() {
+                        errors.push(message.to_string());
+                    }
+                }
+            }
+        }
+        out.push(TableResult { file, offered, accepted: count, errors });
+    }
+    out
+}
+
+/// Say what rAthena means by the type name in a parse failure.
+///
+/// `database.cpp` builds that message with `typeid(R).name()`, which on
+/// everything but MSVC returns the *mangled* name -- so the one diagnostic
+/// that should say what a field expected says `t`, and the modder it is
+/// addressed to has no way to know that means a number. Expanded here rather
+/// than left as a single letter, because the whole reason this report exists
+/// is that nobody could act on what the server said.
+fn expand_type_name(message: &str) -> Option<String> {
+    const MARKER: &str = "cannot be parsed as ";
+    let at = message.find(MARKER)? + MARKER.len();
+    let rest = &message[at..];
+    let end = rest.find(['.', ' ']).unwrap_or(rest.len());
+    let name = match &rest[..end] {
+        "b" => "true or false",
+        "a" | "c" | "h" | "s" | "t" | "i" | "j" | "l" | "m" | "x" | "y" => "a whole number",
+        "f" | "d" => "a number",
+        _ => return None,
+    };
+    Some(format!("{} is {name}", &rest[..end]))
+}
+
+/// Turn one table's result into the sentence Settings shows.
+fn describe(result: &TableResult) -> String {
+    let kept = result.accepted;
+    let offered = result.offered;
+    let plural = |n: u32| if n == 1 { "entry" } else { "entries" };
+    let mut text = format!(
+        "db/{}: {offered} {} offered, {kept} kept.",
+        result.file,
+        plural(offered)
+    );
+    for error in &result.errors {
+        text.push(' ');
+        text.push_str(error);
+        if let Some(expanded) = expand_type_name(error) {
+            text.push_str(&format!(" ({expanded})"));
+        }
+    }
+    one_line(&text)
+}
+
+/// Record what the server made of each mod's tables, for Settings to show.
+///
+/// Called once the map server is up, because that is when it has said so. A
+/// mod whose table was thrown away is still switched on and still has its
+/// other layers in effect, so this is a warning against the mod rather than a
+/// refusal of it.
+pub fn record_load_report(cfg: &Config, dk: &crate::docker::Docker) {
+    let build = cfg.state.join("modbuild/db");
+    let owners = read_owners(&build);
+    if owners.is_empty() {
+        let _ = fs::remove_file(report_path(&cfg.state));
+        return;
+    }
+    let log = dk.logs("ragnarok-map", "4000");
+    let mut problems: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for result in parse_table_results(&log) {
+        if result.accepted >= result.offered && result.errors.is_empty() {
+            continue;
+        }
+        let Some(owner) = owners.get(&result.file) else {
+            continue;
+        };
+        let text = describe(&result);
+        eprintln!("mods: {owner}: {text}");
+        problems.entry(owner.clone()).or_default().push(text);
+    }
+
+    let mut body = String::from("{");
+    for (i, (owner, list)) in problems.iter().enumerate() {
+        if i > 0 {
+            body.push(',');
+        }
+        body.push_str(&crate::json::quote(owner));
+        body.push(':');
+        body.push('[');
+        for (j, text) in list.iter().enumerate() {
+            if j > 0 {
+                body.push(',');
+            }
+            body.push_str(&crate::json::quote(text));
+        }
+        body.push(']');
+    }
+    body.push('}');
+    let _ = fs::write(report_path(&cfg.state), body);
+}
+
+/// What the last start said about one mod's tables.
+fn load_report(state: &Path) -> BTreeMap<String, Vec<String>> {
+    let mut out = BTreeMap::new();
+    let Ok(body) = fs::read_to_string(report_path(state)) else {
+        return out;
+    };
+    let Ok(value) = crate::json::parse(&body) else {
+        return out;
+    };
+    let crate::json::Value::Object(map) = value else {
+        return out;
+    };
+    for (name, entry) in map {
+        if let crate::json::Value::Array(items) = entry {
+            let list: Vec<String> = items
+                .into_iter()
+                .filter_map(|v| match v {
+                    crate::json::Value::String(s) => Some(s),
+                    _ => None,
+                })
+                .collect();
+            if !list.is_empty() {
+                out.insert(name, list);
+            }
+        }
+    }
+    out
+}
+
+pub fn list(cfg: &Config) -> Vec<[String; 10]> {
     let saved = read_settings(&cfg.state).unwrap_or_default();
+    let reported = load_report(&cfg.state);
     scan(cfg)
         .into_iter()
         .map(|m| {
@@ -1107,6 +1401,18 @@ pub fn list(cfg: &Config) -> Vec<[String; 9]> {
                 // values in force, as one JSON array. json::quote escapes every
                 // control character, so this cannot break the tab framing.
                 settings_json(&m.manifest, saved.get(&m.name)),
+                // What the server said about this mod's tables the last time
+                // it started, as a JSON array of sentences. Empty when it said
+                // nothing, and when the server has not started since the mod
+                // was installed -- Settings says which of the two it is.
+                match reported.get(&m.name) {
+                    None => String::from("[]"),
+                    Some(list) => {
+                        let items: Vec<String> =
+                            list.iter().map(|t| crate::json::quote(t)).collect();
+                        format!("[{}]", items.join(","))
+                    }
+                },
             ]
         })
         .collect()
@@ -1139,6 +1445,136 @@ fn write_list(state: &Path, file: &str, name: &str, present: bool, header: &str)
 
 #[cfg(test)]
 mod tests {
+
+    /// The real thing, escape codes and all: rAthena prints its status lines
+    /// without newlines and overwrites them in place, so several share one
+    /// physical line. Taken from a map server that had loaded the mod this was
+    /// written for.
+    const REAL_LOG: &str = "\x1b[1;32m[Status]\x1b[0m:\x1b[K Loading '\x1b[1;37mdb/import/skill_db.yml\x1b[0m'...\x1b[K\x1b[1;32m[Status]\x1b[0m:\x1b[K Loading '\x1b[1;37m1\x1b[0m' entries in '\x1b[1;37mdb/import/skill_db.yml\x1b[0m'\n\x1b[K\x1b[1;31m[Error]\x1b[0m:\x1b[K Node \"Id\" cannot be parsed as t.\n\x1b[1;31m[Error]\x1b[0m:\x1b[K Occurred in file '\x1b[1;37mdb/import/skill_db.yml\x1b[0m' on line 5 and column 4.\n\x1b[1;32m[Status]\x1b[0m:\x1b[K Done reading '\x1b[1;37m0\x1b[0m' entries in '\x1b[1;37mdb/import/skill_db.yml\x1b[0m'\x1b[K\n";
+
+    #[test]
+    fn a_rejected_table_is_read_out_of_the_server_log() {
+        let results = parse_table_results(REAL_LOG);
+        assert_eq!(results.len(), 1);
+        let only = &results[0];
+        assert_eq!(only.file, "skill_db.yml");
+        assert_eq!(only.offered, 1);
+        assert_eq!(only.accepted, 0);
+        assert_eq!(
+            only.errors,
+            vec![
+                "Node \"Id\" cannot be parsed as t.".to_string(),
+                "Occurred in file 'db/import/skill_db.yml' on line 5 and column 4.".to_string(),
+            ]
+        );
+        // "t" is what rAthena prints for a 16-bit number, because it formats
+        // the type with typeid().name(). Expanded, or the sentence ends in a
+        // letter the reader cannot act on.
+        assert_eq!(
+            describe(only),
+            "db/skill_db.yml: 1 entry offered, 0 kept. Node \"Id\" cannot be parsed as t. \
+             (t is a whole number) Occurred in file 'db/import/skill_db.yml' on line 5 and column 4."
+        );
+    }
+
+    #[test]
+    fn a_mangled_type_name_is_expanded_and_anything_else_left_alone() {
+        assert_eq!(
+            expand_type_name("Node \"Id\" cannot be parsed as t."),
+            Some("t is a whole number".to_string())
+        );
+        assert_eq!(
+            expand_type_name("Node \"Flag\" cannot be parsed as b."),
+            Some("b is true or false".to_string())
+        );
+        // MSVC prints the real name, and a name nobody recognises is left as
+        // it came rather than guessed at.
+        assert_eq!(expand_type_name("cannot be parsed as unsigned short."), None);
+        assert_eq!(expand_type_name("Some other complaint entirely."), None);
+    }
+
+    /// A table that loaded is not a problem and must not be reported as one,
+    /// or every start would accuse every mod.
+    #[test]
+    fn a_table_that_loaded_says_nothing() {
+        let log = "[Status]: Loading '3' entries in 'db/import/mob_db.yml'\n\
+                   [Status]: Done reading '3' entries in 'db/import/mob_db.yml'\n";
+        let results = parse_table_results(log);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].accepted, 3);
+        assert!(results[0].errors.is_empty());
+    }
+
+    /// Two mods, two tables, one broken. The errors belong to the table they
+    /// sit between and must not spread to the one that loaded.
+    #[test]
+    fn one_bad_table_does_not_implicate_the_next() {
+        let log = "[Status]: Loading '2' entries in 'db/import/item_db.yml'\n\
+                   [Error]: Node \"Id\" cannot be parsed as t.\n\
+                   [Status]: Done reading '1' entries in 'db/import/item_db.yml'\n\
+                   [Status]: Loading '5' entries in 'db/import/mob_db.yml'\n\
+                   [Status]: Done reading '5' entries in 'db/import/mob_db.yml'\n";
+        let results = parse_table_results(log);
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].file, "item_db.yml");
+        assert_eq!(results[0].errors.len(), 1);
+        assert_eq!(results[1].file, "mob_db.yml");
+        assert!(results[1].errors.is_empty());
+    }
+
+    /// A development tree with no staged import stubs produces sixty of these.
+    /// None of them is a mod's fault, and none names a file a mod supplied, so
+    /// nothing here may pick them up.
+    #[test]
+    fn missing_import_stubs_are_not_a_mods_problem() {
+        let log = "[Status]: Loading 'db/import/instance_db.yml'...\
+                   [Error]: Failed to open INSTANCE_DB database file from 'db/import/instance_db.yml'.\n";
+        assert!(parse_table_results(log).is_empty());
+    }
+
+    /// Only `db/import` is ours. The stock tables load in the same log and
+    /// their counts are none of a mod's business.
+    #[test]
+    fn the_servers_own_tables_are_ignored() {
+        let log = "[Status]: Loading '1635' entries in 'db/re/skill_db.yml'\n\
+                   [Status]: Done reading '1635' entries in 'db/re/skill_db.yml'\n";
+        assert!(parse_table_results(log).is_empty());
+    }
+
+    /// The report survives the run that wrote it, because Settings is usually
+    /// read with the server stopped, and it comes back keyed by mod.
+    #[test]
+    fn the_report_round_trips_to_the_settings_window() {
+        let dir = std::env::temp_dir().join(format!("ro-modreport-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(
+            report_path(&dir),
+            "{\"no-seed-cost\":[\"db/skill_db.yml: 1 entry offered, 0 kept.\"]}",
+        )
+        .unwrap();
+        let back = load_report(&dir);
+        assert_eq!(
+            back.get("no-seed-cost").map(|v| v.as_slice()),
+            Some(["db/skill_db.yml: 1 entry offered, 0 kept.".to_string()].as_slice())
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// The merged tree is one directory; without this nothing in it says which
+    /// mod a complaint belongs to.
+    #[test]
+    fn ownership_survives_the_merge() {
+        let dir = std::env::temp_dir().join(format!("ro-modowners-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        let mut owners = BTreeMap::new();
+        owners.insert("skill_db.yml".to_string(), "no-seed-cost".to_string());
+        owners.insert("mob_db.yml".to_string(), "harder-porings".to_string());
+        write_owners(&dir, &owners);
+        assert_eq!(read_owners(&dir), owners);
+        let _ = fs::remove_dir_all(&dir);
+    }
     use super::*;
 
     fn setting(key: &str, value: SettingValue, min: f64, max: f64) -> Setting {


### PR DESCRIPTION
A player's mod did nothing, and everything the app could show them said it was fine: Settings listed it **on**, **installed**, not refused. The server had read its one table, rejected the only entry in it, and written that to a log nobody opens.

```
Loading '1' entries in 'db/import/skill_db.yml'
[Error]: Node "Id" cannot be parsed as t.
[Error]: Occurred in file 'db/import/skill_db.yml' on line 5 and column 4.
Done reading '0' entries in 'db/import/skill_db.yml'
```

One entry offered, none kept. That is the entire diagnosis, it was already being printed, and nothing carried it the last few inches to the person it was for.

## What changes

The supervisor reads that back once the map server is up — the only moment rAthena's verdict exists — attributes each table to the mod that supplied it, and writes what it found beside the mod settings. Settings shows it under the mod:

> **no-seed-cost** v1.0.0 by you
> Removes Seed of Life cost from Call Homunculus.
> <span>Server could not read part of this mod — db/skill_db.yml: 1 entry offered, 0 kept. Node "Id" cannot be parsed as t. (t is a whole number) Occurred in file 'db/import/skill_db.yml' on line 5 and column 4.</span>

It is a **warning and not a refusal**, because that is what it is: a mod whose `db/` was rejected still has its sprites, scripts and settings in effect. The box stays ticked and the rest keeps working.

## Three things worth review

**Attribution needed the merge to remember where its files came from**, which it did not. `assemble` already built the ownership map and used it for one stderr line before dropping it; it is now written next to the merged tree and read back by the report. Without that, nothing in `db/import` says which mod put a file there.

**`t` is expanded on the way out.** rAthena builds that message with `typeid(R).name()`, which outside MSVC returns the *mangled* name — so the one diagnostic that should say what a field expected says a single letter, and that is most of why this was hard to act on. The original text is kept and the meaning added beside it. Worth reporting upstream separately.

**Scope is deliberately narrow.** Only files a mod actually supplied are reported, so a development tree's sixty missing-stub errors and the server's own 1,635-entry tables stay out of it, and the errors between one table's two markers cannot land on the next. The parser is hand-rolled, like everything else in `stack/`.

## Verification

Against the mod that prompted this, in a disposable world:

- it prints during startup, `mods: no-seed-cost: db/skill_db.yml: 1 entry offered, 0 kept. …`;
- it comes through `ragnarok-stack mods` as a JSON field, attributed to that mod and to no other;
- it renders in the **real Settings window**, driven through the app's own IPC;
- the corrected mod reports nothing, so this does not accuse a mod that loaded.

`cd stack && cargo test` 102/102 with seven new tests covering a real escape-code-laden log excerpt, a table that loaded, one bad table not implicating the next, missing stubs, the server's own tables, the report round trip and the ownership map. `npm test` 108/108, `node --check electron/main.js` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SvT1DAYsc7JnDNZJpvi5GW