### PR TITLE
Switching era should not strand the server

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -198,6 +198,36 @@ Fixed in the next release: the app now waits for the schema rather than just a
 connection, and refuses to start with an error if the account is not there,
 instead of leaving you at a login screen that cannot work.
 
+## After switching era, the server will not start and mentions credentials
+
+The error is:
+
+```
+Internet hosting requires this era's managed service credentials. Start in
+Local mode, give each GM/admin account an 8-23 character password in
+Settings -> Accounts, then use "Prepare server for friends" in
+Settings -> Multiplayer.
+```
+
+and refreshing the account list answers `Start this era's server first`.
+
+Nothing is wrong with the install, and no data is at risk. The credentials
+internet hosting needs are generated separately for renewal and pre-renewal,
+but the hosting choice is one setting for both. So preparing one era for
+friends and then switching to the other left the setting pointing at an era
+that was never prepared, and the server refused to start — including Repair.
+The instructions in the message lead to Settings -> Accounts, which needs a
+running server, so the two halves waited on each other.
+
+**The way out on an affected build:** Settings -> Multiplayer, set hosting back
+to **Local**, and start. Accounts and every other section work again from
+there. Switching back to the era you had prepared restores friends hosting with
+nothing to redo.
+
+From the next release this is handled: an era that was never prepared for
+internet hosting starts in Local mode and says so, instead of not starting.
+Your hosting choice is kept, and the era you prepared still hosts.
+
 ## My characters are gone / I want to move them to another machine
 
 Settings → **Back up…** writes everything to a single file, and **Restore…**

