### PR TITLE
Fast-forward a walk on the server's clock, once there is one

### DIFF
--- a/patches/0017-walk-fast-forward-clock.md
+++ b/patches/0017-walk-fast-forward-clock.md
@@ -1,0 +1,89 @@
+# The walk fast-forward ran on a clock that was never set
+
+A walk arrives from the server with the tick it started at. The client rolls
+the animation back by however long the packet took to arrive, so the character
+is drawn where it has really got to by now. Both numbers that needs are wrong.
+
+## The round trip that was never measured
+
+```js
+SP.returned  = true;
+SP.pongTime  = 0;
+SP.value     = SP.pongTime - SP.pingTime;
+Session.serverTick = pkt.time + SP.value / 2; // Adjust with half ping
+```
+
+`pongTime` is assigned `0` and then `value` is computed from it, so `value` is
+always `-pingTime`. `pingTime` is not a timestamp either — it is
+`Date.now() - startTick`, the age of the connection. So the "half ping"
+correction is minus half the age of the session, and it grows for as long as
+you play. Measured on a ten-second-old connection:
+
+| field | value |
+|---|---|
+| `pingTime` | 10048 |
+| `pongTime` | 0 |
+| `value` | -10048 |
+
+`serverTick` was set 5,024 ms behind the server, and half an hour into a
+session it would be fifteen minutes behind.
+
+## The two clocks that were never the same clock
+
+Before any pong, `Session.serverTick` counts from the moment the renderer
+started. `moveStartTime` counts from the moment the map server started. The
+guard in `computeWalkStartTick` was `!Session.serverTick`, which is only false
+on the very first frame, so the subtraction went ahead on two unrelated clocks.
+
+Over twelve clicked moves on a development machine the difference sat at a
+steady **-40379 ms** — negative, so `elapsed <= 0` and the fast-forward never
+ran at all. That is why this does not reproduce on a machine that launches the
+app and plays: the code is simply dead there.
+
+It stops being dead when the page outlives the map server, which **Apply, an
+era switch, Repair and crash recovery all arrange**. Then the same subtraction
+comes out positive, and for a player-like entity the clamp is the whole path
+duration:
+
+```js
+const maxFastForward = isPlayerLike ? pathDuration : Math.min(pathDuration, this.walk.speed);
+```
+
+So the character is drawn at the far end of a path it has not walked, and the
+next server update drags it back. That is the reported symptom: a click, a step
+backwards, then the walk.
+
+## The fix
+
+Measure the round trip against the base `pingTime` is already measured from,
+and refuse to fast-forward anything until a pong has put `serverTick` on the
+server's clock. `serverTickSynced` is cleared when a connection is set up, so a
+relog cannot inherit the previous session's correction.
+
+## Verification
+
+Same world, same twelve clicked moves, before and after, with the numbers read
+out of the running client:
+
+| | before | after |
+|---|---|---|
+| `ping.value` | -10048, growing | 37, 33, 33 ms |
+| `serverTick` vs the server's own tick | 5,024 ms behind | within half a round trip |
+| `rawElapsed` per move | -40379 | 16 to 20 ms |
+| walks fast-forwarded | 0 of 12 | 16 of 16 |
+
+Path durations in that run were 450 to 1,900 ms, so the correction is now a
+1-4% nudge that does what it was written to do, instead of either nothing at
+all or a teleport to the end of the path.
+
+**What this does not prove.** The symptom has not been reproduced on a machine
+that shows it; this is the mechanism found by reading and then measured. It
+explains the reported shape and the device-dependence, and both defects are
+real and worth fixing regardless. Verification on a machine that actually
+rubber-bands is still outstanding — [#87](../../../issues/87)'s Steam Deck is
+the next instrument for that.
+
+## Upstream
+
+Both defects are roBrowserLegacy's, not ours, and neither is specific to how
+this app runs it. Worth sending upstream.

--- a/scripts/patch-client.sh
+++ b/scripts/patch-client.sh
@@ -1042,6 +1042,112 @@ elif s.count(old) == 1:
 else:
     sys.exit("CartItems.js: the host drop registrations no longer match (%d hits); re-check the patch" % s.count(old))
 
+# 0017 - The walk fast-forward ran on a clock that was never set.
+#
+# A walk arrives with the server tick it started at, and the client rolls it
+# back by the latency so the character is drawn where it really is by now. Both
+# numbers that computation needs are wrong.
+#
+# `onPong` assigns `SP.pongTime = 0` and then computes
+# `SP.value = SP.pongTime - SP.pingTime` from it, so the "half ping" correction
+# is always minus half of `pingTime` -- and `pingTime` is time-since-connect,
+# not a timestamp. Measured on a ten-second-old session it read -10048, and the
+# error grows for as long as the session lasts.
+#
+# Before the first pong it is worse than wrong, it is unrelated: `serverTick`
+# counts from the renderer starting and `moveStartTime` counts from the map
+# server starting. Over twelve clicked moves here the difference sat at a
+# steady -40379 ms, which is negative, so the fast-forward never ran at all --
+# which is why this does not reproduce on a machine that launches the app and
+# plays. Let the page outlive the server, as Apply, era switch, Repair and
+# crash recovery all arrange, and the same subtraction comes out positive. The
+# clamp for a player is the whole path duration, so the character is drawn at
+# the far end of its path and the next server update drags it back.
+#
+# So: measure the round trip against the base `pingTime` is already measured
+# from, and do not fast-forward anything until a pong has put `serverTick` on
+# the server's clock.
+p = rb / "src/Engine/SessionStorage.js"
+s = p.read_text()
+old = """	serverTick: 0,"""
+new = """	serverTick: 0,
+	/// Whether a pong has put `serverTick` on the server's clock. Until one
+	/// has, it counts from the renderer starting and means nothing next to a
+	/// tick the server sent.
+	serverTickSynced: false,"""
+if "serverTickSynced" in s:
+    print("SessionStorage.js already patched")
+elif s.count(old) == 1:
+    p.write_text(s.replace(old, new, 1))
+    print("patched SessionStorage.js (serverTick sync flag)")
+else:
+    sys.exit("SessionStorage.js: serverTick no longer matches (%d hits); re-check the patch" % s.count(old))
+
+p = rb / "src/Engine/MapEngine.js"
+s = p.read_text()
+if "SP.epoch" in s:
+    print("MapEngine.js ping/pong already patched")
+else:
+    old = """				const startTick = Date.now();
+\t\t\t\tNetwork.setPing(() => {"""
+    new = """				const startTick = Date.now();
+\t\t\t\t// A new connection makes any previous correction meaningless.
+\t\t\t\tSession.serverTickSynced = false;
+\t\t\t\tNetwork.setPing(() => {"""
+    if s.count(old) != 1:
+        sys.exit("MapEngine.js: the ping setup no longer matches (%d hits); re-check the patch" % s.count(old))
+    s = s.replace(old, new, 1)
+
+    old = """\t\t\t\t\tSP.pingTime = ping.clientTime;
+\t\t\t\t\tSP.returned = false;"""
+    new = """\t\t\t\t\tSP.pingTime = ping.clientTime;
+\t\t\t\t\t// The base pingTime is measured from, so the pong can be put on
+\t\t\t\t\t// the same clock and subtracted. Without it there is nothing here
+\t\t\t\t\t// for a pong to be compared against.
+\t\t\t\t\tSP.epoch = startTick;
+\t\t\t\t\tSP.returned = false;"""
+    if s.count(old) != 1:
+        sys.exit("MapEngine.js: the ping send no longer matches (%d hits); re-check the patch" % s.count(old))
+    s = s.replace(old, new, 1)
+
+    old = """\tSP.returned = true;
+\tSP.pongTime = 0;
+\tSP.value = SP.pongTime - SP.pingTime;
+
+\tSession.serverTick = pkt.time + SP.value / 2; // Adjust with half ping"""
+    new = """\tSP.returned = true;
+\t// On the same clock as pingTime, so the subtraction below is the round
+\t// trip it reads as. It used to be assigned 0 first, which made `value`
+\t// minus the age of the session.
+\tSP.pongTime = SP.epoch ? Date.now() - SP.epoch : SP.pingTime;
+\tSP.value = SP.pongTime - SP.pingTime;
+
+\tSession.serverTick = pkt.time + SP.value / 2; // Adjust with half ping
+\tSession.serverTickSynced = true;"""
+    if s.count(old) != 1:
+        sys.exit("MapEngine.js: onPong no longer matches (%d hits); re-check the patch" % s.count(old))
+    p.write_text(s.replace(old, new, 1))
+    print("patched MapEngine.js (round-trip ping, and serverTick marked synced)")
+
+p = rb / "src/Renderer/Entity/EntityWalk.js"
+s = p.read_text()
+old = """\tif (!moveStartTime || !Session || !Session.serverTick) {
+\t\treturn nowTick;
+\t}"""
+new = """\t// Not `!Session.serverTick`: that is non-zero from the first frame, because
+\t// it counts from the renderer starting. Until a pong lands it is not the
+\t// server's clock, and subtracting a server tick from it is meaningless.
+\tif (!moveStartTime || !Session || !Session.serverTickSynced) {
+\t\treturn nowTick;
+\t}"""
+if "!Session.serverTickSynced" in s:
+    print("EntityWalk.js already patched")
+elif s.count(old) == 1:
+    p.write_text(s.replace(old, new, 1))
+    print("patched EntityWalk.js (no fast-forward on an unsynced clock)")
+else:
+    sys.exit("EntityWalk.js: computeWalkStartTick no longer matches (%d hits); re-check the patch" % s.count(old))
+
 PY
 
 python3 "$ROOT/scripts/patch-client-controls.py" "$ROOT" "$RB"


### PR DESCRIPTION
Towards the rubber-banding report in #51 and #101. Two real defects in the latency compensation, found by reading and then measured in a running client.

## The round trip that was never measured

```js
SP.returned  = true;
SP.pongTime  = 0;
SP.value     = SP.pongTime - SP.pingTime;
Session.serverTick = pkt.time + SP.value / 2; // Adjust with half ping
```

`pongTime` is assigned `0` and then `value` is computed **from it**, so `value` is always `-pingTime` — and `pingTime` is not a timestamp either, it is `Date.now() - startTick`, the age of the connection. The "half ping" correction is minus half the age of the session, and it grows for as long as you play. Ten seconds in it read `-10048`, putting `serverTick` 5,024 ms behind the server. Half an hour in it would be fifteen minutes behind.

## The two clocks that were never the same clock

Before any pong, `serverTick` counts from the renderer starting and `moveStartTime` counts from the map server starting. The guard was `!Session.serverTick`, which is only false on the very first frame, so the subtraction went ahead on two unrelated clocks.

Over twelve clicked moves here the difference sat at a steady **-40379 ms**. Negative, so `elapsed <= 0` and the fast-forward never ran at all — which is exactly why this does not reproduce on a machine that launches the app and plays.

It stops being dead when the page outlives the map server, which **Apply, an era switch, Repair and crash recovery all arrange**. The same subtraction then comes out positive, and for a player the clamp is the entire path:

```js
const maxFastForward = isPlayerLike ? pathDuration : Math.min(pathDuration, this.walk.speed);
```

The character is drawn at the far end of a path it has not walked, and the next server update drags it back. A click, a step backwards, then the walk.

## Verification

Same world, same twelve clicked moves, numbers read out of the running client:

| | before | after |
|---|---|---|
| `ping.value` | -10048, growing | 37, 33, 33 ms |
| `serverTick` vs the server's tick | 5,024 ms behind | within half a round trip |
| `rawElapsed` per move | -40379 | 16 to 20 ms |
| walks fast-forwarded | 0 of 12 | 16 of 16 |

Path durations in that run were 450 to 1,900 ms, so the correction is now a 1-4% nudge doing what it was written to do, instead of either nothing or a teleport.

## What this does not prove

**The symptom has not been reproduced on a machine that shows it.** This is the mechanism, and it explains both the reported shape and why it is device-dependent, but I am not claiming it closes #51 until it is seen to. The Steam Deck from #87 is the next instrument; the probe harness is ready to re-run there. Both defects are worth fixing either way.

Both are roBrowserLegacy's and neither is specific to how this app runs it, so they are worth sending upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SvT1DAYsc7JnDNZJpvi5GW