### PR TITLE
Let a mod decide where the AI characters go

### DIFF
--- a/docs-site/docs/mods/ai-characters.mdx
+++ b/docs-site/docs/mods/ai-characters.mdx
@@ -1,0 +1,200 @@
+# Where the AI characters go
+
+The crowd the population engine creates is not scattered at random. Every AI
+character is placed from one table, `db/population_spawn.yml`, and a mod can
+add to that table or take it over entirely.
+
+This is the page for that table. [Making mods](/docs/modding) is the general
+guide; nothing here is needed to write an ordinary mod.
+
+## What the table says
+
+One entry per **profile**. A profile is a group of jobs, defined in
+`db/population_engine.yml`; at spawn time the engine resolves the profile to
+every job that inherits from it and picks one at random per character. There
+are fourteen:
+
+```
+novice_default   combat_pve_low   combat_pve      pve_knight
+pve_paladin      pve_caster       pve_archer      pve_monk
+pve_assassin     pve_rogue        pve_merchant_cart
+pve_taekwon      pve_gunslinger   pve_ninja
+```
+
+Each entry carries three map lists — towns, fields and dungeons — a headcount
+for each list, and an optional per-map cap:
+
+```yaml
+  - Profile: combat_pve_low
+    Towns:
+      - prontera
+    TownsPopulation: 40
+    Fields:
+      - prt_fild08
+      - gef_fild07
+    FieldsPopulation: 30
+    FieldsMaxPerMap: 20
+```
+
+**The headcount is a total for the list, not a number per map.** Each map gets
+`floor(N / count)` characters and the first `N % count` maps get one more, so
+the total comes out exactly. `MaxPerMap` clamps each map afterwards, which
+matters when one map in a long list would otherwise absorb the remainder.
+
+Vendors are not placed from here. They have their own table,
+`db/population_vendors.yml`, which is **not** moddable yet — see
+[what is not wired up](#what-is-not-wired-up).
+
+## Adding to it
+
+Ship `db/population_spawn.yml` in your mod and name only the profiles you care
+about. Entries are matched by `Profile:`, and only the fields an entry actually
+names are touched, so everything you leave out keeps the value it had. A
+profile that is not in the shipped table is added whole.
+
+Every list and every count has two forms, and picking the wrong one is the
+mistake worth avoiding:
+
+| Replaces | Appends to | What it is |
+|---|---|---|
+| `Towns:` | `TownsAdd:` | the town map list |
+| `Fields:` | `FieldsAdd:` | the field map list |
+| `Dungeons:` | `DungeonsAdd:` | the dungeon map list |
+| `TownsPopulation:` | `TownsPopulationAdd:` | characters across all town maps |
+| `FieldsPopulation:` | `FieldsPopulationAdd:` | across all field maps |
+| `DungeonsPopulation:` | `DungeonsPopulationAdd:` | across all dungeon maps |
+| `TownsMaxPerMap:` | `TownsMaxPerMapAdd:` | per-map cap for towns |
+| `FieldsMaxPerMap:` | `FieldsMaxPerMapAdd:` | for fields |
+| `DungeonsMaxPerMap:` | `DungeonsMaxPerMapAdd:` | for dungeons |
+
+**Prefer the `Add` forms unless you mean to own the profile.** A plain `Fields:`
+replaces the list, so adding one map to `combat_pve` means restating the twenty
+already in it — and those twenty are then frozen into your mod, so when the
+shipped table changes your copy quietly wins and the new maps never appear.
+
+Adding a map without adding characters only spreads the existing ones thinner,
+which is what the matching `…PopulationAdd` is for.
+
+A whole working mod:
+
+```yaml
+# my-mod/db/population_spawn.yml — twelve more of them, on my island
+Header:
+  Type: POPULATION_SPAWN_DB
+  Version: 1
+
+Body:
+  - Profile: combat_pve_low
+    FieldsAdd:
+      - ro_isle
+    FieldsPopulationAdd: 12
+    FieldsMaxPerMap: 12
+```
+
+Duplicate map names are dropped rather than counted twice. A category's
+headcount is divided between its maps, so a map named twice would take two
+shares of it.
+
+## Replacing it
+
+Put `Clear: true` in the header. rAthena empties a database before reading a
+file that asks for it, so the shipped table goes and only yours survives:
+
+```yaml
+Header:
+  Type: POPULATION_SPAWN_DB
+  Version: 1
+  Clear: true
+
+Body:
+  - Profile: combat_pve_low
+    Fields:
+      - ro_isle
+    FieldsPopulation: 40
+```
+
+That is the right shape for a server where the AI characters should be nowhere
+except where you say. It is a big hammer: every profile you do not list stops
+being populated at all, including `novice_default`, so new characters arrive to
+an empty starting map.
+
+If another enabled mod also ships this table, the two are combined as usual —
+one header, both sets of entries — and a `Clear:` from *either* one applies to
+the merged result.
+
+## A trap the server will not report
+
+Run the validator over anything you write:
+
+```
+python3 third-party/population-engine/validate.py
+```
+
+It exists because this data has failure modes that pass silently:
+
+- **A job belongs to exactly one profile, and the last definition parsed wins.**
+  A profile that loses all its jobs is skipped without a word, and every map it
+  owned just stays empty.
+- **A gear item in the wrong slot is rejected at load** and the character spawns
+  naked.
+
+Neither produces an error. Both look like a mod that loaded and did nothing.
+
+Also worth knowing: the population engine is **off by default**. Settings →
+Population turns it on, and with it off these databases are never read at all,
+so a mod here changes nothing until someone enables the crowd.
+
+## What is not wired up
+
+Only the spawn table takes a mod's override. The other population databases
+still read from one path and ignore `db/import` entirely:
+
+```
+population_engine.yml    profiles and which jobs belong to them
+population_vendors.yml   where the stalls stand
+population_vendor_pop.yml
+population_chat.yml      what they say
+population_names.yml     what they are called
+population_gear_sets.yml what they wear
+population_skill_db.yml  what they cast
+population_pvp.yml
+```
+
+A mod's copy of any of those lands in a directory nothing opens, and the server
+reports a clean load either way. If you need one of them, say so — the fix is
+the same three lines that fixed this one.
+
+## Why it used to be impossible
+
+Worth recording, because the shape of the failure is a useful thing to
+recognise. The population engine is a source modification to rAthena rather
+than stock rAthena, and it read each of its tables from exactly one path:
+
+```cpp
+static std::string population_config_join_db(const char *basename)
+{
+	return std::string(db_path) + "/" + basename;
+}
+```
+
+`db_path` is `db`, so the table came from `db/population_spawn.yml` and nowhere
+else, while a mod's `db/` is mounted at `db/import`. The server never
+complained: it loaded its own copy, reported `Loading '14' entries in
+'db/population_spawn.yml'`, and the mod's maps stayed empty — indistinguishable
+from a mod that worked and changed nothing.
+
+The fix was to give the table a `Footer: Imports:` block, which is how every
+stock rAthena table has always accepted an override, plus a stub in
+`db/import-tmpl` so the import resolves when no mod supplies one. A named
+import that is not there is an error on every start.
+
+Because the engine is compiled into the map server, this arrived with a
+container image build rather than an app update.
+
+## See also
+
+- [`examples/mods/island-population`](https://github.com/Flux159/ragnarokoffline.app/tree/main/examples/mods/island-population) —
+  the four-line worked example.
+- [Making mods](/docs/modding) — everything else a mod can do.
+- [Settings: Population](/docs/settings-population) —
+  the switches a player sees.

--- a/docs-site/src/pages/DocPage.tsx
+++ b/docs-site/src/pages/DocPage.tsx
@@ -37,6 +37,7 @@ const sidebarItems = [
     items: [
       { label: 'Playing with friends', path: 'friends' },
       { label: 'Making mods', path: 'modding' },
+      { label: 'Where the AI characters go', path: 'mods/ai-characters' },
       { label: 'Troubleshooting', path: 'troubleshooting' },
       { label: 'Repairing the database', path: 'database' },
     ],

--- a/docs/MODDING.md
+++ b/docs/MODDING.md
@@ -291,6 +291,11 @@ The other eight population databases — chat lines, names, gear sets, vendor
 placement — are **not** wired this way yet. A mod's copy of those still lands
 in a directory nothing opens.
 
+**[docs/mods/ai-characters.md](mods/ai-characters.md)** is the full reference:
+every key, how the headcount is divided between maps, which tables are still
+unreachable, and the two ways this data fails without the server saying
+anything.
+
 ## npc/ — adding things to the world
 
 Every `.txt` under `npc/` is loaded as an rAthena script. That covers NPCs,

--- a/docs/MODDING.md
+++ b/docs/MODDING.md
@@ -227,6 +227,70 @@ which is 0.01%.
 
 See [`examples/mods/tougher-monsters`](../examples/mods/tougher-monsters).
 
+### Where the AI characters go
+
+The wandering AI characters are placed by `db/population_spawn.yml`, one entry
+per *profile* — `novice_default`, `combat_pve_low`, `pve_knight` and eleven
+more — each with a list of town, field and dungeon maps and a headcount to
+spread across each list.
+
+A mod ships `db/population_spawn.yml` like any other table, and names only the
+profiles it cares about. Entries are matched by `Profile:`, and only the fields
+an entry actually names are touched, so the rest of the table is left alone. A
+profile that is not in the shipped table is added whole.
+
+Each list and count has two forms, and the difference matters:
+
+| | |
+|---|---|
+| `Towns:` `Fields:` `Dungeons:` | **replace** that profile's list |
+| `TownsAdd:` `FieldsAdd:` `DungeonsAdd:` | **append** to it |
+| `TownsPopulation:` and the `Fields`/`Dungeons` pair | set the headcount |
+| `TownsPopulationAdd:` and its pair | add to the headcount |
+| `TownsMaxPerMap:` and its pair, plus the `…Add` forms | the per-map cap |
+
+Prefer the `Add` forms. A category's headcount is divided between its maps, so
+adding a map with the plain form means restating the twenty already there — and
+then silently keeping *those* twenty when the shipped table changes.
+
+```yaml
+# my-mod/db/population_spawn.yml — twelve more of them, on my island
+Header:
+  Type: POPULATION_SPAWN_DB
+  Version: 1
+
+Body:
+  - Profile: combat_pve_low
+    FieldsAdd:
+      - ro_isle
+    FieldsPopulationAdd: 12
+```
+
+**To own the table outright instead**, put `Clear: true` in the header.
+rAthena empties a database before reading a file that asks for it, so the
+shipped table goes and only yours remains — which is what you want for a server
+where the AI characters should be nowhere except where you say:
+
+```yaml
+Header:
+  Type: POPULATION_SPAWN_DB
+  Version: 1
+  Clear: true
+```
+
+If another enabled mod also ships this table, the two are combined as usual,
+and a `Clear:` from either one applies to the merged result.
+
+Two things the server will not tell you, which is why
+`third-party/population-engine/validate.py` exists: a job belongs to exactly
+one profile and the last definition silently wins, so a profile that loses all
+its jobs is skipped without a word and its maps just stay empty. Run the
+validator over anything you write here.
+
+The other eight population databases — chat lines, names, gear sets, vendor
+placement — are **not** wired this way yet. A mod's copy of those still lands
+in a directory nothing opens.
+
 ## npc/ — adding things to the world
 
 Every `.txt` under `npc/` is loaded as an rAthena script. That covers NPCs,

--- a/docs/mods/README.md
+++ b/docs/mods/README.md
@@ -1,0 +1,12 @@
+# Mod reference
+
+[Making mods](../MODDING.md) is the guide to read first. It covers the whole
+mod format: `db/`, `npc/`, `conf/`, `data/`, `System/`, `client/`, and how to
+install, test and share one.
+
+These pages go deeper on parts of the server that need more than a paragraph,
+and that nobody would find by guessing:
+
+| | |
+|---|---|
+| [Where the AI characters go](ai-characters.md) | the population engine's spawn table: adding maps to it, replacing it, and the eight tables that still cannot be modded |

--- a/docs/mods/ai-characters.md
+++ b/docs/mods/ai-characters.md
@@ -1,0 +1,200 @@
+# Where the AI characters go
+
+The crowd the population engine creates is not scattered at random. Every AI
+character is placed from one table, `db/population_spawn.yml`, and a mod can
+add to that table or take it over entirely.
+
+This is the page for that table. [Making mods](../MODDING.md) is the general
+guide; nothing here is needed to write an ordinary mod.
+
+## What the table says
+
+One entry per **profile**. A profile is a group of jobs, defined in
+`db/population_engine.yml`; at spawn time the engine resolves the profile to
+every job that inherits from it and picks one at random per character. There
+are fourteen:
+
+```
+novice_default   combat_pve_low   combat_pve      pve_knight
+pve_paladin      pve_caster       pve_archer      pve_monk
+pve_assassin     pve_rogue        pve_merchant_cart
+pve_taekwon      pve_gunslinger   pve_ninja
+```
+
+Each entry carries three map lists — towns, fields and dungeons — a headcount
+for each list, and an optional per-map cap:
+
+```yaml
+  - Profile: combat_pve_low
+    Towns:
+      - prontera
+    TownsPopulation: 40
+    Fields:
+      - prt_fild08
+      - gef_fild07
+    FieldsPopulation: 30
+    FieldsMaxPerMap: 20
+```
+
+**The headcount is a total for the list, not a number per map.** Each map gets
+`floor(N / count)` characters and the first `N % count` maps get one more, so
+the total comes out exactly. `MaxPerMap` clamps each map afterwards, which
+matters when one map in a long list would otherwise absorb the remainder.
+
+Vendors are not placed from here. They have their own table,
+`db/population_vendors.yml`, which is **not** moddable yet — see
+[what is not wired up](#what-is-not-wired-up).
+
+## Adding to it
+
+Ship `db/population_spawn.yml` in your mod and name only the profiles you care
+about. Entries are matched by `Profile:`, and only the fields an entry actually
+names are touched, so everything you leave out keeps the value it had. A
+profile that is not in the shipped table is added whole.
+
+Every list and every count has two forms, and picking the wrong one is the
+mistake worth avoiding:
+
+| Replaces | Appends to | What it is |
+|---|---|---|
+| `Towns:` | `TownsAdd:` | the town map list |
+| `Fields:` | `FieldsAdd:` | the field map list |
+| `Dungeons:` | `DungeonsAdd:` | the dungeon map list |
+| `TownsPopulation:` | `TownsPopulationAdd:` | characters across all town maps |
+| `FieldsPopulation:` | `FieldsPopulationAdd:` | across all field maps |
+| `DungeonsPopulation:` | `DungeonsPopulationAdd:` | across all dungeon maps |
+| `TownsMaxPerMap:` | `TownsMaxPerMapAdd:` | per-map cap for towns |
+| `FieldsMaxPerMap:` | `FieldsMaxPerMapAdd:` | for fields |
+| `DungeonsMaxPerMap:` | `DungeonsMaxPerMapAdd:` | for dungeons |
+
+**Prefer the `Add` forms unless you mean to own the profile.** A plain `Fields:`
+replaces the list, so adding one map to `combat_pve` means restating the twenty
+already in it — and those twenty are then frozen into your mod, so when the
+shipped table changes your copy quietly wins and the new maps never appear.
+
+Adding a map without adding characters only spreads the existing ones thinner,
+which is what the matching `…PopulationAdd` is for.
+
+A whole working mod:
+
+```yaml
+# my-mod/db/population_spawn.yml — twelve more of them, on my island
+Header:
+  Type: POPULATION_SPAWN_DB
+  Version: 1
+
+Body:
+  - Profile: combat_pve_low
+    FieldsAdd:
+      - ro_isle
+    FieldsPopulationAdd: 12
+    FieldsMaxPerMap: 12
+```
+
+Duplicate map names are dropped rather than counted twice. A category's
+headcount is divided between its maps, so a map named twice would take two
+shares of it.
+
+## Replacing it
+
+Put `Clear: true` in the header. rAthena empties a database before reading a
+file that asks for it, so the shipped table goes and only yours survives:
+
+```yaml
+Header:
+  Type: POPULATION_SPAWN_DB
+  Version: 1
+  Clear: true
+
+Body:
+  - Profile: combat_pve_low
+    Fields:
+      - ro_isle
+    FieldsPopulation: 40
+```
+
+That is the right shape for a server where the AI characters should be nowhere
+except where you say. It is a big hammer: every profile you do not list stops
+being populated at all, including `novice_default`, so new characters arrive to
+an empty starting map.
+
+If another enabled mod also ships this table, the two are combined as usual —
+one header, both sets of entries — and a `Clear:` from *either* one applies to
+the merged result.
+
+## A trap the server will not report
+
+Run the validator over anything you write:
+
+```
+python3 third-party/population-engine/validate.py
+```
+
+It exists because this data has failure modes that pass silently:
+
+- **A job belongs to exactly one profile, and the last definition parsed wins.**
+  A profile that loses all its jobs is skipped without a word, and every map it
+  owned just stays empty.
+- **A gear item in the wrong slot is rejected at load** and the character spawns
+  naked.
+
+Neither produces an error. Both look like a mod that loaded and did nothing.
+
+Also worth knowing: the population engine is **off by default**. Settings →
+Population turns it on, and with it off these databases are never read at all,
+so a mod here changes nothing until someone enables the crowd.
+
+## What is not wired up
+
+Only the spawn table takes a mod's override. The other population databases
+still read from one path and ignore `db/import` entirely:
+
+```
+population_engine.yml    profiles and which jobs belong to them
+population_vendors.yml   where the stalls stand
+population_vendor_pop.yml
+population_chat.yml      what they say
+population_names.yml     what they are called
+population_gear_sets.yml what they wear
+population_skill_db.yml  what they cast
+population_pvp.yml
+```
+
+A mod's copy of any of those lands in a directory nothing opens, and the server
+reports a clean load either way. If you need one of them, say so — the fix is
+the same three lines that fixed this one.
+
+## Why it used to be impossible
+
+Worth recording, because the shape of the failure is a useful thing to
+recognise. The population engine is a source modification to rAthena rather
+than stock rAthena, and it read each of its tables from exactly one path:
+
+```cpp
+static std::string population_config_join_db(const char *basename)
+{
+	return std::string(db_path) + "/" + basename;
+}
+```
+
+`db_path` is `db`, so the table came from `db/population_spawn.yml` and nowhere
+else, while a mod's `db/` is mounted at `db/import`. The server never
+complained: it loaded its own copy, reported `Loading '14' entries in
+'db/population_spawn.yml'`, and the mod's maps stayed empty — indistinguishable
+from a mod that worked and changed nothing.
+
+The fix was to give the table a `Footer: Imports:` block, which is how every
+stock rAthena table has always accepted an override, plus a stub in
+`db/import-tmpl` so the import resolves when no mod supplies one. A named
+import that is not there is an error on every start.
+
+Because the engine is compiled into the map server, this arrived with a
+container image build rather than an app update.
+
+## See also
+
+- [`examples/mods/island-population`](../../examples/mods/island-population) —
+  the four-line worked example.
+- [Making mods](../MODDING.md) — everything else a mod can do.
+- [Settings: Population](https://ragnarokoffline.app/docs/settings-population) —
+  the switches a player sees.

--- a/examples/mods/island-population/README.md
+++ b/examples/mods/island-population/README.md
@@ -1,65 +1,65 @@
 # island-population
 
-**This mod does not work, and the reason is worth more than the mod would be.**
+Puts twelve AI characters on the custom island from
+[`custom-map`](../custom-map), and leaves every other map exactly as it was.
 
-It is here because §3.7 of the brief asks whether a mod can put AI characters on
-a custom map, and the answer — read out of the loader rather than guessed — is
-no, not without a change to the engine.
+The whole mod is four lines of body in `db/population_spawn.yml`:
 
-## The wall
+```yaml
+Body:
+  - Profile: combat_pve_low
+    FieldsAdd:
+      - ro_isle
+    FieldsPopulationAdd: 12
+```
 
-The Population Engine is a source modification to rAthena, not stock rAthena,
-and it does not participate in the `db/import` mechanism at all. Every one of
-its tables is loaded from exactly one path:
+## Why `FieldsAdd` and not `Fields`
+
+`Fields:` **replaces** that profile's field list. Writing it here would take
+`combat_pve_low`'s low-level characters off every field map they are supposed
+to be on and strand all of them on the island — and it would need the twenty
+map names already in the profile restated, which would then go stale the next
+time the shipped table changes.
+
+`FieldsPopulationAdd:` is the same argument for the headcount. A category's
+population is divided between its maps, so adding a map without adding
+characters just spreads the existing ones thinner.
+
+To own the table outright instead of adding to it, put `Clear: true` in the
+header. rAthena empties a database before reading a file that asks for it, so
+the shipped table goes and only this one remains. That is the right shape for
+a server where the AI characters should be nowhere except where you say.
+
+## This did not used to work
+
+Until 1.3.0 it could not. The Population Engine is a source modification to
+rAthena rather than stock rAthena, and it read each of its tables from exactly
+one path:
 
 ```cpp
-// third-party/population-engine/files/src/map/population_engine/config/population_config.cpp
 static std::string population_config_join_db(const char *basename)
 {
 	return std::string(db_path) + "/" + basename;
 }
 ```
 
-`db_path` is `db`, so `population_spawn.yml` is read from `db/population_spawn.yml`
-and from nowhere else. There is no import path in the list, no era subdirectory,
-and no second load that could merge one in.
+`db_path` is `db`, so the table came from `db/population_spawn.yml` and nowhere
+else, while a mod's copy is mounted at `db/import/population_spawn.yml`. The
+server did not complain. It loaded its own copy, reported `Loading '14' entries
+in 'db/population_spawn.yml'`, and the island stayed empty — indistinguishable
+from a mod that loaded and did nothing.
 
-Meanwhile `scripts/apply-server-mods.sh` copies the engine's tables into the
-rAthena checkout at **image build time**, so the file that is actually read
-lives inside the container image. A mod's `db/population_spawn.yml` is mounted
-at `db/import/population_spawn.yml`, which nothing opens.
+What fixed it was a `Footer: Imports:` on the shipped table, which is how every
+stock rAthena table has always taken an override, plus a stub in
+`db/import-tmpl` so the import resolves when no mod supplies one. The `…Add`
+forms came with it, because per-profile override alone still meant restating a
+list to add one entry to it.
 
-The server does not complain. It loads its own copy, reports
-`Loading '14' entries in 'db/population_spawn.yml'`, and the island stays
-empty — which is indistinguishable from a mod that loaded and did nothing.
+**The other eight population databases are still not wired this way** — chat
+lines, names, gear sets, vendor placement. A mod's copy of those lands in a
+directory nothing opens, exactly as this one used to.
 
-## What it would take
-
-Six lines in the engine, and an image build to ship them:
-
-```cpp
-static std::string population_config_join_db(const char *basename)
-{
-	// A mod's tables arrive at db/import; prefer one when it is there.
-	std::string import = std::string(db_path) + "/" + DBIMPORT + "/" + basename;
-	if (std::filesystem::exists(import))
-		return import;
-	return std::string(db_path) + "/" + basename;
-}
-```
-
-That is replace-not-merge, which is the right shape for this table: the spawn
-config is a distribution across the whole world, and a partial override that
-merged would silently halve somebody else's population. It also means a mod
-that touches it must ship the whole file — which is why the one in `db/` here
-is complete rather than a fragment.
-
-The narrower alternative — the supervisor bind-mounting a merged file over
-`/rathena/db/population_spawn.yml` — was considered and does not survive
-contact: single-file binds are unreliable when the host path contains a space,
-and on macOS the state directory is under `Application Support`.
-
-## The trap that is already documented, and still applies
+## The trap that has not gone away
 
 `third-party/population-engine/validate.py` exists because this YAML has two
 failure modes the server never reports:
@@ -67,18 +67,11 @@ failure modes the server never reports:
 - **A job belongs to exactly one profile, and the last block parsed silently
   wins.** A profile that loses all its jobs is skipped without a word and the
   maps it owns just stay empty.
-- **A gear item in the wrong slot is rejected at load** and the shell spawns
-  naked.
+- **A gear item in the wrong slot is rejected at load** and the character
+  spawns naked.
 
 Run it over anything you write here:
 
 ```
 python3 third-party/population-engine/validate.py
 ```
-
-## Status
-
-Blocked. Tracked against issue
-[#6](https://github.com/Flux159/ragnarokoffline.app/issues/6)'s wider "mods
-should reach further into the server" theme; the engine change belongs in the
-next image build, not in a mod.

--- a/examples/mods/island-population/db/population_spawn.yml
+++ b/examples/mods/island-population/db/population_spawn.yml
@@ -1,18 +1,20 @@
-# Put AI characters on the custom island from the custom-map mod.
+# Twelve AI characters on the custom island from the custom-map mod.
 #
-# ---------------------------------------------------------------------------
-# THIS DOES NOT WORK YET. See README.md. The file is here because it is the
-# file that *would* work, and because the shape of it is worth having.
-# ---------------------------------------------------------------------------
+# The whole file is four lines of body, and that is the point. Profiles are
+# matched by name against the shipped table and only the fields named here are
+# touched, so everywhere else in the world is left exactly as it was.
 #
-# The Population Engine spawns by profile, not by job: a Profile named here
-# resolves to every job that inherits from it in db/population_engine.yml, and
-# one job is picked at random per shell.
+# FieldsAdd rather than Fields: the plain form *replaces* the profile's field
+# list, which would take combat_pve_low's low-level characters off every field
+# map they are supposed to be on and strand them all here. FieldsPopulationAdd
+# for the same reason -- adding a map without adding shells only spreads the
+# existing ones thinner.
 #
-# This is a complete file, not an addition: whatever mechanism eventually reads
-# it will either replace the shipped table or merge over it, and a partial file
-# under a merge would leave every other map unpopulated. Start from
-# third-party/population-engine/files/db/population_spawn.yml and edit.
+# To own the table outright instead, add `Clear: true` to the Header: the
+# shipped table is emptied and only what is here survives.
+#
+# Check anything you write with:
+#   python3 third-party/population-engine/validate.py
 
 Header:
   Type: POPULATION_SPAWN_DB
@@ -20,7 +22,7 @@ Header:
 
 Body:
   - Profile: combat_pve_low
-    Fields:
+    FieldsAdd:
       - ro_isle
-    FieldsPopulation: 12
+    FieldsPopulationAdd: 12
     FieldsMaxPerMap: 12

--- a/examples/mods/island-population/mod.json
+++ b/examples/mods/island-population/mod.json
@@ -1,7 +1,7 @@
 {
   "name": "island-population",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": "Ragnarok Offline",
-  "description": "Puts AI characters on the custom island. BLOCKED: the Population Engine does not read db/import.",
-  "requires": { "app": ">=1.0.6", "era": "any" }
+  "description": "Puts twelve AI characters on the custom island, without moving any of the ones already in the world.",
+  "requires": { "app": ">=1.3.0", "era": "any" }
 }

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -256,6 +256,15 @@ if [ -d "$ROOT/vendor/rathena/db/import-tmpl" ]; then
 else
     echo "warning: no vendor/rathena/db/import-tmpl -- mods overriding a db table will warn" >&2
 fi
+# The population engine's stubs, from third-party/ rather than the checkout:
+# they only reach vendor/rathena when apply-server-mods.sh has run, and a
+# packaging run that skipped bootstrap would otherwise ship a db/import with a
+# hole in it -- which the map server reports as a missing import on every
+# start, once per table.
+if [ -d "$ROOT/third-party/population-engine/files/db/import-tmpl" ]; then
+    mkdir -p "$PAYLOAD/db-import"
+    cp "$ROOT"/third-party/population-engine/files/db/import-tmpl/* "$PAYLOAD/db-import/"
+fi
 
 # Mods that ship with the app. The supervisor reads these alongside the ones a
 # player installs, and a player's mod of the same name replaces the shipped

--- a/stack/src/mods.rs
+++ b/stack/src/mods.rs
@@ -884,6 +884,43 @@ fn header_type(text: &str) -> Option<String> {
     None
 }
 
+/// Whether a table's header asks rAthena to empty the database before reading
+/// it -- `Header: Clear: true`, which rAthena honours for every YAML database
+/// (`YamlDatabase::load`, src/common/database.cpp). It is how a mod says "this
+/// table is mine outright" rather than "add these entries to it".
+fn header_clears(text: &str) -> bool {
+    let Some((_, after)) = section(text, "Header:") else {
+        return false;
+    };
+    for line in text[after..].split_inclusive('\n') {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if !line.starts_with(' ') && !line.starts_with('\t') {
+            break;
+        }
+        if let Some(value) = trimmed.strip_prefix("Clear:") {
+            return value.trim().eq_ignore_ascii_case("true");
+        }
+    }
+    false
+}
+
+/// Put `Clear: true` into a header that does not have it, keeping the
+/// indentation the file already uses.
+fn add_header_clear(text: &str) -> Option<String> {
+    let (_, after) = section(text, "Header:")?;
+    let indent = text[after..]
+        .split_inclusive('\n')
+        .find(|line| !line.trim().is_empty())
+        .map(|line| &line[..line.len() - line.trim_start().len()])
+        .filter(|indent| !indent.is_empty())
+        .unwrap_or("  ")
+        .to_string();
+    Some(format!("{}{indent}Clear: true\n{}", &text[..after], &text[after..]))
+}
+
 /// Combine two mods' copies of the same rAthena table.
 ///
 /// Two mods that both add an item each ship `db/item_db.yml`, and merging them
@@ -900,6 +937,16 @@ fn merge_tables(existing: &str, incoming: &str) -> Option<String> {
     if header_type(existing)? != header_type(incoming)? {
         return None;
     }
+    // The merged file keeps the first header, so a later mod's `Clear: true`
+    // would be dropped and its table would quietly become an addition to the
+    // one it meant to replace. Carry it across instead: clearing is the
+    // stronger statement, and both mods' entries still survive it.
+    let existing = if header_clears(incoming) && !header_clears(existing) {
+        add_header_clear(existing)?
+    } else {
+        existing.to_string()
+    };
+    let existing = existing.as_str();
     let (_, incoming_body) = section(incoming, "Body:")?;
     // A Footer carries `Imports:`, which names other files rather than holding
     // entries. Keeping the first file's and dropping the rest is right: the
@@ -1760,6 +1807,53 @@ mod tests {
 
     /// Alphabetical is the floor, so the order is predictable without anyone
     /// declaring anything.
+    // Two mods, one population table: one adds its island, the other declares
+    // the table its own. The merged file has to keep both bodies *and* the
+    // Clear, or the replacing mod silently becomes an addition.
+    #[test]
+    fn a_replacing_table_keeps_its_clear_through_a_merge_with_an_adding_one() {
+        let adds = "Header:\n  Type: POPULATION_SPAWN_DB\n  Version: 1\n\nBody:\n  - Profile: combat_pve_low\n    FieldsAdd:\n      - ro_isle\n";
+        let replaces = "Header:\n  Type: POPULATION_SPAWN_DB\n  Version: 1\n  Clear: true\n\nBody:\n  - Profile: novice_default\n    Towns:\n      - new_1-1\n";
+        assert!(!header_clears(adds));
+        assert!(header_clears(replaces));
+
+        // Whichever order the mod names put them in.
+        let merged = merge_tables(adds, replaces).expect("same Type merges");
+        assert!(header_clears(&merged), "{merged}");
+        assert!(merged.contains("ro_isle"), "{merged}");
+        assert!(merged.contains("new_1-1"), "{merged}");
+        assert_eq!(merged.matches("Clear: true").count(), 1, "{merged}");
+
+        let merged = merge_tables(replaces, adds).expect("same Type merges");
+        assert!(header_clears(&merged), "{merged}");
+        assert!(merged.contains("ro_isle"), "{merged}");
+
+        // Two ordinary tables are untouched by any of this.
+        let merged = merge_tables(adds, adds).expect("same Type merges");
+        assert!(!header_clears(&merged), "{merged}");
+    }
+
+    // The spawn table has to keep declaring the import a mod's copy arrives
+    // through. Without the Footer the file loads, the mod's copy sits in
+    // db/import unread, and nothing reports it.
+    #[test]
+    fn the_population_spawn_table_still_imports_the_mod_overlay() {
+        let table = include_str!(
+            "../../third-party/population-engine/files/db/population_spawn.yml"
+        );
+        assert_eq!(header_type(table).as_deref(), Some("POPULATION_SPAWN_DB"));
+        assert!(
+            table.contains("- Path: db/import/population_spawn.yml"),
+            "the engine would read nothing a mod ships"
+        );
+        let stub = include_str!(
+            "../../third-party/population-engine/files/db/import-tmpl/population_spawn.yml"
+        );
+        assert_eq!(header_type(stub).as_deref(), Some("POPULATION_SPAWN_DB"));
+        // A stub that cleared would empty the shipped table on every start.
+        assert!(!header_clears(stub));
+    }
+
     #[test]
     fn with_nothing_declared_the_order_is_alphabetical() {
         assert_eq!(

--- a/third-party/population-engine/files/db/import-tmpl/population_spawn.yml
+++ b/third-party/population-engine/files/db/import-tmpl/population_spawn.yml
@@ -1,0 +1,34 @@
+# Population Engine Spawn Database — import stub.
+#
+# Copied into db/import by `make import`, the same way rAthena's own sixty
+# stubs are, so db/population_spawn.yml can import it unconditionally. An
+# import that names a file which is not there is an error on every start.
+#
+# A mod's db/population_spawn.yml replaces this file. Entries are matched to
+# the shipped table by Profile name, and only the fields an entry names are
+# touched:
+#
+#   Body:
+#     - Profile: combat_pve_low
+#       FieldsAdd:
+#         - ro_isle              # added to the profile's field list
+#       FieldsPopulationAdd: 12  # added to its field population
+#
+# Towns/Fields/Dungeons replace a profile's list; TownsAdd/FieldsAdd/
+# DungeonsAdd append to it. The same pair exists for the population and
+# per-map cap of each category. A Profile that is not in the shipped table is
+# added whole.
+#
+# To replace the shipped table outright rather than add to it, put
+# `Clear: true` in the Header below: rAthena empties the database before
+# reading a file that asks for it, so only this file's entries survive.
+
+Header:
+  Type: POPULATION_SPAWN_DB
+  Version: 1
+
+#Body:
+#  - Profile: combat_pve_low
+#    FieldsAdd:
+#      - ro_isle
+#    FieldsPopulationAdd: 12

--- a/third-party/population-engine/files/db/population_spawn.yml
+++ b/third-party/population-engine/files/db/population_spawn.yml
@@ -678,3 +678,18 @@ Body:
       - in_sphinx4
       - in_sphinx5
     DungeonsPopulation: 40
+
+# RAGNAROKMAC: the import a mod's table arrives through.
+#
+# Without this the engine reads this file and nothing else, a mod's
+# db/population_spawn.yml lands at db/import/population_spawn.yml where
+# nothing opens it, and the server reports a clean load either way -- which is
+# indistinguishable from a mod that worked and changed nothing.
+#
+# Entries in the imported file are matched to these by Profile name and only
+# the fields they actually name are touched, so a mod adds a profile or edits
+# one without restating the rest. `Header: Clear: true` in the imported file
+# replaces this table outright instead.
+Footer:
+  Imports:
+  - Path: db/import/population_spawn.yml

--- a/third-party/population-engine/files/src/map/population_engine/config/population_spawn_db.cpp
+++ b/third-party/population-engine/files/src/map/population_engine/config/population_spawn_db.cpp
@@ -39,10 +39,45 @@ uint64 PopulationSpawnDatabase::parseBodyNode(const ryml::NodeRef& node)
 		}
 	};
 
+	// RAGNAROKMAC: the append form of the three lists above.
+	//
+	// A plain `Towns:` in an imported file replaces the profile's list, which
+	// is right for a mod that owns the profile and wrong for one that just
+	// wants its island populated: adding one map to combat_pve would mean
+	// restating the twenty it already has, and then silently keeping those
+	// twenty when the shipped table changes. `TownsAdd:` adds to the list
+	// instead. Duplicates are dropped, because the population of a category is
+	// divided between its maps and a map named twice would take two shares.
+	auto append_map_list = [&](const char* key, std::vector<std::string>& out) {
+		const ryml::NodeRef& seq = node[c4::to_csubstr(key)];
+		if (!seq.is_seq())
+			return;
+		for (const ryml::NodeRef& it : seq.children()) {
+			if (!it.has_val()) continue;
+			ryml::csubstr v = it.val();
+			if (v.empty()) continue;
+			std::string name(v.data(), v.size());
+			if (std::find(out.begin(), out.end(), name) == out.end())
+				out.emplace_back(std::move(name));
+		}
+	};
+
+	// RAGNAROKMAC: and of the counts, for the same reason -- a mod that adds a
+	// map without adding shells has only spread the existing ones thinner.
+	auto add_count = [&](const char* key, int32_t& out) {
+		if (!this->nodeExists(node, key))
+			return;
+		int32_t v = 0;
+		if (this->asInt32(node, key, v))
+			out = std::max(0, out + v);
+	};
+
 	if (this->nodeExists(node, "Towns"))
 		parse_map_list("Towns", entry->towns);
 	else if (!exists)
 		entry->towns.clear();
+	if (this->nodeExists(node, "TownsAdd"))
+		append_map_list("TownsAdd", entry->towns);
 
 	if (this->nodeExists(node, "TownsPopulation")) {
 		int32_t v = 0;
@@ -51,6 +86,7 @@ uint64 PopulationSpawnDatabase::parseBodyNode(const ryml::NodeRef& node)
 	} else if (!exists) {
 		entry->towns_population = 0;
 	}
+	add_count("TownsPopulationAdd", entry->towns_population);
 
 	if (this->nodeExists(node, "TownsMaxPerMap")) {
 		int32_t v = 0;
@@ -59,11 +95,14 @@ uint64 PopulationSpawnDatabase::parseBodyNode(const ryml::NodeRef& node)
 	} else if (!exists) {
 		entry->towns_max_per_map = 0;
 	}
+	add_count("TownsMaxPerMapAdd", entry->towns_max_per_map);
 
 	if (this->nodeExists(node, "Fields"))
 		parse_map_list("Fields", entry->fields);
 	else if (!exists)
 		entry->fields.clear();
+	if (this->nodeExists(node, "FieldsAdd"))
+		append_map_list("FieldsAdd", entry->fields);
 
 	if (this->nodeExists(node, "FieldsPopulation")) {
 		int32_t v = 0;
@@ -72,6 +111,7 @@ uint64 PopulationSpawnDatabase::parseBodyNode(const ryml::NodeRef& node)
 	} else if (!exists) {
 		entry->fields_population = 0;
 	}
+	add_count("FieldsPopulationAdd", entry->fields_population);
 
 	if (this->nodeExists(node, "FieldsMaxPerMap")) {
 		int32_t v = 0;
@@ -80,11 +120,14 @@ uint64 PopulationSpawnDatabase::parseBodyNode(const ryml::NodeRef& node)
 	} else if (!exists) {
 		entry->fields_max_per_map = 0;
 	}
+	add_count("FieldsMaxPerMapAdd", entry->fields_max_per_map);
 
 	if (this->nodeExists(node, "Dungeons"))
 		parse_map_list("Dungeons", entry->dungeons);
 	else if (!exists)
 		entry->dungeons.clear();
+	if (this->nodeExists(node, "DungeonsAdd"))
+		append_map_list("DungeonsAdd", entry->dungeons);
 
 	if (this->nodeExists(node, "DungeonsPopulation")) {
 		int32_t v = 0;
@@ -93,6 +136,7 @@ uint64 PopulationSpawnDatabase::parseBodyNode(const ryml::NodeRef& node)
 	} else if (!exists) {
 		entry->dungeons_population = 0;
 	}
+	add_count("DungeonsPopulationAdd", entry->dungeons_population);
 
 	if (this->nodeExists(node, "DungeonsMaxPerMap")) {
 		int32_t v = 0;
@@ -101,6 +145,7 @@ uint64 PopulationSpawnDatabase::parseBodyNode(const ryml::NodeRef& node)
 	} else if (!exists) {
 		entry->dungeons_max_per_map = 0;
 	}
+	add_count("DungeonsMaxPerMapAdd", entry->dungeons_max_per_map);
 
 	if (!exists)
 		this->put(profile_name, entry);


### PR DESCRIPTION
Stacked on [#110](https://github.com/Flux159/ragnarokoffline.app/pull/110), which is where `merge_tables` lives.

A mod can now add to the AI characters' map lists, or take the table over
entirely.

## What was wrong

The Population Engine is a source modification to rAthena, not stock rAthena,
and it read each of its tables from exactly one path:

```cpp
return std::string(db_path) + "/" + basename;   // db/population_spawn.yml
```

A mod's `db/` is mounted at `db/import`, so its copy landed somewhere nothing
opens. The failure mode is the bad kind: the server loaded its own table,
reported `Loading '14' entries in 'db/population_spawn.yml'`, and the mod's
maps stayed empty. Indistinguishable from a mod that worked and did nothing.
`examples/mods/island-population` existed only to document that wall.

## What this does

The mechanism every stock rAthena table already uses, rather than a new one.
The shipped table declares its import, and a stub goes in `db/import-tmpl` so
the import resolves when no mod supplies one, because a named import that is
not there is an error on every start.

Both halves of the ask fall out of that:

- **Add onto it.** Entries are matched by `Profile:` and only the fields an
  entry names are touched. A mod edits one profile, or adds a new one, and
  leaves the rest of the world alone.
- **Replace it fully.** `Header: Clear: true`. rAthena empties a database
  before reading a file that asks for it, and has done for years.

Per-profile override alone was not enough. Adding one map to `combat_pve`
would have meant restating the twenty already in it, and then silently keeping
those twenty when the shipped table moved on. So every list and count takes an
append form: `TownsAdd`, `FieldsAdd`, `DungeonsAdd`, and the matching
`…PopulationAdd` and `…MaxPerMapAdd`. Duplicates are dropped, since a
category's headcount is divided between its maps and a map named twice would
take two shares.

The whole example mod is now four lines:

```yaml
Body:
  - Profile: combat_pve_low
    FieldsAdd:
      - ro_isle
    FieldsPopulationAdd: 12
```

## One thing the merge had to learn

Merging two mods' copies of a table keeps the first file's header, so a second
mod's `Clear: true` was dropped and its table quietly became an addition to the
one it meant to replace. It is carried across now: clearing is the stronger
statement, and both mods' entries still survive it. That applies to every
table, not just this one.

## Verification

- The modified parser compiles against the real rAthena headers
  (`g++ -fsyntax-only` with the vendored ryml).
- `third-party/population-engine/validate.py` still passes over the shipped
  data with the footer added.
- Two new supervisor tests: one merges an adding table with a replacing one in
  both orders and asserts the `Clear` and both bodies survive; one asserts the
  shipped table still declares the import and that the stub does *not* clear,
  since a clearing stub would empty the table on every start.
- `cargo test` 118 passing, `npm test` with `STACK_BIN` 117 passing.

**This needs a new container image to take effect** — the engine is compiled
into the map server — so it lands with the next image build rather than on an
existing install.

## Not done

The other eight population databases are still unreachable: chat lines, names,
gear sets, vendor placement. Same wall, same fix, not done here. Both the
modding guide and the example mod say so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SvT1DAYsc7JnDNZJpvi5GW