--- a/src/settings.html
+++ b/src/settings.html
@@ -732,9 +732,21 @@ async function chooseEra(pre) {
 
   try {
     const s = await invoke('get_settings');
-    await invoke('save_settings', { settings: { ...s, prerenewal: pre } });
+    const out = await invoke('save_settings', { settings: { ...s, prerenewal: pre } });
     clearInterval(ticking);
     show(`Switched to ${label} in ${elapsed()}s. Log in again — your character list is the ${label} one.`);
+    // Internet hosting credentials are per era, so an era that was never
+    // prepared for friends starts in Local mode. The supervisor says so; say
+    // it here as well, because the player asked for a different era, not for
+    // their friends' link to stop working, and the log is not where they are
+    // looking.
+    const narrowed = String(out || '').split('\n')
+      .find(line => line.includes('has not been prepared for internet hosting'));
+    if (narrowed) {
+      const note = document.createElement('p');
+      note.textContent = narrowed.trim();
+      status.append(note);
+    }
     log(`${label} ready`);
   } catch (e) {
     clearInterval(ticking);

--- a/stack/src/cmds.rs
+++ b/stack/src/cmds.rs
@@ -1340,8 +1340,13 @@ pub fn secure_services(cfg: &Config, dk: &Docker, lan: bool, ram_mib: Option<u32
 pub fn up(cfg: &Config, dk: &Docker, lan: bool, ram_mib: Option<u32>) -> Result<(), String> {
     // Validate before touching the engine or replacing any running service.
     let open_registration = crate::registration::enabled(&cfg.state)?;
-    let scope = crate::hosting::Scope::load(cfg, lan)?;
+    // Era-aware: a scope saved against an era that was never prepared for
+    // internet hosting starts Local rather than refusing to start at all.
+    let (scope, hosting_notice) = crate::hosting::effective_for_start(cfg, lan)?;
     crate::hosting::before_start(cfg, scope)?;
+    if let Some(notice) = &hosting_notice {
+        println!("{notice}");
+    }
     let lan = scope.lan();
     let credentials = crate::service_credentials::load(&cfg.state, crate::service_credentials::era(cfg))?;
     let conf = cfg.state.join("conf");
@@ -1965,7 +1970,13 @@ pub fn restore(cfg: &Config, dk: &Docker, src: &str) -> Result<(), String> {
 /// Player data is untouched — characters live in the ragnarokmac-db volume.
 pub fn repair(cfg: &Config, dk: &Docker, lan: bool, ram_mib: Option<u32>) -> Result<(), String> {
     crate::registration::enabled(&cfg.state)?;
-    crate::hosting::before_start(cfg, crate::hosting::Scope::load(cfg, lan)?)?;
+    // Repair is the escape hatch, so it must not be the thing that is stuck:
+    // see effective_for_start.
+    let (repair_scope, hosting_notice) = crate::hosting::effective_for_start(cfg, lan)?;
+    crate::hosting::before_start(cfg, repair_scope)?;
+    if let Some(notice) = &hosting_notice {
+        println!("{notice}");
+    }
     crate::crashes::capture_all(cfg, dk);
     phase(cfg, "Repairing…");
     // Break the lock rather than wait: the usual reason to reach for repair is

--- a/stack/src/hosting.rs
+++ b/stack/src/hosting.rs
@@ -76,6 +76,43 @@ pub fn before_start(cfg: &Config, scope: Scope) -> Result<(), String> {
     Ok(())
 }
 
+/// The scope a start can actually honour, and what to tell the player when it
+/// is not the one they saved.
+///
+/// `hosting_scope` is one setting for the whole install, but the credentials
+/// internet hosting needs are generated per era. So preparing renewal for
+/// friends and then switching to pre-renewal left the saved scope pointing at
+/// an era that was never prepared, and `before_start` refused every start --
+/// including Repair, which exists to be the way out. The instructions in that
+/// error go through Settings -> Accounts, which needs a running server, so
+/// there was no way out at all: the server would not start until the accounts
+/// were fixed, and the accounts could not be reached until the server started.
+///
+/// A start narrows the scope to Local for the unprepared era instead, and says
+/// so. It only ever narrows -- nothing here can turn internet hosting on -- and
+/// the saved setting is left alone, so going back to the prepared era goes back
+/// to hosting as well.
+pub fn effective_for_start(
+    cfg: &Config,
+    legacy_lan: bool,
+) -> Result<(Scope, Option<String>), String> {
+    let scope = Scope::load(cfg, legacy_lan)?;
+    if !scope.internet() {
+        return Ok((scope, None));
+    }
+    let era = service_credentials::era(cfg);
+    if service_credentials::load(&cfg.state, era)?.is_some() {
+        return Ok((scope, None));
+    }
+    Ok((
+        Scope::Local,
+        Some(format!(
+            "{era} has not been prepared for internet hosting, so the server started in Local mode. \"{}\" is still saved and still applies to the era that was prepared. To host {era} as well, use \"Prepare server for friends\" in Settings -> Multiplayer once it is running.",
+            scope.name()
+        )),
+    ))
+}
+
 fn unsafe_admin_count(dk: &Docker) -> Result<u32, String> {
     // Count every enabled privileged account, including renamed GMs. Also
     // cover the shipped login if its group was changed. No passwords leave SQL.
@@ -294,6 +331,83 @@ mod tests {
             assert_eq!(Scope::from_settings(&settings, true).is_ok(), name == "lan");
         }
     }
+    fn fixture_config(name: &str) -> Config {
+        let root = std::env::temp_dir().join(format!("ro-host-{name}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(root.join("state")).unwrap();
+        Config {
+            root: root.join("app"),
+            state: root.join("state"),
+            nebula_home: root.join("nebula"),
+            nebula: root.join("unused"),
+            docker: root.join("unused"),
+            image: String::new(),
+            db_image: String::new(),
+            app_version: None,
+        }
+    }
+
+    // Reported by a player: prepare renewal for friends, switch to
+    // pre-renewal, and the server will not start. The error told them to fix
+    // it in Settings -> Accounts, which needs a running server, so there was no
+    // way out -- Repair included.
+    #[test]
+    fn an_era_that_was_never_prepared_starts_local_instead_of_not_at_all() {
+        let cfg = fixture_config("era-switch");
+        std::fs::write(
+            cfg.state.join("settings.json"),
+            "{\"hosting_scope\":\"friends\"}",
+        )
+        .unwrap();
+        service_credentials::prepare(&cfg).unwrap();
+
+        // The era that was prepared is unaffected: friends hosting, no notice.
+        let (scope, notice) = effective_for_start(&cfg, false).unwrap();
+        assert_eq!(scope, Scope::Friends);
+        assert!(notice.is_none());
+        assert!(before_start(&cfg, scope).is_ok());
+
+        // Switching era leaves the same saved scope pointing at credentials
+        // that do not exist.
+        std::fs::write(cfg.state.join("prerenewal"), "").unwrap();
+        assert!(before_start(&cfg, Scope::Friends).is_err());
+
+        let (scope, notice) = effective_for_start(&cfg, false).unwrap();
+        assert_eq!(scope, Scope::Local);
+        assert!(before_start(&cfg, scope).is_ok());
+        let notice = notice.expect("a narrowed scope has to say so");
+        assert!(notice.contains("prerenewal"), "{notice}");
+        assert!(notice.contains("Local mode"), "{notice}");
+
+        // Narrowing only. The setting is the player's, and going back to the
+        // era they prepared goes back to hosting.
+        assert!(std::fs::read_to_string(cfg.state.join("settings.json"))
+            .unwrap()
+            .contains("friends"));
+        std::fs::remove_file(cfg.state.join("prerenewal")).unwrap();
+        assert_eq!(effective_for_start(&cfg, false).unwrap().0, Scope::Friends);
+    }
+
+    #[test]
+    fn narrowing_never_turns_hosting_on_and_never_hides_a_bad_setting() {
+        let cfg = fixture_config("narrow-only");
+        // Local stays local even with credentials sitting there.
+        service_credentials::prepare(&cfg).unwrap();
+        for saved in ["local", "lan"] {
+            std::fs::write(
+                cfg.state.join("settings.json"),
+                format!("{{\"hosting_scope\":\"{saved}\"}}"),
+            )
+            .unwrap();
+            let (scope, notice) = effective_for_start(&cfg, false).unwrap();
+            assert_eq!(scope.name(), saved);
+            assert!(notice.is_none());
+        }
+        // An unreadable scope is still a hard failure, not a quiet Local.
+        std::fs::write(cfg.state.join("settings.json"), "{\"hosting_scope\":23}").unwrap();
+        assert!(effective_for_start(&cfg, false).is_err());
+    }
+
     #[test]
     fn invalid_scope_and_login_imports_fail_closed() {
         for value in ["null", "false", "23", "\"Friends\"", "\"\""] {

--- a/tests/hosting-policy.test.cjs
+++ b/tests/hosting-policy.test.cjs
@@ -39,22 +39,72 @@ test('scope is strict and survives unrelated account/era settings without silent
   }
 });
 
-test('real startup and Repair reject invalid or unprepared internet scopes before engine mutation', { skip: !process.env.STACK_BIN }, t => {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ro-scope-engine-'));
+function engineFixture(t, name) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `ro-scope-${name}-`));
   t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  // Nothing here may be executed. If the supervisor reaches the engine, it
+  // reaches this instead, and says so loudly.
   const fake = path.join(dir, 'must-not-execute' + (process.platform === 'win32' ? '.exe' : ''));
   fs.writeFileSync(fake, 'not executable', { mode: 0o700 });
   const file = path.join(dir, 'settings.json');
-  for (const hosting_scope of ['friends', 'public', 'invalid', null]) {
-    fs.writeFileSync(file, JSON.stringify({ hosting_scope, open_registration: true }));
+  const run = (verb, flags, timeout = 5000) => spawnSync(process.env.STACK_BIN, [verb, ...flags], {
+    encoding: 'utf8', timeout,
+    env: { ...process.env, RAGNAROK_OFFLINE_ROOT: dir, RAGNAROKMAC_STATE: dir,
+      NEBULA_HOME: path.join(dir, 'never-started'), NEBULA_BIN: fake, RAGNAROKMAC_DOCKER: fake },
+  });
+  const save = settings => fs.writeFileSync(file, JSON.stringify({ open_registration: true, ...settings }));
+  return { dir, file, run, save };
+}
+
+test('real startup and Repair reject an unusable hosting scope before engine mutation', { skip: !process.env.STACK_BIN }, t => {
+  const { dir, run, save } = engineFixture(t, 'engine');
+  // A scope that cannot be read is a hard stop. It is not narrowed to
+  // something safe, because a setting nobody can read is not a preference --
+  // it is damage, and guessing at it is how a player ends up hosting
+  // something they never asked to host.
+  for (const hosting_scope of ['invalid', null]) {
+    save({ hosting_scope });
     for (const verb of ['up', 'repair']) for (const flags of [[], ['--lan']]) {
-      const r = spawnSync(process.env.STACK_BIN, [verb, ...flags], { encoding: 'utf8', timeout: 5000,
-        env: { ...process.env, RAGNAROK_OFFLINE_ROOT: dir, RAGNAROKMAC_STATE: dir,
-          NEBULA_HOME: path.join(dir, 'never-started'), NEBULA_BIN: fake, RAGNAROKMAC_DOCKER: fake } });
+      const r = run(verb, flags);
       assert.equal(r.status, 1);
-      assert.match(r.stderr, /Invalid hosting scope|conflicts with the saved hosting scope|managed service credentials/);
+      assert.match(r.stderr, /Invalid hosting scope/);
       assert.equal(fs.existsSync(path.join(dir, 'never-started')), false);
       assert.equal(fs.existsSync(path.join(dir, 'phase')), false);
     }
+  }
+  // --lan against a saved internet scope stays a conflict rather than a
+  // narrowing: internet modes require loopback game ports and the flag asks
+  // for the opposite, so there is no reading of it that is safe to act on.
+  for (const hosting_scope of ['friends', 'public']) {
+    save({ hosting_scope });
+    for (const verb of ['up', 'repair']) {
+      const r = run(verb, ['--lan']);
+      assert.equal(r.status, 1);
+      assert.match(r.stderr, /conflicts with the saved hosting scope/);
+      assert.equal(fs.existsSync(path.join(dir, 'never-started')), false);
+      assert.equal(fs.existsSync(path.join(dir, 'phase')), false);
+    }
+  }
+});
+
+// The reported bug: prepare renewal for friends, switch to pre-renewal, and
+// every start refused because the credentials are per era and the scope is
+// not. Repair refused too, and the instructions in the error needed a running
+// server, so there was no way out.
+test('an internet scope with no credentials for this era starts Local rather than refusing', { skip: !process.env.STACK_BIN }, t => {
+  const { file, run, save } = engineFixture(t, 'unprepared');
+  // Both internet scopes and both verbs, paired rather than crossed: these
+  // runs reach the engine and take seconds each, and the narrowing is one
+  // decision made in one place before either verb gets going.
+  for (const [hosting_scope, verb] of [['friends', 'up'], ['public', 'repair']]) {
+    save({ hosting_scope });
+    // The engine is a stub, so this still fails -- but it now fails *at the
+    // engine*, which is the whole point: policy let it through.
+    const r = run(verb, [], 20000);
+    assert.match(r.stdout, /has not been prepared for internet hosting/);
+    assert.doesNotMatch(r.stderr, /managed service credentials/);
+    // Narrowing only, and only for this start: the player's setting is still
+    // theirs, so going back to the era they prepared goes back to hosting.
+    assert.equal(JSON.parse(fs.readFileSync(file, 'utf8')).hosting_scope, hosting_scope);
   }
 });


### PR DESCRIPTION
A player prepared renewal for friends, switched to pre-renewal, and could not
start the server again:

```
Internet hosting requires this era's managed service credentials. Start in
Local mode, give each GM/admin account an 8-23 character password in
Settings -> Accounts, then use "Prepare server for friends" in
Settings -> Multiplayer.
```

Following those instructions gave `Start this era's server first`.

## What is wrong

The credentials internet hosting needs are generated **per era** — they live in
`state/private/service-credentials/<era>/`. The hosting choice is **one
setting** for the whole install, in `state/settings.json`. Switching era
therefore leaves the saved scope pointing at an era that was never prepared,
and `hosting::before_start` refuses the start.

The part that makes it a trap rather than a message is that every route out
runs through a server that will not start:

- Settings → Accounts needs a live database, hence `Start this era's server first`.
- **Repair runs the same check**, and Repair is the escape hatch for exactly
  this shape of problem.

So yes — this comes from the sharing work, and it is reachable by doing nothing
unusual.

## The fix

A start narrows the scope to Local for an era that has no credentials, and says
which era and why. It only ever narrows: nothing here can turn internet hosting
on, and `before_start` still refuses if anything ever hands it an internet scope
without credentials. The saved setting is untouched, so returning to the era
that was prepared returns to friends hosting with nothing to redo.

The era switch in Settings repeats the notice. A player who asked for
pre-renewal did not ask for their friends' link to stop working, and the
supervisor log is not where they are looking.

## Tests

- `an_era_that_was_never_prepared_starts_local_instead_of_not_at_all` walks the
  reported sequence and asserts the old check still fails on it, so the test
  would catch a regression rather than just describing the new behaviour.
- `narrowing_never_turns_hosting_on_and_never_hides_a_bad_setting` covers the
  invariant and keeps an unreadable `hosting_scope` a hard failure.

`cargo test` 104 passing, `npm test` 119 passing.

## For people already stuck

Troubleshooting now has it: Settings → Multiplayer, set hosting back to Local,
start. Everything else works from there, and switching back to the prepared era
restores hosting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SvT1DAYsc7JnDNZJpvi5GW